### PR TITLE
refactor: replace manual PID/spawn daemon with PM2 wrapper

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,13 +40,13 @@ if [ -x "/opt/homebrew/bin/python3" ]; then
 fi
 echo -e "${BLUE}🐍 Using Python: ${PYTHON_BIN}${NC}"
 
-# 2. Install Node Package (Engine)
-echo -e "${BLUE}📦 Installing TypeScript Execution Engine...${NC}"
-npm install -g sportsclaw-engine-core@latest || {
-    echo -e "${RED}❌ Failed to install Node package.${NC}"
+# 2. Install Node Package (Engine) + PM2 (Daemon Manager)
+echo -e "${BLUE}📦 Installing TypeScript Execution Engine + PM2...${NC}"
+npm install -g sportsclaw-engine-core@latest pm2@latest || {
+    echo -e "${RED}❌ Failed to install Node packages.${NC}"
     exit 1
 }
-echo -e "${GREEN}✓ Engine installed.${NC}\n"
+echo -e "${GREEN}✓ Engine + PM2 installed.${NC}\n"
 
 # 3. Install Python Package (Data Skills)
 echo -e "${BLUE}🐍 Installing Python Data Skills...${NC}"


### PR DESCRIPTION
## Summary
- **Gutted** the manual `child_process.spawn` + PID file logic in `src/daemon.ts` and rewrote all four daemon commands (`start`, `stop`, `status`, `logs`) to delegate to PM2
- Each listener now runs as a named PM2 process (`sportsclaw-discord`, `sportsclaw-telegram`) with proper lifecycle management
- Added a `requirePm2()` guard that checks `which pm2` before any daemon operation and prints install guidance if missing
- Updated `scripts/install.sh` to ship `pm2@latest` alongside the engine package

## Test plan
- [ ] Run `sportsclaw start telegram` — verify PM2 starts the process (`pm2 list` shows `sportsclaw-telegram` online)
- [ ] Run `sportsclaw status` — verify status table renders with PM2-backed data
- [ ] Run `sportsclaw logs telegram` — verify PM2 log output is shown
- [ ] Run `sportsclaw stop telegram` — verify the PM2 process is stopped and deleted
- [ ] Uninstall PM2 temporarily (`npm uninstall -g pm2`) and run `sportsclaw start telegram` — verify the exact error message prints
- [ ] Run `scripts/install.sh` on a clean env — verify `pm2` is installed globally alongside the engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)