### PR TITLE
feat: Core SportsClaw Engine (Phase 1 & 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.env

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SportsClaw is a lightweight execution loop designed specifically for building re
 Instead of relying on complex abstraction layers, SportsClaw focuses on executing deterministic primitives (`sports-skills`) and strict instructional guardrails to ensure agents report exact, hallucination-free sports information.
 
 ### Inspiration
-SportsClaw's execution engine draws direct inspiration from [NanoClaw](https://github.com/anthropics/nanoclaw) and [pi.dev](https://pi.dev) — proving that a tight, sub-1000-line agentic loop can outperform bloated orchestration frameworks when paired with well-designed tool primitives.
+SportsClaw's execution engine draws direct inspiration from [NanoClaw](https://github.com/anthropics/nanoclaw), [pi.dev](https://pi.dev), and [OpenClaw](https://github.com/anthropics/openclaw) — proving that a tight, sub-1000-line agentic loop can outperform bloated orchestration frameworks when paired with well-designed tool primitives.
 
 ### Core Focus
 * **Sports-First:** Built from the ground up to handle the unique challenges of real-time sports data and betting markets.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ A lean, high-performance sports AI agent framework.
 ~500 lines of TypeScript. Bring your own LLM.
 
 ### Purpose
-SportsClaw is a lightweight execution loop designed specifically for building reliable sports AI agents. It connects frontier models directly to live sports data (scores, odds, play-by-play, stats) without the bloat of traditional, heavy agent frameworks. 
+SportsClaw is a lightweight execution loop designed specifically for building reliable sports AI agents. It connects frontier models directly to live sports data (scores, odds, play-by-play, stats) without the bloat of traditional, heavy agent frameworks.
 
 Instead of relying on complex abstraction layers, SportsClaw focuses on executing deterministic primitives (`sports-skills`) and strict instructional guardrails to ensure agents report exact, hallucination-free sports information.
+
+### Inspiration
+SportsClaw's execution engine draws direct inspiration from [NanoClaw](https://github.com/anthropics/nanoclaw) and [pi.dev](https://pi.dev) — proving that a tight, sub-1000-line agentic loop can outperform bloated orchestration frameworks when paired with well-designed tool primitives.
 
 ### Core Focus
 * **Sports-First:** Built from the ground up to handle the unique challenges of real-time sports data and betting markets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,469 @@
+{
+  "name": "sportsclaw-engine-core",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sportsclaw-engine-core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "description": "A lean, high-performance sports AI agent framework. ~500 lines of TypeScript.",
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "sportsclaw": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sportsclaw-engine-core",
+  "version": "0.1.0",
+  "description": "A lean, high-performance sports AI agent framework. ~500 lines of TypeScript.",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc && node dist/index.js"
+  },
+  "keywords": ["sports", "ai", "agent", "llm", "anthropic"],
+  "author": "Machina Sports",
+  "license": "MIT",
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,0 +1,203 @@
+/**
+ * SportsClaw Engine — Core Agent Execution Loop
+ *
+ * A lightweight (~500 line total) agentic loop that:
+ *   1. Sends user messages + tool definitions to Claude
+ *   2. Intercepts tool_use blocks from the response
+ *   3. Executes them via the Python subprocess bridge
+ *   4. Feeds tool_result blocks back to Claude
+ *   5. Repeats until the model emits end_turn or max turns is reached
+ *
+ * No heavy frameworks. No LangChain. No CrewAI. Just a clean loop.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  DEFAULT_CONFIG,
+  type SportsClawConfig,
+  type Message,
+  type ToolUseBlock,
+  type ToolResultBlockParam,
+  type TurnResult,
+} from "./types.js";
+import { TOOL_SPECS, dispatchToolCall, type ToolCallInput } from "./tools.js";
+
+// ---------------------------------------------------------------------------
+// System prompt
+// ---------------------------------------------------------------------------
+
+const BASE_SYSTEM_PROMPT = `You are SportsClaw, a high-performance sports AI agent built by Machina Sports.
+
+Your core directives:
+1. ACCURACY FIRST — Never guess or hallucinate scores, stats, or odds. If the tool returns data, report it exactly. If a tool call fails, say so honestly.
+2. USE TOOLS — When the user asks about live scores, standings, schedules, odds, or any sports data, ALWAYS use the sports_query tool. Do not make up data from training knowledge when live data is available.
+3. BE CONCISE — Sports fans want quick, clear answers. Lead with the data, add context after.
+4. CITE THE SOURCE — When reporting data from a tool call, mention it came from live data.
+
+You have access to the sports_query tool which connects to the sports-skills data engine supporting: NFL, NBA, MLB, NHL, Soccer, F1, MMA, Tennis, College Football, and College Basketball.`;
+
+// ---------------------------------------------------------------------------
+// Engine class
+// ---------------------------------------------------------------------------
+
+export class SportsClawEngine {
+  private client: Anthropic;
+  private config: Required<SportsClawConfig>;
+  private messages: Message[] = [];
+
+  constructor(config?: Partial<SportsClawConfig>) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.client = new Anthropic();
+  }
+
+  /** Full system prompt (base + user-supplied) */
+  private get systemPrompt(): string {
+    if (this.config.systemPrompt) {
+      return `${BASE_SYSTEM_PROMPT}\n\n${this.config.systemPrompt}`;
+    }
+    return BASE_SYSTEM_PROMPT;
+  }
+
+  /** Anthropic tool definitions in the format the API expects */
+  private get tools(): Anthropic.Tool[] {
+    return TOOL_SPECS.map((spec) => ({
+      name: spec.name,
+      description: spec.description,
+      input_schema: spec.input_schema,
+    }));
+  }
+
+  /** Reset conversation history */
+  reset(): void {
+    this.messages = [];
+  }
+
+  /** Get current conversation history (read-only copy) */
+  get history(): readonly Message[] {
+    return [...this.messages];
+  }
+
+  /**
+   * Run a single API call → tool execution → result cycle.
+   * Returns whether the agent is done and any text produced.
+   */
+  private async executeTurn(): Promise<TurnResult> {
+    const response = await this.client.messages.create({
+      model: this.config.model,
+      max_tokens: 4096,
+      system: this.systemPrompt,
+      tools: this.tools,
+      messages: this.messages,
+    });
+
+    // Collect text and tool_use blocks from the response
+    let text = "";
+    const toolUseBlocks: ToolUseBlock[] = [];
+
+    for (const block of response.content) {
+      if (block.type === "text") {
+        text += block.text;
+      } else if (block.type === "tool_use") {
+        toolUseBlocks.push(block);
+      }
+    }
+
+    // Append assistant message to history
+    this.messages.push({ role: "assistant", content: response.content });
+
+    // If no tool calls, we're done
+    if (toolUseBlocks.length === 0) {
+      return { done: true, text, toolCalls: 0 };
+    }
+
+    // Execute each tool call and collect results
+    const toolResults: ToolResultBlockParam[] = [];
+
+    for (const toolUse of toolUseBlocks) {
+      if (this.config.verbose) {
+        console.error(
+          `[sportsclaw] tool_call: ${toolUse.name}(${JSON.stringify(toolUse.input)})`
+        );
+      }
+
+      const resultStr = dispatchToolCall(
+        toolUse.name,
+        toolUse.input as ToolCallInput,
+        this.config
+      );
+
+      if (this.config.verbose) {
+        const preview =
+          resultStr.length > 200
+            ? resultStr.slice(0, 200) + "..."
+            : resultStr;
+        console.error(`[sportsclaw] tool_result: ${preview}`);
+      }
+
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: resultStr,
+      });
+    }
+
+    // Append tool results as a user message
+    this.messages.push({ role: "user", content: toolResults });
+
+    // The model still needs to process tool results, so we're not done
+    return {
+      done: response.stop_reason === "end_turn",
+      text,
+      toolCalls: toolUseBlocks.length,
+    };
+  }
+
+  /**
+   * Run the full agent loop for a user prompt.
+   *
+   * Sends the prompt to the LLM, executes any tool calls, and continues
+   * until the model produces a final text response or maxTurns is hit.
+   *
+   * Returns the final assistant text.
+   */
+  async run(userPrompt: string): Promise<string> {
+    this.messages.push({ role: "user", content: userPrompt });
+
+    let totalText = "";
+    let turns = 0;
+
+    while (turns < this.config.maxTurns) {
+      turns++;
+
+      if (this.config.verbose) {
+        console.error(`[sportsclaw] --- turn ${turns} ---`);
+      }
+
+      const result = await this.executeTurn();
+      totalText = result.text || totalText;
+
+      if (result.done) {
+        if (this.config.verbose) {
+          console.error(
+            `[sportsclaw] done after ${turns} turn(s), ${result.toolCalls} tool call(s) this turn`
+          );
+        }
+        return totalText;
+      }
+    }
+
+    // Max turns reached — return what we have
+    console.error(
+      `[sportsclaw] max turns (${this.config.maxTurns}) reached, returning partial result`
+    );
+    return totalText || "[SportsClaw] Max turns reached without a final response.";
+  }
+
+  /**
+   * Convenience: run a prompt and print the result to stdout.
+   */
+  async runAndPrint(userPrompt: string): Promise<void> {
+    const result = await this.run(userPrompt);
+    console.log(result);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
  *   const answer = await engine.run("What are today's NBA scores?");
  */
 
+import { fileURLToPath } from "node:url";
 import { SportsClawEngine } from "./engine.js";
 
 // ---------------------------------------------------------------------------
@@ -64,8 +65,8 @@ async function main(): Promise<void> {
   }
 
   const engine = new SportsClawEngine({
-    model: process.env.SPORTSCLAW_MODEL || undefined,
-    pythonPath: process.env.PYTHON_PATH || undefined,
+    ...(process.env.SPORTSCLAW_MODEL && { model: process.env.SPORTSCLAW_MODEL }),
+    ...(process.env.PYTHON_PATH && { pythonPath: process.env.PYTHON_PATH }),
     verbose,
   });
 
@@ -85,9 +86,7 @@ async function main(): Promise<void> {
 }
 
 // Run if executed directly
-const isMain =
-  process.argv[1]?.endsWith("index.js") ||
-  process.argv[1]?.endsWith("index.ts");
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 
 if (isMain) {
   main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * SportsClaw Engine — Entry Point
+ *
+ * Usage:
+ *   npx sportsclaw "What is the score of the last NFL game?"
+ *   ANTHROPIC_API_KEY=sk-... node dist/index.js "Who leads the Premier League?"
+ *
+ * Or import as a library:
+ *   import { SportsClawEngine } from "sportsclaw-engine-core";
+ *   const engine = new SportsClawEngine();
+ *   const answer = await engine.run("What are today's NBA scores?");
+ */
+
+import { SportsClawEngine } from "./engine.js";
+
+// ---------------------------------------------------------------------------
+// Re-exports for library usage
+// ---------------------------------------------------------------------------
+
+export { SportsClawEngine } from "./engine.js";
+export { TOOL_SPECS, executePythonBridge, dispatchToolCall } from "./tools.js";
+export type {
+  SportsClawConfig,
+  ToolSpec,
+  PythonBridgeResult,
+  TurnResult,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  // Parse flags
+  const verbose = args.includes("--verbose") || args.includes("-v");
+  const filteredArgs = args.filter((a) => a !== "--verbose" && a !== "-v");
+  const prompt = filteredArgs.join(" ");
+
+  if (!prompt) {
+    console.log("SportsClaw Engine v0.1.0");
+    console.log("");
+    console.log("Usage:");
+    console.log('  npx sportsclaw "What is the score of the last NFL game?"');
+    console.log('  node dist/index.js "Who leads the Premier League?"');
+    console.log("");
+    console.log("Options:");
+    console.log("  --verbose, -v    Enable verbose logging");
+    console.log("");
+    console.log("Environment:");
+    console.log("  ANTHROPIC_API_KEY    Your Anthropic API key (required)");
+    console.log("  SPORTSCLAW_MODEL     Model override (default: claude-sonnet-4-20250514)");
+    console.log("  PYTHON_PATH          Path to Python interpreter (default: python3)");
+    process.exit(0);
+  }
+
+  // Check for API key
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("Error: ANTHROPIC_API_KEY environment variable is required.");
+    console.error("Set it with: export ANTHROPIC_API_KEY=sk-...");
+    process.exit(1);
+  }
+
+  const engine = new SportsClawEngine({
+    model: process.env.SPORTSCLAW_MODEL || undefined,
+    pythonPath: process.env.PYTHON_PATH || undefined,
+    verbose,
+  });
+
+  try {
+    await engine.runAndPrint(prompt);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+      if (verbose) {
+        console.error(error.stack);
+      }
+    } else {
+      console.error("An unknown error occurred:", error);
+    }
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+const isMain =
+  process.argv[1]?.endsWith("index.js") ||
+  process.argv[1]?.endsWith("index.ts");
+
+if (isMain) {
+  main();
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,0 +1,187 @@
+/**
+ * SportsClaw Engine — Tool Definitions & Python Subprocess Bridge
+ *
+ * This module defines the tools the LLM can call and implements the core
+ * "Python bridge" — the mechanism that intercepts tool calls and executes
+ * them via `python3 -m sports_skills <sport> <command> [--args ...]`.
+ *
+ * Design principle: The TypeScript layer ORCHESTRATES; the Python layer EXECUTES.
+ * Zero TS-to-Python rewriting is required.
+ */
+
+import { spawnSync } from "node:child_process";
+import type { ToolSpec, PythonBridgeResult, SportsClawConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Tool catalogue — these are the tools exposed to the LLM
+// ---------------------------------------------------------------------------
+
+export const TOOL_SPECS: ToolSpec[] = [
+  {
+    name: "sports_query",
+    description: [
+      "Execute a sports data query via the sports-skills Python package.",
+      "This tool fetches live and historical sports data including scores,",
+      "standings, schedules, odds, play-by-play, stats, and more.",
+      "",
+      "Supported sports: nfl, nba, mlb, nhl, soccer, f1, mma, tennis, cfb, cbb.",
+      "",
+      "Examples of sport + command pairs:",
+      '  sport="nfl", command="scores"          → current/recent NFL scores',
+      '  sport="nfl", command="standings"        → NFL standings',
+      '  sport="nba", command="schedule"         → NBA schedule',
+      '  sport="soccer", command="standings", args={"league": "premier_league"}',
+      '  sport="f1", command="race_results", args={"year": 2025, "round": 1}',
+      "",
+      "Pass any extra parameters as key-value pairs in the `args` object.",
+    ].join("\n"),
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        sport: {
+          type: "string",
+          description: "The sport to query (e.g. nfl, nba, mlb, nhl, soccer, f1).",
+        },
+        command: {
+          type: "string",
+          description: "The specific command/action to execute (e.g. scores, standings, schedule).",
+        },
+        args: {
+          type: "object",
+          description: "Optional key-value arguments passed to the command.",
+          additionalProperties: true,
+        },
+      },
+      required: ["sport", "command"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Python Subprocess Bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the CLI arguments for invoking sports-skills.
+ *
+ * Invocation pattern:
+ *   python3 -m sports_skills <sport> <command> [--key value ...]
+ */
+function buildArgs(
+  sport: string,
+  command: string,
+  args?: Record<string, unknown>
+): string[] {
+  const cliArgs = ["-m", "sports_skills", sport, command];
+
+  if (args) {
+    for (const [key, value] of Object.entries(args)) {
+      if (value === undefined || value === null) continue;
+      cliArgs.push(`--${key}`, String(value));
+    }
+  }
+
+  return cliArgs;
+}
+
+/**
+ * Execute a sports-skills command via a synchronous child process.
+ *
+ * Returns a structured result with stdout parsed as JSON when possible.
+ */
+export function executePythonBridge(
+  sport: string,
+  command: string,
+  args?: Record<string, unknown>,
+  config?: Partial<SportsClawConfig>
+): PythonBridgeResult {
+  const pythonPath = config?.pythonPath ?? "python3";
+  const cliArgs = buildArgs(sport, command, args);
+
+  if (config?.verbose) {
+    console.error(`[sportsclaw] exec: ${pythonPath} ${cliArgs.join(" ")}`);
+  }
+
+  const result = spawnSync(pythonPath, cliArgs, {
+    encoding: "utf-8",
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024, // 10 MB
+    env: { ...process.env, ...config?.env },
+  });
+
+  // Process exited with an error
+  if (result.error) {
+    return {
+      success: false,
+      error: `Failed to spawn process: ${result.error.message}`,
+      stderr: result.stderr ?? undefined,
+    };
+  }
+
+  if (result.status !== 0) {
+    return {
+      success: false,
+      error: `Process exited with code ${result.status}`,
+      stdout: result.stdout ?? undefined,
+      stderr: result.stderr ?? undefined,
+    };
+  }
+
+  // Try to parse stdout as JSON
+  const stdout = (result.stdout ?? "").trim();
+  try {
+    const data = JSON.parse(stdout);
+    return { success: true, data };
+  } catch {
+    // Not JSON — return raw stdout
+    return { success: true, data: stdout, stdout };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool dispatcher — routes tool calls to the right handler
+// ---------------------------------------------------------------------------
+
+export interface ToolCallInput {
+  sport?: string;
+  command?: string;
+  args?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Dispatch a tool call by name and return the string result for the LLM.
+ */
+export function dispatchToolCall(
+  toolName: string,
+  input: ToolCallInput,
+  config?: Partial<SportsClawConfig>
+): string {
+  if (toolName === "sports_query") {
+    if (!input.sport || !input.command) {
+      return JSON.stringify({
+        error: "Missing required parameters: sport and command",
+      });
+    }
+
+    const result = executePythonBridge(
+      input.sport,
+      input.command,
+      input.args,
+      config
+    );
+
+    if (!result.success) {
+      // Provide a helpful message so the LLM can tell the user
+      return JSON.stringify({
+        error: result.error,
+        stderr: result.stderr,
+        hint: "The sports-skills Python package may not be installed. Install it with: pip install sports-skills",
+      });
+    }
+
+    return JSON.stringify(result.data);
+  }
+
+  return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,10 +15,14 @@ export interface SportsClawConfig {
   model?: string;
   /** Maximum agentic turns before the loop halts (default: 25) */
   maxTurns?: number;
+  /** Maximum tokens for model responses (default: 4096) */
+  maxTokens?: number;
   /** System prompt prepended to every conversation */
   systemPrompt?: string;
   /** Path to the Python interpreter (default: python3) */
   pythonPath?: string;
+  /** Timeout in ms for Python subprocess calls (default: 30000) */
+  timeout?: number;
   /** Extra environment variables passed to child processes */
   env?: Record<string, string>;
   /** Enable verbose logging (default: false) */
@@ -28,8 +32,10 @@ export interface SportsClawConfig {
 export const DEFAULT_CONFIG: Required<SportsClawConfig> = {
   model: "claude-sonnet-4-20250514",
   maxTurns: 25,
+  maxTokens: 4096,
   systemPrompt: "",
   pythonPath: "python3",
+  timeout: 30_000,
   env: {},
   verbose: false,
 };
@@ -66,9 +72,9 @@ export type ToolUseBlock = Anthropic.ToolUseBlock;
 export type ToolResultBlockParam = Anthropic.ToolResultBlockParam;
 
 export interface TurnResult {
-  /** Whether the agent has finished (stop_reason === "end_turn") */
+  /** Whether the agent has finished (no more tool calls pending) */
   done: boolean;
-  /** The final assistant text so far */
+  /** The assistant text produced this turn */
   text: string;
   /** Number of tool calls executed this turn */
   toolCalls: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,75 @@
+/**
+ * SportsClaw Engine — Type Definitions
+ *
+ * Shared types for the agent execution loop, tool bridge, and configuration.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface SportsClawConfig {
+  /** Anthropic model to use (default: claude-sonnet-4-20250514) */
+  model?: string;
+  /** Maximum agentic turns before the loop halts (default: 25) */
+  maxTurns?: number;
+  /** System prompt prepended to every conversation */
+  systemPrompt?: string;
+  /** Path to the Python interpreter (default: python3) */
+  pythonPath?: string;
+  /** Extra environment variables passed to child processes */
+  env?: Record<string, string>;
+  /** Enable verbose logging (default: false) */
+  verbose?: boolean;
+}
+
+export const DEFAULT_CONFIG: Required<SportsClawConfig> = {
+  model: "claude-sonnet-4-20250514",
+  maxTurns: 25,
+  systemPrompt: "",
+  pythonPath: "python3",
+  env: {},
+  verbose: false,
+};
+
+// ---------------------------------------------------------------------------
+// Tool definitions exposed to the LLM
+// ---------------------------------------------------------------------------
+
+export interface ToolSpec {
+  name: string;
+  description: string;
+  input_schema: Anthropic.Tool["input_schema"];
+}
+
+// ---------------------------------------------------------------------------
+// Python bridge types
+// ---------------------------------------------------------------------------
+
+export interface PythonBridgeResult {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Conversation / Turn types
+// ---------------------------------------------------------------------------
+
+export type Message = Anthropic.MessageParam;
+export type ContentBlock = Anthropic.ContentBlock;
+export type ToolUseBlock = Anthropic.ToolUseBlock;
+export type ToolResultBlockParam = Anthropic.ToolResultBlockParam;
+
+export interface TurnResult {
+  /** Whether the agent has finished (stop_reason === "end_turn") */
+  done: boolean;
+  /** The final assistant text so far */
+  text: string;
+  /** Number of tool calls executed this turn */
+  toolCalls: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- **Phase 1 — Core Agent Execution Loop**: A lightweight (~500 line) TypeScript agentic loop built on `@anthropic-ai/sdk`. No heavy frameworks (LangChain, CrewAI, etc). Clean, from-scratch NanoClaw-style loop that sends prompts to Claude, intercepts `tool_use` blocks, executes them, and feeds `tool_result` blocks back until the model produces a final response.

- **Phase 2 — Python Subprocess Bridge (The Core Moat)**: A TypeScript tool handler that intercepts LLM tool calls and executes them via `child_process.spawnSync` against the `sports-skills` Python package (`python3 -m sports_skills <sport> <command> [--args]`). Parses stdout JSON and feeds structured results back to the LLM. Zero TS-to-Python rewriting — the TS layer orchestrates, the Python layer executes.

### Architecture

```
User Prompt → SportsClawEngine.run()
  → Claude API (with tool definitions)
  → tool_use: sports_query(sport, command, args)
  → dispatchToolCall() → executePythonBridge()
  → python3 -m sports_skills <sport> <command>
  → JSON stdout → tool_result → Claude API
  → Final text response → User
```

### Files

| File | Lines | Purpose |
|------|-------|---------|
| `src/types.ts` | 75 | Config, tool specs, bridge result types |
| `src/tools.ts` | 187 | Tool catalogue + Python subprocess bridge |
| `src/engine.ts` | 203 | Core agentic execution loop |
| `src/index.ts` | 94 | CLI entry point + library re-exports |
| **Total** | **559** | ~500 line target ✓ |

### Supported Sports

NFL, NBA, MLB, NHL, Soccer, F1, MMA, Tennis, College Football, College Basketball

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc` — zero errors)
- [x] CLI help output works (`node dist/index.js`)
- [x] Python bridge gracefully handles missing `sports-skills` package
- [x] API key validation works (exits with clear error when missing)
- [ ] End-to-end test with `ANTHROPIC_API_KEY` set and `sports-skills` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)