### PR TITLE
feat: Markdown Persistent Memory (OpenClaw Architecture)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,11 @@ export {
   bootstrapDefaultSchemas,
   DEFAULT_SKILLS,
 } from "./schema.js";
+export { MemoryManager, getMemoryDir } from "./memory.js";
 export type {
   LLMProvider,
   SportsClawConfig,
+  RunOptions,
   ToolSpec,
   PythonBridgeResult,
   TurnResult,

--- a/src/listeners/discord.ts
+++ b/src/listeners/discord.ts
@@ -100,13 +100,16 @@ export async function startDiscordListener(): Promise<void> {
 
     if (!prompt) return;
 
+    // Use the Discord user ID for memory isolation
+    const userId = `discord-${message.author.id}`;
+
     try {
       // Show typing indicator
       await message.channel.sendTyping();
 
       // Fresh engine per request — avoids shared-state race conditions
       const engine = new SportsClawEngine(engineConfig);
-      const response = await engine.run(prompt);
+      const response = await engine.run(prompt, { userId });
 
       // Discord has a 2000 char limit — split if needed
       const chunks = splitMessage(response, 2000);

--- a/src/listeners/telegram.ts
+++ b/src/listeners/telegram.ts
@@ -155,10 +155,13 @@ async function processUpdate(
     }),
   });
 
+  // Use the Telegram user ID for memory isolation
+  const userId = `telegram-${msg.from?.id ?? msg.chat.id}`;
+
   try {
     // Fresh engine per request — avoids shared-state issues
     const engine = new SportsClawEngine(engineConfig);
-    const response = await engine.run(prompt);
+    const response = await engine.run(prompt, { userId });
 
     // Telegram has a 4096 char limit — split if needed
     const chunks = splitMessage(response, 4096);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,177 @@
+/**
+ * SportsClaw — Markdown Persistent Memory (OpenClaw Architecture)
+ *
+ * A 3-layer memory system using plain .md files:
+ *
+ *   HOT   → CONTEXT.md   — Current state snapshot (overwritten on context shifts)
+ *   WARM  → <date>.md    — Append-only conversation log for today
+ *   COLD  → older .md    — Previous days' logs (read-only archive)
+ *
+ * Storage layout:
+ *   ~/.sportsclaw/memory/<userId>/CONTEXT.md
+ *   ~/.sportsclaw/memory/<userId>/2026-02-23.md
+ *
+ * No SQLite. No JSON blobs. Just markdown.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MEMORY_BASE =
+  process.env.SPORTSCLAW_MEMORY_DIR ||
+  join(homedir(), ".sportsclaw", "memory");
+
+const CONTEXT_FILE = "CONTEXT.md";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Get today's date as YYYY-MM-DD */
+function todayStamp(): string {
+  const d = new Date();
+  return d.toISOString().slice(0, 10);
+}
+
+/** Read a file, returning empty string if it doesn't exist */
+function safeRead(path: string): string {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/** Format a timestamp for log entries */
+function timestamp(): string {
+  return new Date().toISOString().replace("T", " ").slice(0, 19);
+}
+
+// ---------------------------------------------------------------------------
+// MemoryManager
+// ---------------------------------------------------------------------------
+
+export class MemoryManager {
+  private dir: string;
+  private userId: string;
+
+  constructor(userId: string) {
+    this.userId = userId;
+    this.dir = join(MEMORY_BASE, sanitizeId(userId));
+    mkdirSync(this.dir, { recursive: true });
+  }
+
+  /** Absolute path to the user's memory directory */
+  get memoryDir(): string {
+    return this.dir;
+  }
+
+  // -------------------------------------------------------------------------
+  // HOT layer — CONTEXT.md
+  // -------------------------------------------------------------------------
+
+  /** Read the user's current context snapshot */
+  readContext(): string {
+    return safeRead(join(this.dir, CONTEXT_FILE));
+  }
+
+  /** Overwrite the user's context snapshot */
+  writeContext(content: string): void {
+    writeFileSync(join(this.dir, CONTEXT_FILE), content, "utf-8");
+  }
+
+  // -------------------------------------------------------------------------
+  // WARM layer — <date>.md
+  // -------------------------------------------------------------------------
+
+  /** Read today's conversation log */
+  readTodayLog(): string {
+    return safeRead(join(this.dir, `${todayStamp()}.md`));
+  }
+
+  /** Append a user→assistant exchange to today's log */
+  appendExchange(userPrompt: string, assistantReply: string): void {
+    const logPath = join(this.dir, `${todayStamp()}.md`);
+    const ts = timestamp();
+
+    const entry = [
+      `## [${ts}]`,
+      "",
+      `**User:** ${userPrompt}`,
+      "",
+      `**Assistant:** ${assistantReply}`,
+      "",
+      "---",
+      "",
+    ].join("\n");
+
+    appendFileSync(logPath, entry, "utf-8");
+  }
+
+  /** Append a raw note (e.g., tool output) to today's log */
+  appendNote(label: string, content: string): void {
+    const logPath = join(this.dir, `${todayStamp()}.md`);
+    const ts = timestamp();
+
+    const entry = [`> **${label}** (${ts}): ${content}`, ""].join("\n");
+
+    appendFileSync(logPath, entry, "utf-8");
+  }
+
+  // -------------------------------------------------------------------------
+  // Combined read for system prompt injection
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build a memory block suitable for injection into the system prompt.
+   * Returns empty string if the user has no memory yet.
+   */
+  buildMemoryBlock(): string {
+    const context = this.readContext();
+    const todayLog = this.readTodayLog();
+
+    if (!context && !todayLog) return "";
+
+    const parts: string[] = [
+      "## Persistent Memory",
+      `User ID: ${this.userId}`,
+    ];
+
+    if (context) {
+      parts.push("", "### Current Context (CONTEXT.md)", context);
+    }
+
+    if (todayLog) {
+      // Only inject the tail of today's log to stay within token budget
+      const lines = todayLog.split("\n");
+      const MAX_LOG_LINES = 100;
+      const tail =
+        lines.length > MAX_LOG_LINES
+          ? lines.slice(-MAX_LOG_LINES).join("\n")
+          : todayLog;
+
+      parts.push("", "### Today's Conversation Log", tail);
+    }
+
+    return parts.join("\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/** Sanitize a user/thread ID for safe use as a directory name */
+function sanitizeId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 128);
+}
+
+/** Get the base memory directory (useful for CLI / diagnostics) */
+export function getMemoryDir(): string {
+  return MEMORY_BASE;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,3 +110,12 @@ export interface SportToolDef {
   command: string;
   input_schema: Record<string, unknown>;
 }
+
+// ---------------------------------------------------------------------------
+// Memory options passed to engine.run()
+// ---------------------------------------------------------------------------
+
+export interface RunOptions {
+  /** User or thread ID for memory isolation. If omitted, memory is disabled. */
+  userId?: string;
+}


### PR DESCRIPTION
## Summary

- **Add `MemoryManager` class** (`src/memory.ts`) — a persistent memory system using plain `.md` files, following the OpenClaw 3-layer architecture:
  - **HOT**: `CONTEXT.md` — current state snapshot (active game, user intent, preferences), overwritten when context shifts
  - **WARM**: `<date>.md` — append-only conversation log per day
  - **COLD**: older `.md` files — read-only archive from previous days
- **Integrate memory into the engine** — before each LLM call, reads `CONTEXT.md` and today's log and injects them into the system prompt; after the LLM replies, appends the exchange to the date log
- **Add `update_context` internal tool** — an LLM-callable tool that overwrites `CONTEXT.md` when the user changes topic or context shifts significantly
- **Update Discord and Telegram listeners** — both now pass `userId` (prefixed with platform name) into `engine.run()` so memory is isolated per user

## Design decisions

- **No SQLite, no JSON blobs** — memory is stored as human-readable markdown at `~/.sportsclaw/memory/<userId>/`
- **Backward compatible** — `engine.run(prompt)` still works without a userId; memory is only activated when `RunOptions.userId` is provided
- **Token budget aware** — today's log injection is capped at the last 100 lines to avoid blowing up the context window
- **Configurable** — memory directory can be overridden via `SPORTSCLAW_MEMORY_DIR` env var

## Test plan

- [ ] Run `sportsclaw "Who won the Super Bowl?"` (no userId) — should work exactly as before
- [ ] Run engine programmatically with `userId` — verify `~/.sportsclaw/memory/<userId>/CONTEXT.md` and date log are created
- [ ] Send multiple messages via Discord/Telegram — verify per-user memory isolation
- [ ] Verify the LLM calls `update_context` when context shifts (e.g., switching from NFL to NBA)
- [ ] Verify large conversation logs are truncated to last 100 lines in the system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)