### PR TITLE
feat: integrate terminal and SVG chart visualizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sportsclaw-engine-core",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/sdk": "^2.4.7",
@@ -16,6 +16,7 @@
         "@clack/prompts": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "ai": "^6.0.97",
+        "asciichart": "^1.5.25",
         "figlet": "^1.10.0",
         "marked": "^15.0.12",
         "marked-terminal": "^7.3.0",
@@ -25,6 +26,7 @@
         "sportsclaw": "dist/index.js"
       },
       "devDependencies": {
+        "@types/asciichart": "^1.5.8",
         "@types/marked-terminal": "^6.1.1",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0"
@@ -454,6 +456,13 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@types/asciichart": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@types/asciichart/-/asciichart-1.5.8.tgz",
+      "integrity": "sha512-8yzgCUybv8/yUfj4WeTh7G+V+AxU7AzwsF2CrkTtARKHdrxE/EiByF2efUMj6qdm87tENucNu6pLs22RWU0H7g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/cardinal/-/cardinal-2.1.1.tgz",
@@ -634,6 +643,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/asciichart": {
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/asciichart/-/asciichart-1.5.25.tgz",
+      "integrity": "sha512-PNxzXIPPOtWq8T7bgzBtk9cI2lgS4SJZthUHEiQ1aoIc3lNzGfUvIvo9LiAnq26TACo9t1/4qP6KTGAUbzX9Xg==",
       "license": "MIT"
     },
     "node_modules/body-parser": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "discord.js": "^14.16.0"
   },
   "devDependencies": {
+    "@types/asciichart": "^1.5.8",
     "@types/marked-terminal": "^6.1.1",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
@@ -53,6 +54,7 @@
     "@clack/prompts": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "ai": "^6.0.97",
+    "asciichart": "^1.5.25",
     "figlet": "^1.10.0",
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0",

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -93,8 +93,8 @@ function renderSpark(opts: ChartOptions): string {
   const values = flatSeries(opts.data);
   if (values.length === 0) return "(no data)";
 
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = values.reduce((a, b) => Math.min(a, b), Infinity);
+  const max = values.reduce((a, b) => Math.max(a, b), -Infinity);
 
   const spark = values
     .map((v) => {
@@ -118,8 +118,8 @@ function renderBars(opts: ChartOptions): string {
   if (values.length === 0) return "(no data)";
 
   const labels = opts.xLabels ?? values.map((_, i) => String(i + 1));
-  const maxLabelLen = Math.max(...labels.map((l) => l.length));
-  const max = Math.max(...values);
+  const maxLabelLen = labels.map((l) => l.length).reduce((a, b) => Math.max(a, b), -Infinity);
+  const max = values.reduce((a, b) => Math.max(a, b), -Infinity);
   const BAR_WIDTH = 40;
   const FILL = "█";
 
@@ -144,7 +144,7 @@ function renderColumns(opts: ChartOptions): string {
   if (values.length === 0) return "(no data)";
 
   const labels = opts.xLabels ?? values.map((_, i) => String(i + 1));
-  const max = Math.max(...values);
+  const max = values.reduce((a, b) => Math.max(a, b), -Infinity);
   const height = opts.height ?? 8;
 
   const rows: string[] = [];
@@ -182,8 +182,8 @@ function renderBraille(opts: ChartOptions): string {
   const values = flatSeries(opts.data);
   if (values.length === 0) return "(no data)";
 
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = values.reduce((a, b) => Math.min(a, b), Infinity);
+  const max = values.reduce((a, b) => Math.max(a, b), -Infinity);
   const height = opts.height ?? 8;
 
   // Braille: each character is a 2×4 dot matrix (2 cols, 4 rows)
@@ -222,7 +222,7 @@ function renderBraille(opts: ChartOptions): string {
         if (x >= values.length) continue;
         for (let dr = 0; dr < 4; dr++) {
           const y = cr * 4 + dr;
-          if (y >= rows && !grid[y]?.[x]) continue;
+          if (!grid[y]?.[x]) continue;
           if (grid[y]?.[x]) {
             code |= DOT_MAP[dc][dr];
           }
@@ -240,6 +240,11 @@ function renderBraille(opts: ChartOptions): string {
   return parts.join("\n");
 }
 
+/** Escape special characters for safe SVG text content. */
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
 /** SVG line chart — raw SVG string for downstream rendering. */
 function renderSvg(opts: ChartOptions): string {
   const values = flatSeries(opts.data);
@@ -248,8 +253,8 @@ function renderSvg(opts: ChartOptions): string {
   const W = 600;
   const H = 300;
   const PAD = 40;
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = values.reduce((a, b) => Math.min(a, b), Infinity);
+  const max = values.reduce((a, b) => Math.max(a, b), -Infinity);
   const xStep = values.length > 1 ? (W - PAD * 2) / (values.length - 1) : 0;
 
   const points = values
@@ -273,12 +278,12 @@ function renderSvg(opts: ChartOptions): string {
   // Axis labels
   if (opts.xAxisLabel) {
     svgParts.push(
-      `  <text x="${W / 2}" y="${H - 8}" text-anchor="middle" fill="#aaa" font-size="12">${opts.xAxisLabel}</text>`
+      `  <text x="${W / 2}" y="${H - 8}" text-anchor="middle" fill="#aaa" font-size="12">${escapeXml(opts.xAxisLabel)}</text>`
     );
   }
   if (opts.yAxisLabel) {
     svgParts.push(
-      `  <text x="12" y="${H / 2}" text-anchor="middle" fill="#aaa" font-size="12" transform="rotate(-90,12,${H / 2})">${opts.yAxisLabel}</text>`
+      `  <text x="12" y="${H / 2}" text-anchor="middle" fill="#aaa" font-size="12" transform="rotate(-90,12,${H / 2})">${escapeXml(opts.yAxisLabel)}</text>`
     );
   }
 

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,0 +1,313 @@
+/**
+ * sportsclaw — Chart Rendering Utilities
+ *
+ * Converts arrays of numbers into terminal-friendly visualizations.
+ * Uses `asciichart` for line charts and provides built-in renderers
+ * for sparklines, horizontal bars, vertical columns, and braille plots.
+ */
+
+import asciichart from "asciichart";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ChartType = "ascii" | "spark" | "bars" | "columns" | "braille" | "svg";
+
+export interface ChartOptions {
+  /** Array of numeric values (single series) or array of arrays (multi-series). */
+  data: number[] | number[][];
+  /** Chart type to render. */
+  chartType: ChartType;
+  /** Label for the X axis. */
+  xAxisLabel?: string;
+  /** Label for the Y axis. */
+  yAxisLabel?: string;
+  /** Optional labels for each data point on the X axis. */
+  xLabels?: string[];
+  /** Height in terminal rows (for ascii/braille). Default: 12 */
+  height?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flatten to a single numeric array (first series if multi). */
+function flatSeries(data: number[] | number[][]): number[] {
+  if (data.length === 0) return [];
+  return Array.isArray(data[0]) ? (data[0] as number[]) : (data as number[]);
+}
+
+/** Get all series as number[][]. */
+function allSeries(data: number[] | number[][]): number[][] {
+  if (data.length === 0) return [];
+  return Array.isArray(data[0]) ? (data as number[][]) : [data as number[]];
+}
+
+/** Normalize a value to [0, 1] given min/max. */
+function normalize(v: number, min: number, max: number): number {
+  return max === min ? 0.5 : (v - min) / (max - min);
+}
+
+// ---------------------------------------------------------------------------
+// Renderers
+// ---------------------------------------------------------------------------
+
+/** Line chart using asciichart (box-drawing characters). */
+function renderAscii(opts: ChartOptions): string {
+  const series = allSeries(opts.data);
+  if (series.length === 0 || series[0].length === 0) return "(no data)";
+
+  const height = opts.height ?? 12;
+  const colors = [
+    asciichart.default,
+    asciichart.blue,
+    asciichart.green,
+    asciichart.red,
+    asciichart.yellow,
+    asciichart.cyan,
+    asciichart.magenta,
+  ];
+
+  const cfg: asciichart.PlotConfig = {
+    height,
+    colors: series.map((_, i) => colors[i % colors.length]),
+  };
+
+  const chart = asciichart.plot(
+    series.length === 1 ? series[0] : series,
+    cfg
+  );
+
+  const lines: string[] = [];
+  if (opts.yAxisLabel) lines.push(`  ${opts.yAxisLabel}`);
+  lines.push(chart);
+  if (opts.xAxisLabel) lines.push(`  ${opts.xAxisLabel}`);
+  return lines.join("\n");
+}
+
+/** Sparkline — compact single-row visualization using block elements. */
+function renderSpark(opts: ChartOptions): string {
+  const TICKS = "▁▂▃▄▅▆▇█";
+  const values = flatSeries(opts.data);
+  if (values.length === 0) return "(no data)";
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  const spark = values
+    .map((v) => {
+      const n = normalize(v, min, max);
+      const idx = Math.round(n * (TICKS.length - 1));
+      return TICKS[idx];
+    })
+    .join("");
+
+  const parts: string[] = [];
+  if (opts.yAxisLabel) parts.push(`${opts.yAxisLabel}: `);
+  parts.push(spark);
+  parts.push(`  (${min}–${max})`);
+  if (opts.xAxisLabel) parts.push(`\n  ${opts.xAxisLabel}`);
+  return parts.join("");
+}
+
+/** Horizontal bar chart. */
+function renderBars(opts: ChartOptions): string {
+  const values = flatSeries(opts.data);
+  if (values.length === 0) return "(no data)";
+
+  const labels = opts.xLabels ?? values.map((_, i) => String(i + 1));
+  const maxLabelLen = Math.max(...labels.map((l) => l.length));
+  const max = Math.max(...values);
+  const BAR_WIDTH = 40;
+  const FILL = "█";
+
+  const lines = values.map((v, i) => {
+    const label = (labels[i] ?? String(i + 1)).padStart(maxLabelLen);
+    const barLen = max === 0 ? 0 : Math.round((v / max) * BAR_WIDTH);
+    const bar = FILL.repeat(barLen);
+    return `${label} │ ${bar} ${v}`;
+  });
+
+  const parts: string[] = [];
+  if (opts.yAxisLabel) parts.push(`  ${opts.yAxisLabel}`);
+  parts.push(...lines);
+  if (opts.xAxisLabel) parts.push(`  ${opts.xAxisLabel}`);
+  return parts.join("\n");
+}
+
+/** Vertical column chart. */
+function renderColumns(opts: ChartOptions): string {
+  const BLOCKS = "▁▂▃▄▅▆▇█";
+  const values = flatSeries(opts.data);
+  if (values.length === 0) return "(no data)";
+
+  const labels = opts.xLabels ?? values.map((_, i) => String(i + 1));
+  const max = Math.max(...values);
+  const height = opts.height ?? 8;
+
+  const rows: string[] = [];
+
+  // Build column grid top-down
+  for (let row = height; row >= 1; row--) {
+    const threshold = (row / height) * max;
+    const prevThreshold = ((row - 1) / height) * max;
+    const cells = values.map((v) => {
+      if (v >= threshold) return "█";
+      if (v > prevThreshold) {
+        const frac = (v - prevThreshold) / (threshold - prevThreshold);
+        const idx = Math.round(frac * (BLOCKS.length - 1));
+        return BLOCKS[idx];
+      }
+      return " ";
+    });
+    rows.push("  " + cells.join(" "));
+  }
+
+  // Baseline
+  rows.push("  " + "─".repeat(values.length * 2 - 1));
+  // Labels
+  rows.push("  " + labels.map((l) => l.charAt(0)).join(" "));
+
+  const parts: string[] = [];
+  if (opts.yAxisLabel) parts.push(`  ${opts.yAxisLabel}`);
+  parts.push(...rows);
+  if (opts.xAxisLabel) parts.push(`  ${opts.xAxisLabel}`);
+  return parts.join("\n");
+}
+
+/** Braille dot chart — high-resolution in compact space. */
+function renderBraille(opts: ChartOptions): string {
+  const values = flatSeries(opts.data);
+  if (values.length === 0) return "(no data)";
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const height = opts.height ?? 8;
+
+  // Braille: each character is a 2×4 dot matrix (2 cols, 4 rows)
+  // We map pairs of data points into braille columns
+  const rows = height * 4; // dot rows
+  const grid: boolean[][] = Array.from({ length: rows }, () =>
+    Array(values.length).fill(false) as boolean[]
+  );
+
+  // Plot points
+  for (let x = 0; x < values.length; x++) {
+    const y = Math.round(normalize(values[x], min, max) * (rows - 1));
+    // Invert Y (row 0 = top)
+    grid[rows - 1 - y][x] = true;
+  }
+
+  // Encode to braille characters (each char = 2 cols × 4 rows)
+  const charCols = Math.ceil(values.length / 2);
+  const charRows = Math.ceil(rows / 4);
+  const BRAILLE_BASE = 0x2800;
+  // Braille dot numbering for a 2×4 cell:
+  // Col 0: dots 1,2,3,7 (bits 0,1,2,6)
+  // Col 1: dots 4,5,6,8 (bits 3,4,5,7)
+  const DOT_MAP = [
+    [0x01, 0x02, 0x04, 0x40], // column 0: rows 0-3
+    [0x08, 0x10, 0x20, 0x80], // column 1: rows 0-3
+  ];
+
+  const lines: string[] = [];
+  for (let cr = 0; cr < charRows; cr++) {
+    let line = "";
+    for (let cc = 0; cc < charCols; cc++) {
+      let code = BRAILLE_BASE;
+      for (let dc = 0; dc < 2; dc++) {
+        const x = cc * 2 + dc;
+        if (x >= values.length) continue;
+        for (let dr = 0; dr < 4; dr++) {
+          const y = cr * 4 + dr;
+          if (y >= rows && !grid[y]?.[x]) continue;
+          if (grid[y]?.[x]) {
+            code |= DOT_MAP[dc][dr];
+          }
+        }
+      }
+      line += String.fromCharCode(code);
+    }
+    lines.push("  " + line);
+  }
+
+  const parts: string[] = [];
+  if (opts.yAxisLabel) parts.push(`  ${opts.yAxisLabel}`);
+  parts.push(...lines);
+  if (opts.xAxisLabel) parts.push(`  ${opts.xAxisLabel}`);
+  return parts.join("\n");
+}
+
+/** SVG line chart — raw SVG string for downstream rendering. */
+function renderSvg(opts: ChartOptions): string {
+  const values = flatSeries(opts.data);
+  if (values.length === 0) return "<svg></svg>";
+
+  const W = 600;
+  const H = 300;
+  const PAD = 40;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const xStep = values.length > 1 ? (W - PAD * 2) / (values.length - 1) : 0;
+
+  const points = values
+    .map((v, i) => {
+      const x = PAD + i * xStep;
+      const y = H - PAD - normalize(v, min, max) * (H - PAD * 2);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  const svgParts = [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">`,
+    `  <rect width="${W}" height="${H}" fill="#1a1a2e"/>`,
+    // Axes
+    `  <line x1="${PAD}" y1="${PAD}" x2="${PAD}" y2="${H - PAD}" stroke="#555" stroke-width="1"/>`,
+    `  <line x1="${PAD}" y1="${H - PAD}" x2="${W - PAD}" y2="${H - PAD}" stroke="#555" stroke-width="1"/>`,
+    // Data line
+    `  <polyline points="${points}" fill="none" stroke="#00d4ff" stroke-width="2"/>`,
+  ];
+
+  // Axis labels
+  if (opts.xAxisLabel) {
+    svgParts.push(
+      `  <text x="${W / 2}" y="${H - 8}" text-anchor="middle" fill="#aaa" font-size="12">${opts.xAxisLabel}</text>`
+    );
+  }
+  if (opts.yAxisLabel) {
+    svgParts.push(
+      `  <text x="12" y="${H / 2}" text-anchor="middle" fill="#aaa" font-size="12" transform="rotate(-90,12,${H / 2})">${opts.yAxisLabel}</text>`
+    );
+  }
+
+  svgParts.push("</svg>");
+  return svgParts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const RENDERERS: Record<ChartType, (opts: ChartOptions) => string> = {
+  ascii: renderAscii,
+  spark: renderSpark,
+  bars: renderBars,
+  columns: renderColumns,
+  braille: renderBraille,
+  svg: renderSvg,
+};
+
+/**
+ * Render a chart from numeric data.
+ *
+ * @returns The rendered chart as a plain-text or SVG string.
+ */
+export function renderChart(opts: ChartOptions): string {
+  const renderer = RENDERERS[opts.chartType];
+  if (!renderer) {
+    return `Unknown chart type "${opts.chartType}". Supported: ${Object.keys(RENDERERS).join(", ")}`;
+  }
+  return renderer(opts);
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -69,6 +69,7 @@ import {
 import { AskUserQuestionHalt } from "./ask.js";
 import { isGuideIntent, generateGuideResponse } from "./guide.js";
 import { createTask, listTasks, completeTask } from "./taskbus.js";
+import { renderChart, type ChartType } from "./charts.js";
 import { subagentManager, type SubagentResult } from "./subagent.js";
 import { heartbeatService } from "./heartbeat.js";
 
@@ -115,6 +116,13 @@ Your core directives:
    - League standings
    - Recent news
    Issue all tool calls together. Do NOT call them one at a time.
+7b. VISUALIZE DATA — When you have tabular or time-series data (standings points, scoring trends, player stat comparisons), use the \`render_chart\` tool to produce a visual chart instead of listing raw numbers. Choose the right chart type:
+   - \`ascii\`: line charts for trends over time (e.g., win probability, scoring runs)
+   - \`spark\`: compact sparkline for inline trend summaries
+   - \`bars\`: horizontal bars for comparing named categories (e.g., team stats)
+   - \`columns\`: vertical columns for small datasets
+   - \`braille\`: high-density dot plot for compact trend visualization
+   Always fetch the data with sports tools first, then visualize the results. Do not use render_chart without data.
 8. FAN PROFILE — When you see a Fan Profile in [MEMORY], use it to:
    - Skip lookup steps (use stored team_id/competition_id directly)
    - Proactively fetch data for high-interest entities only on truly vague queries
@@ -2057,6 +2065,96 @@ export class sportsclawEngine {
           return `Video generated successfully with prompt: "${args.prompt}"`;
         } catch (error) {
           return `Failed to generate video: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    });
+
+    // -----------------------------------------------------------------
+    // Chart visualization tool
+    // -----------------------------------------------------------------
+
+    toolMap["render_chart"] = defineTool({
+      description:
+        "Render a terminal-friendly chart from numeric data. Use this to visualize " +
+        "trends, comparisons, and distributions instead of listing raw numbers.\n" +
+        "Chart types:\n" +
+        "- ascii: Line chart with box-drawing characters (best for trends over time)\n" +
+        "- spark: Compact single-row sparkline (best for inline trend summaries)\n" +
+        "- bars: Horizontal bar chart (best for comparing named categories)\n" +
+        "- columns: Vertical column chart (best for small datasets)\n" +
+        "- braille: High-resolution braille dot plot (compact trend visualization)\n" +
+        "- svg: Raw SVG output (for downstream rendering in chat apps)",
+      inputSchema: jsonSchema({
+        type: "object",
+        properties: {
+          data: {
+            oneOf: [
+              { type: "array", items: { type: "number" } },
+              {
+                type: "array",
+                items: { type: "array", items: { type: "number" } },
+              },
+            ],
+            description:
+              "Array of numbers (single series) or array of arrays (multi-series).",
+          },
+          chartType: {
+            type: "string",
+            enum: ["ascii", "spark", "bars", "columns", "braille", "svg"],
+            description: "Type of chart to render.",
+          },
+          xAxisLabel: {
+            type: "string",
+            description: "Label for the X axis.",
+          },
+          yAxisLabel: {
+            type: "string",
+            description: "Label for the Y axis.",
+          },
+          xLabels: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Labels for each data point (used in bars/columns charts).",
+          },
+          height: {
+            type: "number",
+            description: "Chart height in terminal rows. Default: 12 for ascii, 8 for columns/braille.",
+          },
+        },
+        required: ["data", "chartType"],
+      }),
+      execute: async (args: {
+        data?: number[] | number[][];
+        chartType?: string;
+        xAxisLabel?: string;
+        yAxisLabel?: string;
+        xLabels?: string[];
+        height?: number;
+      }) => {
+        if (!args.data || !Array.isArray(args.data) || args.data.length === 0) {
+          return "Error: data must be a non-empty array of numbers.";
+        }
+        if (!args.chartType) {
+          return "Error: chartType is required.";
+        }
+        const validTypes = ["ascii", "spark", "bars", "columns", "braille", "svg"];
+        if (!validTypes.includes(args.chartType)) {
+          return `Error: unknown chartType "${args.chartType}". Valid: ${validTypes.join(", ")}`;
+        }
+
+        try {
+          const result = renderChart({
+            data: args.data,
+            chartType: args.chartType as ChartType,
+            xAxisLabel: args.xAxisLabel,
+            yAxisLabel: args.yAxisLabel,
+            xLabels: args.xLabels,
+            height: args.height,
+          });
+          return "```\n" + result + "\n```";
+        } catch (error) {
+          return `Chart rendering failed: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
     });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -116,21 +116,21 @@ Your core directives:
    - League standings
    - Recent news
    Issue all tool calls together. Do NOT call them one at a time.
-7b. VISUALIZE DATA — When you have tabular or time-series data (standings points, scoring trends, player stat comparisons), use the \`render_chart\` tool to produce a visual chart instead of listing raw numbers. Choose the right chart type:
+8. VISUALIZE DATA — When you have tabular or time-series data (standings points, scoring trends, player stat comparisons), use the \`render_chart\` tool to produce a visual chart instead of listing raw numbers. Choose the right chart type:
    - \`ascii\`: line charts for trends over time (e.g., win probability, scoring runs)
    - \`spark\`: compact sparkline for inline trend summaries
    - \`bars\`: horizontal bars for comparing named categories (e.g., team stats)
    - \`columns\`: vertical columns for small datasets
    - \`braille\`: high-density dot plot for compact trend visualization
    Always fetch the data with sports tools first, then visualize the results. Do not use render_chart without data.
-8. FAN PROFILE — When you see a Fan Profile in [MEMORY], use it to:
+9. FAN PROFILE — When you see a Fan Profile in [MEMORY], use it to:
    - Skip lookup steps (use stored team_id/competition_id directly)
    - Proactively fetch data for high-interest entities only on truly vague queries
      that do NOT explicitly name a sport, team, league, or player
    - Prioritize high-interest entities over low-interest ones
    - When the user asks "what's new?" or "morning update", fetch current data for their top 3 high-interest entities using parallel tool calls
-9. ALWAYS call update_fan_profile after answering a sports question to record which teams, leagues, players, and sports the user asked about.
-10. SOUL — You have a soul that evolves with each user. When you see a Soul in [MEMORY]:
+10. ALWAYS call update_fan_profile after answering a sports question to record which teams, leagues, players, and sports the user asked about.
+11. SOUL — You have a soul that evolves with each user. When you see a Soul in [MEMORY]:
     - USE IT to shape your voice, tone, energy, and humor. Be that person.
     - Reference callbacks naturally when relevant — don't force them.
     - Respect the user's preferences for how they like data delivered.
@@ -139,18 +139,18 @@ Your core directives:
     - A memorable moment worth referencing later (upset win, bad beat, etc.)
     - A preference for how they want info (tables vs prose, with/without odds, etc.)
     Do NOT call it every turn. Only when there's a real observation. Quality over quantity.
-11. MEMORY HYGIENE — Keep all memory files concise and focused:
+12. MEMORY HYGIENE — Keep all memory files concise and focused:
     - CONTEXT.md: current state only. Overwrite, don't accumulate.
     - SOUL.md: one-sentence observations. Refine voice instead of appending.
       When callbacks or rapport grow long, consolidate older entries into tighter summaries.
     - FAN_PROFILE.md: entity-level data only. No prose.
     Each file should stay small enough to skim in seconds.
-11.5 KALSHI MASCOTS — When searching Kalshi markets via search_markets, you CAN use team mascots (e.g. Lakers, Pelicans) as the query as long as you provide the correct sport code. The tool will auto-translate it to city names behind the scenes.
-12. FAILURE DISCIPLINE — If any requested data tool fails, you MUST:
+12.5 KALSHI MASCOTS — When searching Kalshi markets via search_markets, you CAN use team mascots (e.g. Lakers, Pelicans) as the query as long as you provide the correct sport code. The tool will auto-translate it to city names behind the scenes.
+13. FAILURE DISCIPLINE — If any requested data tool fails, you MUST:
     - Explicitly mark that section as unavailable.
     - Avoid analysis or conclusions for the failed data dimension.
     - Continue with other dimensions only if their tools succeeded.
-13. PLAYER LOOKUPS — When asked about a specific player:
+14. PLAYER LOOKUPS — When asked about a specific player:
     a. If you already have the player's ID (from memory or a prior call), use it directly.
     b. If you DON'T have the ID, use a discovery tool first:
        - Rankings, leaderboards, or roster tools typically return player IDs alongside names.
@@ -158,7 +158,7 @@ Your core directives:
          find the player by name, extract their ID, then call the player detail tool.
     c. These lookups are SEQUENTIAL — don't parallelize steps that depend on IDs from prior calls.
     d. If no discovery path exists for a sport, say so. Don't guess IDs.
-14. FOOTBALL PLAYER LOOKUPS — For football (soccer) players specifically:
+15. FOOTBALL PLAYER LOOKUPS — For football (soccer) players specifically:
     a. ALWAYS call \`football_search_player\` first with the player's name. It returns both
        \`tm_player_id\` (Transfermarkt) and \`espn_athlete_id\` (ESPN) in one call.
     b. Use the IDs from search results to call \`football_get_player_profile\` with BOTH
@@ -166,7 +166,7 @@ Your core directives:
        transfer history from Transfermarkt + ESPN stats).
     c. For transfer data, pass the \`tm_player_id\` list to \`football_get_season_transfers\`.
     d. Save discovered IDs to the Fan Profile for future lookups.
-15. SELF-IMPROVEMENT — You have two optional tools for learning across sessions:
+16. SELF-IMPROVEMENT — You have two optional tools for learning across sessions:
     - \`reflect\`: log a one-sentence lesson when something genuinely surprising happens
       (a tool failure, a data gap, a workaround you discovered). These are rare events.
     - \`evolve_strategy\`: codify a behavioral pattern into your system instructions
@@ -2088,15 +2088,9 @@ export class sportsclawEngine {
         type: "object",
         properties: {
           data: {
-            oneOf: [
-              { type: "array", items: { type: "number" } },
-              {
-                type: "array",
-                items: { type: "array", items: { type: "number" } },
-              },
-            ],
+            type: "array",
             description:
-              "Array of numbers (single series) or array of arrays (multi-series).",
+              "Numeric data to chart. Accepts number[] (single series) or number[][] (multi-series).",
           },
           chartType: {
             type: "string",


### PR DESCRIPTION
## Description

Integrates terminal-based (ASCII, sparklines, bars) and SVG chart visualizations into the sportsclaw agent loop, inspired by `chartli`. 

## Changes
- Added `src/charts.ts` with native renderers for `ascii`, `spark`, `bars`, `columns`, `braille`, and `svg`.
- Added `render_chart` tool to the Vercel AI SDK loop in `src/engine.ts`.
- Updated `BASE_SYSTEM_PROMPT` to instruct the LLM to visualize tabular/time-series data.
- Added `asciichart` as a lightweight dependency.