### PR TITLE
feat: CLI, Schema Injection & Docker Container (Phase 3 & 4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.git/
+.env
+*.tsbuildinfo
+.sportsclaw/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Create Python virtual environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 WORKDIR /app
 
 # ---------------------------------------------------------------------------
@@ -35,8 +39,7 @@ WORKDIR /app
 # ---------------------------------------------------------------------------
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && \
-    npm install discord.js
+RUN npm ci --omit=dev --include=optional
 
 COPY tsconfig.json ./
 COPY src/ ./src/
@@ -46,7 +49,7 @@ RUN npx tsc
 # Stage 2: Install Python sports-skills package
 # ---------------------------------------------------------------------------
 
-RUN pip3 install --break-system-packages sports-skills 2>/dev/null || \
+RUN pip install sports-skills 2>/dev/null || \
     echo "[sportsclaw] Warning: sports-skills not found on PyPI yet. Install manually."
 
 # ---------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,13 @@ RUN pip3 install --break-system-packages sports-skills 2>/dev/null || \
 ENV SPORTSCLAW_SCHEMA_DIR=/app/.sportsclaw/schemas
 RUN mkdir -p /app/.sportsclaw/schemas
 
+# ---------------------------------------------------------------------------
+# Bootstrap: pre-load all 14 default sport schemas into the image
+# ---------------------------------------------------------------------------
+
+RUN node dist/index.js init --verbose 2>&1 || \
+    echo "[sportsclaw] Warning: schema bootstrap incomplete. Some skills may need manual setup."
+
 # The entrypoint is the sportsclaw CLI
 ENTRYPOINT ["node", "dist/index.js"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# =============================================================================
+# SportsClaw — Trojan Horse Container (Phase 4)
+#
+# A single container with Node.js (engine) + Python 3 (sports-skills).
+# Developers can run the agent, CLI commands, or chat listeners out of the box.
+#
+# Build:
+#   docker build -t sportsclaw .
+#
+# Run (one-shot query):
+#   docker run --rm -e ANTHROPIC_API_KEY=sk-... sportsclaw "Who won the Super Bowl?"
+#
+# Run (add a sport schema):
+#   docker run --rm sportsclaw add nfl
+#
+# Run (Discord listener):
+#   docker run --rm -e ANTHROPIC_API_KEY=sk-... -e DISCORD_BOT_TOKEN=... sportsclaw listen discord
+#
+# Run (Telegram listener):
+#   docker run --rm -e ANTHROPIC_API_KEY=sk-... -e TELEGRAM_BOT_TOKEN=... sportsclaw listen telegram
+# =============================================================================
+
+FROM node:20-slim AS base
+
+# Install Python 3 and pip into the same image
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# ---------------------------------------------------------------------------
+# Stage 1: Install Node.js dependencies and build TypeScript
+# ---------------------------------------------------------------------------
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && \
+    npm install discord.js
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npx tsc
+
+# ---------------------------------------------------------------------------
+# Stage 2: Install Python sports-skills package
+# ---------------------------------------------------------------------------
+
+RUN pip3 install --break-system-packages sports-skills 2>/dev/null || \
+    echo "[sportsclaw] Warning: sports-skills not found on PyPI yet. Install manually."
+
+# ---------------------------------------------------------------------------
+# Runtime configuration
+# ---------------------------------------------------------------------------
+
+# Schema storage inside the container
+ENV SPORTSCLAW_SCHEMA_DIR=/app/.sportsclaw/schemas
+RUN mkdir -p /app/.sportsclaw/schemas
+
+# The entrypoint is the sportsclaw CLI
+ENTRYPOINT ["node", "dist/index.js"]
+
+# Default: show help
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ A lean, high-performance sports AI agent framework.
 ~500 lines of TypeScript. Bring your own LLM.
 
 ### Purpose
-SportsClaw is a lightweight execution loop designed specifically for building reliable sports AI agents. It connects frontier models directly to live sports data (scores, odds, play-by-play, stats) without the bloat of traditional, heavy agent frameworks.
+SportsClaw is a lightweight execution loop designed specifically for building reliable sports AI agents. It connects frontier models directly to live sports data (scores, odds, play-by-play, stats) through [sports-skills](https://sports-skills.sh) — without the bloat of traditional, heavy agent frameworks.
 
 Instead of relying on complex abstraction layers, SportsClaw focuses on executing deterministic primitives (`sports-skills`) and strict instructional guardrails to ensure agents report exact, hallucination-free sports information.
+
+### Built-in Sports Data Skills
+
+SportsClaw ships with **14 sports data skills** out of the box, powered by the [`sports-skills`](https://sports-skills.sh) Python package:
+
+`football-data` `nfl-data` `nba-data` `nhl-data` `mlb-data` `wnba-data` `tennis-data` `cfb-data` `cbb-data` `golf-data` `fastf1` `kalshi` `polymarket` `sports-news`
+
+> **[sports-skills.sh](https://sports-skills.sh)** — Full dictionary and documentation for all built-in sports data skills.
 
 ### Inspiration
 SportsClaw's execution engine draws direct inspiration from [NanoClaw](https://github.com/anthropics/nanoclaw), [pi.dev](https://pi.dev), and [OpenClaw](https://github.com/anthropics/openclaw) — proving that a tight, sub-1000-line agentic loop can outperform bloated orchestration frameworks when paired with well-designed tool primitives.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,25 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sportsclaw-engine-core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0"
       },
+      "bin": {
+        "sportsclaw": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0"
+      },
+      "optionalDependencies": {
+        "discord.js": "^14.16.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -46,6 +52,180 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@discordjs/builders": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -63,6 +243,27 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -127,6 +328,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.40",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.40.tgz",
+      "integrity": "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/dunder-proto": {
@@ -196,6 +435,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -338,6 +584,27 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -420,6 +687,20 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -432,6 +713,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -463,6 +754,28 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A lean, high-performance sports AI agent framework. ~500 lines of TypeScript.",
   "type": "module",
   "main": "dist/index.js",
@@ -16,13 +16,20 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsc && node dist/index.js"
+    "dev": "tsc && node dist/index.js",
+    "listen:discord": "tsc && node dist/index.js listen discord",
+    "listen:telegram": "tsc && node dist/index.js listen telegram",
+    "docker:build": "docker build -t sportsclaw .",
+    "docker:run": "docker run --rm --env-file .env sportsclaw"
   },
-  "keywords": ["sports", "ai", "agent", "llm", "anthropic"],
+  "keywords": ["sports", "ai", "agent", "llm", "anthropic", "discord", "telegram"],
   "author": "Machina Sports",
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0"
+  },
+  "optionalDependencies": {
+    "discord.js": "^14.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -20,7 +20,14 @@ import {
   type ToolResultBlockParam,
   type TurnResult,
 } from "./types.js";
-import { TOOL_SPECS, dispatchToolCall, type ToolCallInput } from "./tools.js";
+import {
+  getAllToolSpecs,
+  injectSchema,
+  clearDynamicTools,
+  dispatchToolCall,
+  type ToolCallInput,
+} from "./tools.js";
+import { loadAllSchemas } from "./schema.js";
 
 // ---------------------------------------------------------------------------
 // System prompt
@@ -30,11 +37,9 @@ const BASE_SYSTEM_PROMPT = `You are SportsClaw, a high-performance sports AI age
 
 Your core directives:
 1. ACCURACY FIRST — Never guess or hallucinate scores, stats, or odds. If the tool returns data, report it exactly. If a tool call fails, say so honestly.
-2. USE TOOLS — When the user asks about live scores, standings, schedules, odds, or any sports data, ALWAYS use the sports_query tool. Do not make up data from training knowledge when live data is available.
+2. USE TOOLS — When the user asks about live scores, standings, schedules, odds, or any sports data, ALWAYS use the available tools. Do not make up data from training knowledge when live data is available.
 3. BE CONCISE — Sports fans want quick, clear answers. Lead with the data, add context after.
-4. CITE THE SOURCE — When reporting data from a tool call, mention it came from live data.
-
-You have access to the sports_query tool which connects to the sports-skills data engine supporting: NFL, NBA, MLB, NHL, Soccer, F1, MMA, Tennis, College Football, and College Basketball.`;
+4. CITE THE SOURCE — When reporting data from a tool call, mention it came from live data.`;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -63,19 +68,51 @@ export class SportsClawEngine {
   constructor(config?: Partial<SportsClawConfig>) {
     this.config = { ...DEFAULT_CONFIG, ...filterDefined(config ?? {}) };
     this.client = new Anthropic();
+    this.loadDynamicSchemas();
   }
 
-  /** Full system prompt (base + user-supplied) */
-  private get systemPrompt(): string {
-    if (this.config.systemPrompt) {
-      return `${BASE_SYSTEM_PROMPT}\n\n${this.config.systemPrompt}`;
+  /**
+   * Load all saved sport schemas from disk and inject them into the tool
+   * registry so the LLM can call sport-specific tools directly.
+   */
+  private loadDynamicSchemas(): void {
+    clearDynamicTools();
+    const schemas = loadAllSchemas();
+    for (const schema of schemas) {
+      injectSchema(schema);
+      if (this.config.verbose) {
+        console.error(
+          `[sportsclaw] loaded schema: ${schema.sport} (${schema.tools.length} tools)`
+        );
+      }
     }
-    return BASE_SYSTEM_PROMPT;
+  }
+
+  /** Full system prompt (base + dynamic tool info + user-supplied) */
+  private get systemPrompt(): string {
+    const parts = [BASE_SYSTEM_PROMPT];
+
+    // List available tools for the LLM
+    const allSpecs = getAllToolSpecs();
+    const toolNames = allSpecs.map((s) => s.name);
+    if (toolNames.length > 1) {
+      parts.push(
+        "",
+        `Available tools: ${toolNames.join(", ")}`,
+        "Use the most specific tool available for each query."
+      );
+    }
+
+    if (this.config.systemPrompt) {
+      parts.push("", this.config.systemPrompt);
+    }
+
+    return parts.join("\n");
   }
 
   /** Anthropic tool definitions in the format the API expects */
   private get tools(): Anthropic.Tool[] {
-    return TOOL_SPECS.map((spec) => ({
+    return getAllToolSpecs().map((spec) => ({
       name: spec.name,
       description: spec.description,
       input_schema: spec.input_schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 /**
- * SportsClaw Engine — Entry Point
+ * SportsClaw Engine — CLI Entry Point
  *
- * Usage:
- *   npx sportsclaw "What is the score of the last NFL game?"
- *   ANTHROPIC_API_KEY=sk-... node dist/index.js "Who leads the Premier League?"
+ * Subcommands:
+ *   sportsclaw add <sport>       — Inject a sport schema from the Python package
+ *   sportsclaw remove <sport>    — Remove a previously added sport schema
+ *   sportsclaw list              — List all installed sport schemas
+ *   sportsclaw listen <platform> — Start a Discord or Telegram listener
+ *   sportsclaw "<prompt>"        — Run a one-shot query (default)
  *
  * Or import as a library:
  *   import { SportsClawEngine } from "sportsclaw-engine-core";
@@ -14,50 +17,163 @@
 
 import { fileURLToPath } from "node:url";
 import { SportsClawEngine } from "./engine.js";
+import {
+  fetchSportSchema,
+  saveSchema,
+  removeSchema,
+  listSchemas,
+  getSchemaDir,
+} from "./schema.js";
 
 // ---------------------------------------------------------------------------
 // Re-exports for library usage
 // ---------------------------------------------------------------------------
 
 export { SportsClawEngine } from "./engine.js";
-export { TOOL_SPECS, executePythonBridge, dispatchToolCall } from "./tools.js";
+export {
+  TOOL_SPECS,
+  executePythonBridge,
+  dispatchToolCall,
+  getAllToolSpecs,
+  injectSchema,
+  clearDynamicTools,
+} from "./tools.js";
+export {
+  fetchSportSchema,
+  saveSchema,
+  removeSchema,
+  listSchemas,
+  loadAllSchemas,
+} from "./schema.js";
 export type {
   SportsClawConfig,
   ToolSpec,
   PythonBridgeResult,
   TurnResult,
+  SportSchema,
+  SportToolDef,
 } from "./types.js";
 
 // ---------------------------------------------------------------------------
-// CLI entry point
+// CLI: `sportsclaw add <sport>`
 // ---------------------------------------------------------------------------
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
+async function cmdAdd(args: string[]): Promise<void> {
+  const sport = args[0];
+  if (!sport) {
+    console.error("Usage: sportsclaw add <sport>");
+    console.error("Example: sportsclaw add nfl");
+    process.exit(1);
+  }
 
-  // Parse flags
+  const pythonPath = process.env.PYTHON_PATH || "python3";
+  console.log(`Fetching schema for "${sport}"...`);
+
+  try {
+    const schema = await fetchSportSchema(sport, { pythonPath });
+    saveSchema(schema);
+    console.log(`Successfully added "${sport}" (${schema.tools.length} tools):`);
+    for (const tool of schema.tools) {
+      console.log(`  - ${tool.name}: ${tool.description.slice(0, 80)}`);
+    }
+    console.log(`\nSchema saved to ${getSchemaDir()}/${sport}.json`);
+    console.log("The agent will now use these tools automatically.");
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error("Failed to add sport schema:", error);
+    }
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI: `sportsclaw remove <sport>`
+// ---------------------------------------------------------------------------
+
+function cmdRemove(args: string[]): void {
+  const sport = args[0];
+  if (!sport) {
+    console.error("Usage: sportsclaw remove <sport>");
+    process.exit(1);
+  }
+
+  if (removeSchema(sport)) {
+    console.log(`Removed schema for "${sport}".`);
+  } else {
+    console.error(`No schema found for "${sport}".`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI: `sportsclaw list`
+// ---------------------------------------------------------------------------
+
+function cmdList(): void {
+  const schemas = listSchemas();
+  if (schemas.length === 0) {
+    console.log("No sport schemas installed.");
+    console.log('Add one with: sportsclaw add <sport>');
+    return;
+  }
+  console.log(`Installed sport schemas (${schemas.length}):`);
+  for (const name of schemas) {
+    console.log(`  - ${name}`);
+  }
+  console.log(`\nSchema directory: ${getSchemaDir()}`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI: `sportsclaw listen <platform>`
+// ---------------------------------------------------------------------------
+
+async function cmdListen(args: string[]): Promise<void> {
+  const platform = args[0]?.toLowerCase();
+  if (!platform || !["discord", "telegram"].includes(platform)) {
+    console.error("Usage: sportsclaw listen <discord|telegram>");
+    process.exit(1);
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("Error: ANTHROPIC_API_KEY environment variable is required.");
+    process.exit(1);
+  }
+
+  if (platform === "discord") {
+    if (!process.env.DISCORD_BOT_TOKEN) {
+      console.error("Error: DISCORD_BOT_TOKEN environment variable is required.");
+      console.error("Get one at https://discord.com/developers/applications");
+      process.exit(1);
+    }
+    const { startDiscordListener } = await import("./listeners/discord.js");
+    await startDiscordListener();
+  } else if (platform === "telegram") {
+    if (!process.env.TELEGRAM_BOT_TOKEN) {
+      console.error("Error: TELEGRAM_BOT_TOKEN environment variable is required.");
+      console.error("Get one from @BotFather on Telegram.");
+      process.exit(1);
+    }
+    const { startTelegramListener } = await import("./listeners/telegram.js");
+    await startTelegramListener();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI: default — run a one-shot query
+// ---------------------------------------------------------------------------
+
+async function cmdQuery(args: string[]): Promise<void> {
   const verbose = args.includes("--verbose") || args.includes("-v");
   const filteredArgs = args.filter((a) => a !== "--verbose" && a !== "-v");
   const prompt = filteredArgs.join(" ");
 
   if (!prompt) {
-    console.log("SportsClaw Engine v0.1.0");
-    console.log("");
-    console.log("Usage:");
-    console.log('  npx sportsclaw "What is the score of the last NFL game?"');
-    console.log('  node dist/index.js "Who leads the Premier League?"');
-    console.log("");
-    console.log("Options:");
-    console.log("  --verbose, -v    Enable verbose logging");
-    console.log("");
-    console.log("Environment:");
-    console.log("  ANTHROPIC_API_KEY    Your Anthropic API key (required)");
-    console.log("  SPORTSCLAW_MODEL     Model override (default: claude-sonnet-4-20250514)");
-    console.log("  PYTHON_PATH          Path to Python interpreter (default: python3)");
+    printHelp();
     process.exit(0);
   }
 
-  // Check for API key
   if (!process.env.ANTHROPIC_API_KEY) {
     console.error("Error: ANTHROPIC_API_KEY environment variable is required.");
     console.error("Set it with: export ANTHROPIC_API_KEY=sk-...");
@@ -82,6 +198,63 @@ async function main(): Promise<void> {
       console.error("An unknown error occurred:", error);
     }
     process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+function printHelp(): void {
+  console.log("SportsClaw Engine v0.2.0");
+  console.log("");
+  console.log("Usage:");
+  console.log('  sportsclaw "<prompt>"              Run a one-shot sports query');
+  console.log("  sportsclaw add <sport>             Add a sport schema (e.g. nfl, nba)");
+  console.log("  sportsclaw remove <sport>          Remove a sport schema");
+  console.log("  sportsclaw list                    List installed sport schemas");
+  console.log("  sportsclaw listen <platform>       Start a chat listener (discord, telegram)");
+  console.log("");
+  console.log("Options:");
+  console.log("  --verbose, -v    Enable verbose logging");
+  console.log("  --help, -h       Show this help message");
+  console.log("");
+  console.log("Environment:");
+  console.log("  ANTHROPIC_API_KEY       Your Anthropic API key (required for queries)");
+  console.log("  SPORTSCLAW_MODEL        Model override (default: claude-sonnet-4-20250514)");
+  console.log("  PYTHON_PATH             Path to Python interpreter (default: python3)");
+  console.log("  SPORTSCLAW_SCHEMA_DIR   Custom schema storage directory");
+  console.log("  DISCORD_BOT_TOKEN       Discord bot token (for listen discord)");
+  console.log("  TELEGRAM_BOT_TOKEN      Telegram bot token (for listen telegram)");
+}
+
+// ---------------------------------------------------------------------------
+// Main — route subcommands
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+
+  switch (subcommand) {
+    case "add":
+      return cmdAdd(subArgs);
+    case "remove":
+      return cmdRemove(subArgs);
+    case "list":
+      return cmdList();
+    case "listen":
+      return cmdListen(subArgs);
+    default:
+      // Not a subcommand — treat the entire args as a query prompt
+      return cmdQuery(args);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,12 +35,10 @@ import {
 export { SportsClawEngine } from "./engine.js";
 export {
   TOOL_SPECS,
+  ToolRegistry,
   executePythonBridge,
-  dispatchToolCall,
-  getAllToolSpecs,
-  injectSchema,
-  clearDynamicTools,
 } from "./tools.js";
+export type { ToolCallInput, ToolCallResult } from "./tools.js";
 export {
   fetchSportSchema,
   saveSchema,
@@ -289,6 +287,7 @@ function printHelp(): void {
   console.log("  SPORTSCLAW_SCHEMA_DIR   Custom schema storage directory");
   console.log("  DISCORD_BOT_TOKEN       Discord bot token (for listen discord)");
   console.log("  TELEGRAM_BOT_TOKEN      Telegram bot token (for listen telegram)");
+  console.log("  ALLOWED_USERS           Comma-separated user IDs for listener whitelist");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/listeners/discord.ts
+++ b/src/listeners/discord.ts
@@ -1,0 +1,113 @@
+/**
+ * SportsClaw — Discord Listener (Phase 4)
+ *
+ * A simple Discord bot that pipes messages to the SportsClaw engine.
+ * Requires the `discord.js` package (optional dependency).
+ *
+ * Environment:
+ *   DISCORD_BOT_TOKEN    — Your Discord bot token
+ *   ANTHROPIC_API_KEY    — Anthropic API key for the engine
+ *
+ * The bot responds to:
+ *   - Direct mentions (@SportsClaw <question>)
+ *   - Messages starting with `!claw <question>`
+ */
+
+import { SportsClawEngine } from "../engine.js";
+
+const PREFIX = "!claw";
+
+export async function startDiscordListener(): Promise<void> {
+  // Dynamic import — discord.js is an optional dependency
+  let Discord: typeof import("discord.js");
+  try {
+    Discord = await import("discord.js");
+  } catch {
+    console.error("Error: discord.js is not installed.");
+    console.error("Install it with: npm install discord.js");
+    process.exit(1);
+  }
+
+  const { Client, GatewayIntentBits, Partials } = Discord;
+
+  const client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ],
+    partials: [Partials.Channel],
+  });
+
+  const engine = new SportsClawEngine({
+    ...(process.env.SPORTSCLAW_MODEL && { model: process.env.SPORTSCLAW_MODEL }),
+    ...(process.env.PYTHON_PATH && { pythonPath: process.env.PYTHON_PATH }),
+  });
+
+  client.once("ready", () => {
+    console.log(`[sportsclaw] Discord bot connected as ${client.user?.tag}`);
+    console.log(`[sportsclaw] Listening for "${PREFIX}" commands and mentions.`);
+  });
+
+  client.on("messageCreate", async (message) => {
+    // Ignore bots
+    if (message.author.bot) return;
+
+    let prompt: string | null = null;
+
+    // Check for prefix command: !claw <question>
+    if (message.content.startsWith(PREFIX)) {
+      prompt = message.content.slice(PREFIX.length).trim();
+    }
+
+    // Check for direct mention: @SportsClaw <question>
+    if (!prompt && client.user && message.mentions.has(client.user)) {
+      prompt = message.content
+        .replace(new RegExp(`<@!?${client.user.id}>`, "g"), "")
+        .trim();
+    }
+
+    if (!prompt) return;
+
+    try {
+      // Show typing indicator
+      await message.channel.sendTyping();
+
+      engine.reset();
+      const response = await engine.run(prompt);
+
+      // Discord has a 2000 char limit — split if needed
+      const chunks = splitMessage(response, 2000);
+      for (const chunk of chunks) {
+        await message.reply(chunk);
+      }
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(`[sportsclaw] Discord error: ${errMsg}`);
+      await message.reply("Sorry, I encountered an error processing your request.");
+    }
+  });
+
+  await client.login(process.env.DISCORD_BOT_TOKEN);
+}
+
+/** Split a message into chunks that fit Discord's character limit */
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+    // Try to split at a newline
+    let splitIdx = remaining.lastIndexOf("\n", maxLen);
+    if (splitIdx <= 0) splitIdx = maxLen;
+    chunks.push(remaining.slice(0, splitIdx));
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+  return chunks;
+}

--- a/src/listeners/telegram.ts
+++ b/src/listeners/telegram.ts
@@ -1,0 +1,158 @@
+/**
+ * SportsClaw — Telegram Listener (Phase 4)
+ *
+ * A simple Telegram bot that pipes messages to the SportsClaw engine.
+ * Uses the Telegram Bot API directly via fetch — no extra dependencies.
+ *
+ * Environment:
+ *   TELEGRAM_BOT_TOKEN   — Your Telegram bot token (from @BotFather)
+ *   ANTHROPIC_API_KEY    — Anthropic API key for the engine
+ *
+ * The bot responds to all text messages sent to it (1:1 or in groups when
+ * mentioned via /claw <question>).
+ */
+
+import { SportsClawEngine } from "../engine.js";
+
+const COMMAND_PREFIX = "/claw";
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: {
+    message_id: number;
+    chat: { id: number; type: string };
+    text?: string;
+    from?: { id: number; first_name: string };
+  };
+}
+
+interface TelegramResponse {
+  ok: boolean;
+  result: TelegramUpdate[];
+}
+
+export async function startTelegramListener(): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.error("Error: TELEGRAM_BOT_TOKEN is required.");
+    process.exit(1);
+  }
+
+  const apiBase = `https://api.telegram.org/bot${token}`;
+
+  const engine = new SportsClawEngine({
+    ...(process.env.SPORTSCLAW_MODEL && { model: process.env.SPORTSCLAW_MODEL }),
+    ...(process.env.PYTHON_PATH && { pythonPath: process.env.PYTHON_PATH }),
+  });
+
+  // Verify the bot token is valid
+  const meRes = await fetch(`${apiBase}/getMe`);
+  const meData = (await meRes.json()) as { ok: boolean; result?: { username: string } };
+  if (!meData.ok) {
+    console.error("Error: Invalid TELEGRAM_BOT_TOKEN.");
+    process.exit(1);
+  }
+  console.log(`[sportsclaw] Telegram bot connected as @${meData.result?.username}`);
+  console.log(`[sportsclaw] Listening for messages...`);
+
+  let offset = 0;
+
+  // Long-polling loop
+  while (true) {
+    try {
+      const res = await fetch(
+        `${apiBase}/getUpdates?timeout=30&offset=${offset}`,
+        { signal: AbortSignal.timeout(60_000) }
+      );
+      const data = (await res.json()) as TelegramResponse;
+
+      if (!data.ok || !data.result) continue;
+
+      for (const update of data.result) {
+        offset = update.update_id + 1;
+
+        const msg = update.message;
+        if (!msg?.text) continue;
+
+        let prompt: string | null = null;
+
+        // In private chats, respond to all messages
+        if (msg.chat.type === "private") {
+          prompt = msg.text;
+        }
+
+        // In groups, respond to /claw commands
+        if (!prompt && msg.text.startsWith(COMMAND_PREFIX)) {
+          prompt = msg.text.slice(COMMAND_PREFIX.length).trim();
+        }
+
+        if (!prompt) continue;
+
+        // Send "typing" action
+        await fetch(`${apiBase}/sendChatAction`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: msg.chat.id,
+            action: "typing",
+          }),
+        });
+
+        try {
+          engine.reset();
+          const response = await engine.run(prompt);
+
+          // Telegram has a 4096 char limit — split if needed
+          const chunks = splitMessage(response, 4096);
+          for (const chunk of chunks) {
+            await fetch(`${apiBase}/sendMessage`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                chat_id: msg.chat.id,
+                text: chunk,
+                reply_to_message_id: msg.message_id,
+              }),
+            });
+          }
+        } catch (error: unknown) {
+          const errMsg = error instanceof Error ? error.message : String(error);
+          console.error(`[sportsclaw] Telegram error: ${errMsg}`);
+          await fetch(`${apiBase}/sendMessage`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              chat_id: msg.chat.id,
+              text: "Sorry, I encountered an error processing your request.",
+              reply_to_message_id: msg.message_id,
+            }),
+          });
+        }
+      }
+    } catch (error: unknown) {
+      // Network errors during polling — retry after a short delay
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(`[sportsclaw] Polling error: ${errMsg}`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+}
+
+/** Split a message into chunks that fit Telegram's character limit */
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+    let splitIdx = remaining.lastIndexOf("\n", maxLen);
+    if (splitIdx <= 0) splitIdx = maxLen;
+    chunks.push(remaining.slice(0, splitIdx));
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+  return chunks;
+}

--- a/src/listeners/telegram.ts
+++ b/src/listeners/telegram.ts
@@ -7,12 +7,15 @@
  * Environment:
  *   TELEGRAM_BOT_TOKEN   — Your Telegram bot token (from @BotFather)
  *   ANTHROPIC_API_KEY    — Anthropic API key for the engine
+ *   ALLOWED_USERS        — Comma-separated Telegram user IDs (optional whitelist)
  *
  * The bot responds to all text messages sent to it (1:1 or in groups when
  * mentioned via /claw <question>).
  */
 
 import { SportsClawEngine } from "../engine.js";
+import type { SportsClawConfig } from "../types.js";
+import { splitMessage } from "../utils.js";
 
 const COMMAND_PREFIX = "/claw";
 
@@ -31,6 +34,17 @@ interface TelegramResponse {
   result: TelegramUpdate[];
 }
 
+/** Parse ALLOWED_USERS env var into a Set of user IDs, or null if unset */
+function getAllowedUsers(): Set<string> | null {
+  const raw = process.env.ALLOWED_USERS;
+  if (!raw) return null;
+  const ids = raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  return ids.length > 0 ? new Set(ids) : null;
+}
+
 export async function startTelegramListener(): Promise<void> {
   const token = process.env.TELEGRAM_BOT_TOKEN;
   if (!token) {
@@ -40,19 +54,33 @@ export async function startTelegramListener(): Promise<void> {
 
   const apiBase = `https://api.telegram.org/bot${token}`;
 
-  const engine = new SportsClawEngine({
-    ...(process.env.SPORTSCLAW_MODEL && { model: process.env.SPORTSCLAW_MODEL }),
+  const allowedUsers = getAllowedUsers();
+  if (allowedUsers) {
+    console.log(
+      `[sportsclaw] User whitelist active: ${allowedUsers.size} user(s) allowed`
+    );
+  }
+
+  const engineConfig: Partial<SportsClawConfig> = {
+    ...(process.env.SPORTSCLAW_MODEL && {
+      model: process.env.SPORTSCLAW_MODEL,
+    }),
     ...(process.env.PYTHON_PATH && { pythonPath: process.env.PYTHON_PATH }),
-  });
+  };
 
   // Verify the bot token is valid
   const meRes = await fetch(`${apiBase}/getMe`);
-  const meData = (await meRes.json()) as { ok: boolean; result?: { username: string } };
+  const meData = (await meRes.json()) as {
+    ok: boolean;
+    result?: { username: string };
+  };
   if (!meData.ok) {
     console.error("Error: Invalid TELEGRAM_BOT_TOKEN.");
     process.exit(1);
   }
-  console.log(`[sportsclaw] Telegram bot connected as @${meData.result?.username}`);
+  console.log(
+    `[sportsclaw] Telegram bot connected as @${meData.result?.username}`
+  );
   console.log(`[sportsclaw] Listening for messages...`);
 
   let offset = 0;
@@ -68,67 +96,16 @@ export async function startTelegramListener(): Promise<void> {
 
       if (!data.ok || !data.result) continue;
 
+      // Advance offset for all received updates immediately
       for (const update of data.result) {
-        offset = update.update_id + 1;
-
-        const msg = update.message;
-        if (!msg?.text) continue;
-
-        let prompt: string | null = null;
-
-        // In private chats, respond to all messages
-        if (msg.chat.type === "private") {
-          prompt = msg.text;
-        }
-
-        // In groups, respond to /claw commands
-        if (!prompt && msg.text.startsWith(COMMAND_PREFIX)) {
-          prompt = msg.text.slice(COMMAND_PREFIX.length).trim();
-        }
-
-        if (!prompt) continue;
-
-        // Send "typing" action
-        await fetch(`${apiBase}/sendChatAction`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            chat_id: msg.chat.id,
-            action: "typing",
-          }),
-        });
-
-        try {
-          engine.reset();
-          const response = await engine.run(prompt);
-
-          // Telegram has a 4096 char limit — split if needed
-          const chunks = splitMessage(response, 4096);
-          for (const chunk of chunks) {
-            await fetch(`${apiBase}/sendMessage`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                chat_id: msg.chat.id,
-                text: chunk,
-                reply_to_message_id: msg.message_id,
-              }),
-            });
-          }
-        } catch (error: unknown) {
-          const errMsg = error instanceof Error ? error.message : String(error);
-          console.error(`[sportsclaw] Telegram error: ${errMsg}`);
-          await fetch(`${apiBase}/sendMessage`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              chat_id: msg.chat.id,
-              text: "Sorry, I encountered an error processing your request.",
-              reply_to_message_id: msg.message_id,
-            }),
-          });
-        }
+        offset = Math.max(offset, update.update_id + 1);
       }
+
+      // Process updates concurrently to avoid head-of-line blocking
+      const tasks = data.result.map((update) =>
+        processUpdate(update, apiBase, engineConfig, allowedUsers)
+      );
+      await Promise.allSettled(tasks);
     } catch (error: unknown) {
       // Network errors during polling — retry after a short delay
       const errMsg = error instanceof Error ? error.message : String(error);
@@ -138,21 +115,73 @@ export async function startTelegramListener(): Promise<void> {
   }
 }
 
-/** Split a message into chunks that fit Telegram's character limit */
-function splitMessage(text: string, maxLen: number): string[] {
-  if (text.length <= maxLen) return [text];
+/** Process a single Telegram update in its own async context */
+async function processUpdate(
+  update: TelegramUpdate,
+  apiBase: string,
+  engineConfig: Partial<SportsClawConfig>,
+  allowedUsers: Set<string> | null
+): Promise<void> {
+  const msg = update.message;
+  if (!msg?.text) return;
 
-  const chunks: string[] = [];
-  let remaining = text;
-  while (remaining.length > 0) {
-    if (remaining.length <= maxLen) {
-      chunks.push(remaining);
-      break;
-    }
-    let splitIdx = remaining.lastIndexOf("\n", maxLen);
-    if (splitIdx <= 0) splitIdx = maxLen;
-    chunks.push(remaining.slice(0, splitIdx));
-    remaining = remaining.slice(splitIdx).trimStart();
+  // Check user whitelist
+  if (allowedUsers && msg.from && !allowedUsers.has(String(msg.from.id)))
+    return;
+
+  let prompt: string | null = null;
+
+  // In private chats, respond to all messages
+  if (msg.chat.type === "private") {
+    prompt = msg.text;
   }
-  return chunks;
+
+  // In groups, respond to /claw commands
+  if (!prompt && msg.text.startsWith(COMMAND_PREFIX)) {
+    prompt = msg.text.slice(COMMAND_PREFIX.length).trim();
+  }
+
+  if (!prompt) return;
+
+  // Send "typing" action
+  await fetch(`${apiBase}/sendChatAction`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: msg.chat.id,
+      action: "typing",
+    }),
+  });
+
+  try {
+    // Fresh engine per request — avoids shared-state issues
+    const engine = new SportsClawEngine(engineConfig);
+    const response = await engine.run(prompt);
+
+    // Telegram has a 4096 char limit — split if needed
+    const chunks = splitMessage(response, 4096);
+    for (const chunk of chunks) {
+      await fetch(`${apiBase}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: msg.chat.id,
+          text: chunk,
+          reply_to_message_id: msg.message_id,
+        }),
+      });
+    }
+  } catch (error: unknown) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    console.error(`[sportsclaw] Telegram error: ${errMsg}`);
+    await fetch(`${apiBase}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: msg.chat.id,
+        text: "Sorry, I encountered an error processing your request.",
+        reply_to_message_id: msg.message_id,
+      }),
+    });
+  }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,176 @@
+/**
+ * SportsClaw Engine — Schema Injection (Phase 3)
+ *
+ * Handles fetching sport-specific tool schemas from the Python `sports-skills`
+ * package, persisting them to disk, and loading them at engine startup.
+ *
+ * Flow:
+ *   1. `sportsclaw add nfl`
+ *   2. Runs `python3 -m sports_skills nfl schema` → JSON tool definitions
+ *   3. Saves to ~/.sportsclaw/schemas/nfl.json
+ *   4. On next engine run, schemas are loaded and injected into the tool registry
+ */
+
+import { execFile } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { SportSchema, SportsClawConfig } from "./types.js";
+import { buildSubprocessEnv } from "./tools.js";
+
+// ---------------------------------------------------------------------------
+// Schema directory management
+// ---------------------------------------------------------------------------
+
+/** Resolve the directory where sport schemas are stored */
+export function getSchemaDir(): string {
+  const dir =
+    process.env.SPORTSCLAW_SCHEMA_DIR ||
+    join(homedir(), ".sportsclaw", "schemas");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch schema from Python package
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute `python3 -m sports_skills <sport> schema` and parse the JSON output.
+ *
+ * Throws with a descriptive error if the package isn't installed, the sport
+ * isn't supported, or the output isn't valid JSON.
+ */
+export function fetchSportSchema(
+  sport: string,
+  config?: Partial<SportsClawConfig>
+): Promise<SportSchema> {
+  const pythonPath = config?.pythonPath ?? "python3";
+  const timeout = config?.timeout ?? 30_000;
+
+  return new Promise((resolve, reject) => {
+    execFile(
+      pythonPath,
+      ["-m", "sports_skills", sport, "schema"],
+      {
+        encoding: "utf-8",
+        timeout,
+        maxBuffer: 10 * 1024 * 1024,
+        env: buildSubprocessEnv(config?.env),
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const msg = [
+            `Failed to fetch schema for "${sport}".`,
+            "",
+            error.message,
+            "",
+            "Possible causes:",
+            "  1. The sports-skills Python package is not installed.",
+            '     → pip install sports-skills',
+            `  2. The sport "${sport}" is not supported by the installed version.`,
+            "  3. Python 3 is not available at the configured path.",
+            `     → Current path: ${pythonPath}`,
+          ];
+          if (stderr) {
+            msg.push("", `stderr: ${stderr.trim()}`);
+          }
+          reject(new Error(msg.join("\n")));
+          return;
+        }
+
+        const trimmed = (stdout ?? "").trim();
+        if (!trimmed) {
+          reject(
+            new Error(
+              `No schema output for sport "${sport}". ` +
+                "The sport may not be supported by the installed sports-skills version."
+            )
+          );
+          return;
+        }
+
+        try {
+          const schema = JSON.parse(trimmed) as SportSchema;
+          if (!schema.sport || !Array.isArray(schema.tools)) {
+            reject(
+              new Error(
+                `Invalid schema format for "${sport}": ` +
+                  'response must contain "sport" (string) and "tools" (array) fields.'
+              )
+            );
+            return;
+          }
+          resolve(schema);
+        } catch {
+          reject(
+            new Error(
+              `Invalid JSON in schema output for "${sport}":\n${trimmed.slice(0, 300)}`
+            )
+          );
+        }
+      }
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Persist / load schemas
+// ---------------------------------------------------------------------------
+
+/** Save a sport schema to disk */
+export function saveSchema(schema: SportSchema): void {
+  const dir = getSchemaDir();
+  const filePath = join(dir, `${schema.sport}.json`);
+  writeFileSync(filePath, JSON.stringify(schema, null, 2), "utf-8");
+}
+
+/** Load all saved schemas from the schema directory */
+export function loadAllSchemas(): SportSchema[] {
+  const dir = getSchemaDir();
+  if (!existsSync(dir)) return [];
+
+  const schemas: SportSchema[] = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const content = readFileSync(join(dir, file), "utf-8");
+      const schema = JSON.parse(content) as SportSchema;
+      if (schema.sport && Array.isArray(schema.tools)) {
+        schemas.push(schema);
+      }
+    } catch {
+      // Skip malformed schema files silently
+    }
+  }
+  return schemas;
+}
+
+/** Remove a sport schema from disk. Returns true if found and deleted. */
+export function removeSchema(sport: string): boolean {
+  const dir = getSchemaDir();
+  const filePath = join(dir, `${sport}.json`);
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+    return true;
+  }
+  return false;
+}
+
+/** List all sport names that have saved schemas */
+export function listSchemas(): string[] {
+  const dir = getSchemaDir();
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => f.replace(".json", ""));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,3 +79,22 @@ export interface TurnResult {
   /** Number of tool calls executed this turn */
   toolCalls: number;
 }
+
+// ---------------------------------------------------------------------------
+// Schema injection types (Phase 3)
+// ---------------------------------------------------------------------------
+
+/** Schema returned by `python3 -m sports_skills <sport> schema` */
+export interface SportSchema {
+  sport: string;
+  version?: string;
+  tools: SportToolDef[];
+}
+
+/** A single tool definition within a sport schema */
+export interface SportToolDef {
+  name: string;
+  description: string;
+  command: string;
+  input_schema: Record<string, unknown>;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,37 @@
+/**
+ * SportsClaw — Shared Utilities
+ */
+
+/**
+ * Split a message into chunks that fit a platform's character limit.
+ * Tries to split at newlines for clean breaks, falls back to hard breaks.
+ */
+export function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Try to split at a newline within the limit
+    let splitIdx = remaining.lastIndexOf("\n", maxLen);
+    if (splitIdx < 1) splitIdx = maxLen;
+
+    chunks.push(remaining.slice(0, splitIdx));
+    const next = remaining.slice(splitIdx).trimStart();
+
+    // Guard: if no progress was made, force a hard break to prevent infinite loop
+    if (next.length >= remaining.length) {
+      chunks.push(remaining.slice(maxLen));
+      break;
+    }
+    remaining = next;
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
## Summary

- **Phase 3 — CLI & Schema Injection**: `sportsclaw add <sport>` dynamically pulls JSON tool schemas from the `sports-skills` Python package (`python3 -m sports_skills <sport> schema`), persists them to `~/.sportsclaw/schemas/`, and injects them into the LLM tool registry at engine startup. Graceful error handling when the Python package or sport schema isn't found.
- **Phase 4 — Trojan Horse Container**: Single `Dockerfile` wrapping Node.js (engine) + Python 3 (sports-skills). Discord and Telegram listeners pipe chat messages directly to the engine. Developers can run `sportsclaw listen discord` or `sportsclaw listen telegram` out of the box.

### New CLI Commands
```
sportsclaw add <sport>          # Fetch & inject a sport schema
sportsclaw remove <sport>       # Remove a sport schema
sportsclaw list                 # List installed schemas
sportsclaw listen <platform>    # Start Discord or Telegram listener
```

### New Files
| File | Purpose |
|------|---------|
| `src/schema.ts` | Schema fetch, persist, load, remove |
| `src/listeners/discord.ts` | Discord bot (responds to `!claw` and @mentions) |
| `src/listeners/telegram.ts` | Telegram bot (long-polling, `/claw` commands) |
| `Dockerfile` | Node.js + Python 3 single container |
| `.dockerignore` | Build exclusions |

### Modified Files
| File | Changes |
|------|---------|
| `src/engine.ts` | Loads dynamic schemas at startup, injects into system prompt |
| `src/tools.ts` | Dynamic tool registry, route map, schema injection |
| `src/types.ts` | `SportSchema` and `SportToolDef` types |
| `src/index.ts` | Full CLI with add/remove/list/listen subcommands |
| `package.json` | Version bump, scripts for listeners and Docker |

## Test plan
- [x] `npm run build` compiles without errors
- [x] `sportsclaw --help` displays all commands
- [x] `sportsclaw list` shows empty state correctly
- [x] `sportsclaw add nfl` fails gracefully when sports-skills not installed
- [x] `sportsclaw remove nonexistent` fails gracefully
- [x] `sportsclaw listen discord` validates missing env vars
- [x] `sportsclaw listen telegram` validates missing env vars
- [x] `sportsclaw listen slack` rejects unsupported platform
- [x] Mock schema loading/listing works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)