### PR TITLE
feat: --yolo autonomous mode, --json headless NDJSON, context pruning

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -517,16 +517,11 @@ export class sportsclawEngine {
 
     const parts = [basePrompt];
 
-    // --- YOLO mode directive ---
-    if (this.config.yoloMode) {
-      parts.push("", `## Execution Mode: AUTONOMOUS (YOLO)
-
-You are running in fully autonomous mode with --yolo enabled.
-- Execute ALL tool calls immediately — no approval prompts, no clarification questions.
-- Optimize for throughput: parallel tool calls, minimal output tokens, data-first responses.
-- Do NOT use ask_user_question — decide autonomously based on available data.
-- write_file and execute_command run without gates. Use them freely.`);
-    }
+    // --- YOLO mode: no system prompt change ---
+    // Following Claude Code / OpenClaw pattern: YOLO is a pure execution-policy
+    // concern (approval gates bypassed at the tool layer), not a prompt directive.
+    // The LLM behaves identically regardless of --yolo; only the host permission
+    // checks differ.
 
     // --- Security directives (framework-level, trading gated by config) ---
     parts.push("", getSecurityDirectives(this.config.allowTrading));
@@ -2955,13 +2950,41 @@ You are running in fully autonomous mode with --yolo enabled.
     const agenticPlatform = "cli"; // default; listeners override via RunOptions
     const agenticUserId = runUserId ?? "anonymous";
 
+    // Blocked path patterns for YOLO mode — prevent writes to sensitive locations
+    const YOLO_BLOCKED_PATHS = [
+      /^\/etc\//,
+      /^\/usr\//,
+      /^\/var\//,
+      /^\/sys\//,
+      /^\/proc\//,
+      /^\/boot\//,
+      /[/\\]\.ssh[/\\]/,
+      /[/\\]\.gnupg[/\\]/,
+      /[/\\]\.aws[/\\]/,
+      /[/\\]\.config[/\\]gcloud[/\\]/,
+      /[/\\]\.kube[/\\]/,
+      /[/\\]\.docker[/\\]/,
+    ];
+
+    /** Execute the actual file write (shared by YOLO and pre-approved paths). */
+    const executeWriteFile = async (filePath: string, fileContent: string): Promise<string> => {
+      const { writeFile, mkdir } = await import("node:fs/promises");
+      const { dirname, resolve } = await import("node:path");
+      const resolved = resolve(filePath);
+      await mkdir(dirname(resolved), { recursive: true });
+      await writeFile(resolved, fileContent, "utf-8");
+      return JSON.stringify({
+        status: "success",
+        action: "write_file",
+        path: resolved,
+        size: fileContent.length,
+      });
+    };
+
     toolMap["write_file"] = defineTool({
       description:
-        "Write content to a file. " +
-        (config.yoloMode
-          ? "Executes immediately in YOLO mode."
-          : "This is a privileged operation that requires user approval.") +
-        " Content is written to the local filesystem.",
+        "Write content to a file. This is a privileged operation. " +
+        "Content is written to the local filesystem.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {
@@ -2984,18 +3007,20 @@ You are running in fully autonomous mode with --yolo enabled.
           return "Error: both path and content are required.";
         }
 
-        // YOLO mode: execute immediately, no approval gate
+        // YOLO mode: validate path safety, then execute immediately
         if (config.yoloMode) {
-          const { writeFile, mkdir } = await import("node:fs/promises");
-          const { dirname } = await import("node:path");
-          await mkdir(dirname(filePath), { recursive: true });
-          await writeFile(filePath, fileContent, "utf-8");
-          return JSON.stringify({
-            status: "success",
-            action: "write_file",
-            path: filePath,
-            size: fileContent.length,
-          });
+          const { resolve } = await import("node:path");
+          const resolved = resolve(filePath);
+          const blocked = YOLO_BLOCKED_PATHS.find((p) => p.test(resolved));
+          if (blocked) {
+            return JSON.stringify({
+              status: "error",
+              action: "write_file",
+              error: `Path blocked in YOLO mode: ${resolved} matches restricted pattern. ` +
+                `Write to a project-local or /tmp path instead.`,
+            });
+          }
+          return executeWriteFile(resolved, fileContent);
         }
 
         // Check for allow-always rule
@@ -3005,16 +3030,7 @@ You are running in fully autonomous mode with --yolo enabled.
           "write_file"
         );
         if (preApproved) {
-          const { writeFile, mkdir } = await import("node:fs/promises");
-          const { dirname } = await import("node:path");
-          await mkdir(dirname(filePath), { recursive: true });
-          await writeFile(filePath, fileContent, "utf-8");
-          return JSON.stringify({
-            status: "success",
-            action: "write_file",
-            path: filePath,
-            size: fileContent.length,
-          });
+          return executeWriteFile(filePath, fileContent);
         }
 
         // Not approved and not YOLO: fail fast with error (no stdin blocking)
@@ -3027,11 +3043,8 @@ You are running in fully autonomous mode with --yolo enabled.
 
     toolMap["execute_command"] = defineTool({
       description:
-        "Execute a shell command. " +
-        (config.yoloMode
-          ? "Executes immediately in YOLO mode."
-          : "This is a privileged operation that requires user approval.") +
-        " Use for running scripts, installing packages, or processing data.",
+        "Execute a shell command. This is a privileged operation. " +
+        "Use for running scripts, installing packages, or processing data.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {
@@ -3055,6 +3068,30 @@ You are running in fully autonomous mode with --yolo enabled.
           return "Error: command is required.";
         }
         const effectiveTimeout = Math.min(timeoutMs ?? 30_000, 300_000);
+
+        // YOLO mode: block obviously dangerous commands
+        if (config.yoloMode) {
+          const YOLO_BLOCKED_COMMANDS = [
+            /\brm\s+(-[a-zA-Z]*f|-[a-zA-Z]*r|--force|--recursive)\b/,  // rm -rf, rm -f
+            /\bmkfs\b/, /\bdd\b.*\bof=\/dev\//, /\bfdisk\b/,           // disk ops
+            /\b(shutdown|reboot|halt|poweroff)\b/,                       // system control
+            /\bchmod\s+[0-7]*777\b/,                                     // overly permissive
+            /\bcurl\b.*\|\s*(sh|bash|zsh)\b/,                           // pipe-to-shell
+            /\bwget\b.*\|\s*(sh|bash|zsh)\b/,
+            />\s*\/etc\//, />\s*\/boot\//,                               // redirect to system dirs
+            /\bsudo\b/,                                                  // privilege escalation
+          ];
+          const blocked = YOLO_BLOCKED_COMMANDS.find((p) => p.test(cmd));
+          if (blocked) {
+            return JSON.stringify({
+              status: "error",
+              action: "execute_command",
+              error: `Command blocked in YOLO mode: matches restricted pattern. ` +
+                `Rephrase the command to avoid dangerous operations.`,
+              command: cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd,
+            });
+          }
+        }
 
         // Helper: actually run the command via execFile
         const runCommand = () =>
@@ -3344,14 +3381,19 @@ You are running in fully autonomous mode with --yolo enabled.
     // messages (keeping the most recent ones) to stay within context budget.
     // Memory injections and thread history compound quickly in long-running
     // sessions, so this is essential for autonomous / daemon modes.
+    // IMPORTANT: Always preserve the first message (system prompt / initial
+    // context) to avoid breaking the conversation structure.
     const pruneThreshold = this.config.contextPruneThreshold;
     if (pruneThreshold > 0 && this.messages.length > pruneThreshold) {
-      const keepCount = Math.floor(pruneThreshold * 0.6);
-      const dropped = this.messages.length - keepCount;
-      this.messages = this.messages.slice(-keepCount);
+      const keepCount = Math.floor(pruneThreshold * 0.4);
+      // Preserve the first message (system/setup) + the most recent keepCount messages
+      const pinnedHead = this.messages.slice(0, 1);
+      const recentTail = this.messages.slice(-keepCount);
+      const dropped = this.messages.length - (pinnedHead.length + recentTail.length);
+      this.messages = [...pinnedHead, ...recentTail];
       if (this.config.verbose) {
         console.error(
-          `[sportsclaw] context pruned: dropped ${dropped} old messages, keeping ${this.messages.length}`
+          `[sportsclaw] context pruned: dropped ${dropped} old messages, keeping ${this.messages.length} (1 pinned + ${recentTail.length} recent)`
         );
       }
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -517,6 +517,17 @@ export class sportsclawEngine {
 
     const parts = [basePrompt];
 
+    // --- YOLO mode directive ---
+    if (this.config.yoloMode) {
+      parts.push("", `## Execution Mode: AUTONOMOUS (YOLO)
+
+You are running in fully autonomous mode with --yolo enabled.
+- Execute ALL tool calls immediately — no approval prompts, no clarification questions.
+- Optimize for throughput: parallel tool calls, minimal output tokens, data-first responses.
+- Do NOT use ask_user_question — decide autonomously based on available data.
+- write_file and execute_command run without gates. Use them freely.`);
+    }
+
     // --- Security directives (framework-level, trading gated by config) ---
     parts.push("", getSecurityDirectives(this.config.allowTrading));
 
@@ -1731,6 +1742,16 @@ export class sportsclawEngine {
           return "Error: options must contain 2-5 items.";
         }
 
+        // YOLO mode: auto-select first option, no halt
+        if (config.yoloMode) {
+          return JSON.stringify({
+            status: "auto_selected",
+            context_key,
+            selected: options[0],
+            reason: "YOLO mode — auto-selected first option to maintain execution velocity.",
+          });
+        }
+
         // Throw a sentinel error to halt the engine loop.
         // The listener catches this and renders native UI.
         throw new AskUserQuestionHalt({
@@ -2936,8 +2957,11 @@ export class sportsclawEngine {
 
     toolMap["write_file"] = defineTool({
       description:
-        "Write content to a file. This is a privileged " +
-        "operation that requires user approval. Content is written to the local filesystem.",
+        "Write content to a file. " +
+        (config.yoloMode
+          ? "Executes immediately in YOLO mode."
+          : "This is a privileged operation that requires user approval.") +
+        " Content is written to the local filesystem.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {
@@ -2960,42 +2984,54 @@ export class sportsclawEngine {
           return "Error: both path and content are required.";
         }
 
+        // YOLO mode: execute immediately, no approval gate
+        if (config.yoloMode) {
+          const { writeFile, mkdir } = await import("node:fs/promises");
+          const { dirname } = await import("node:path");
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, fileContent, "utf-8");
+          return JSON.stringify({
+            status: "success",
+            action: "write_file",
+            path: filePath,
+            size: fileContent.length,
+          });
+        }
+
         // Check for allow-always rule
         const preApproved = await isActionPreApproved(
           agenticPlatform,
           agenticUserId,
           "write_file"
         );
-        if (!preApproved) {
-          const requestId = generateApprovalId();
-          throw new ApprovalPendingHalt({
-            id: requestId,
+        if (preApproved) {
+          const { writeFile, mkdir } = await import("node:fs/promises");
+          const { dirname } = await import("node:path");
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, fileContent, "utf-8");
+          return JSON.stringify({
+            status: "success",
             action: "write_file",
-            description: `Write ${fileContent.length} bytes to ${filePath}`,
-            toolArgs: { path: filePath, content: fileContent },
-            platform: agenticPlatform,
-            userId: agenticUserId,
-            createdAt: new Date().toISOString(),
+            path: filePath,
+            size: fileContent.length,
           });
         }
 
-        // Pre-approved: execute
-        return JSON.stringify({
-          status: "approval-pending",
-          message:
-            "write_file action was pre-approved via allow-always.",
-          action: "write_file",
-          path: filePath,
-          size: fileContent.length,
-        });
+        // Not approved and not YOLO: fail fast with error (no stdin blocking)
+        throw new Error(
+          `write_file denied: user approval required. Pass --yolo to bypass approval gates, ` +
+          `or pre-approve via /approve. Target: ${filePath} (${fileContent.length} bytes)`
+        );
       },
     });
 
     toolMap["execute_command"] = defineTool({
       description:
-        "Execute a shell command. This is a privileged " +
-        "operation that requires user approval. Use for " +
-        "running scripts, installing packages, or processing data.",
+        "Execute a shell command. " +
+        (config.yoloMode
+          ? "Executes immediately in YOLO mode."
+          : "This is a privileged operation that requires user approval.") +
+        " Use for running scripts, installing packages, or processing data.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {
@@ -3020,34 +3056,57 @@ export class sportsclawEngine {
         }
         const effectiveTimeout = Math.min(timeoutMs ?? 30_000, 300_000);
 
+        // Helper: actually run the command via execFile
+        const runCommand = () =>
+          new Promise<string>((resolve) => {
+            const subprocessEnv = buildSubprocessEnv(config.env);
+            execFile(
+              "sh",
+              ["-c", cmd],
+              { timeout: effectiveTimeout, env: subprocessEnv, maxBuffer: 10 * 1024 * 1024 },
+              (error, stdout, stderr) => {
+                if (error) {
+                  resolve(JSON.stringify({
+                    status: "error",
+                    action: "execute_command",
+                    command: cmd,
+                    error: error.message,
+                    stderr: stderr?.slice(0, 2000) || "",
+                    stdout: stdout?.slice(0, 2000) || "",
+                  }));
+                } else {
+                  resolve(JSON.stringify({
+                    status: "success",
+                    action: "execute_command",
+                    command: cmd,
+                    stdout: stdout?.slice(0, 8000) || "",
+                    stderr: stderr?.slice(0, 2000) || "",
+                  }));
+                }
+              }
+            );
+          });
+
+        // YOLO mode: execute immediately, no approval gate
+        if (config.yoloMode) {
+          return runCommand();
+        }
+
         // Check for allow-always rule
         const preApproved = await isActionPreApproved(
           agenticPlatform,
           agenticUserId,
           "execute_command"
         );
-        if (!preApproved) {
-          const requestId = generateApprovalId();
-          throw new ApprovalPendingHalt({
-            id: requestId,
-            action: "execute_command",
-            description: `Execute: ${cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd}`,
-            toolArgs: { command: cmd, timeout_ms: effectiveTimeout },
-            platform: agenticPlatform,
-            userId: agenticUserId,
-            createdAt: new Date().toISOString(),
-          });
+        if (preApproved) {
+          return runCommand();
         }
 
-        // Pre-approved: execute
-        return JSON.stringify({
-          status: "approval-pending",
-          message:
-            "execute_command action was pre-approved via allow-always.",
-          action: "execute_command",
-          command: cmd,
-          timeout_ms: effectiveTimeout,
-        });
+        // Not approved and not YOLO: fail fast with error (no stdin blocking)
+        throw new Error(
+          `execute_command denied: user approval required. Pass --yolo to bypass approval gates, ` +
+          `or pre-approve via /approve. Command: ${cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd}`
+        );
       },
     });
 
@@ -3187,8 +3246,14 @@ export class sportsclawEngine {
       });
     }
 
+    // --- YOLO mode: log entry for observability ---
+    if (this.config.yoloMode && this.config.verbose) {
+      console.error("[sportsclaw] YOLO MODE — autonomous execution, zero interactive gates");
+    }
+
     // --- Sprint 2: Guide subagent — intercept meta-queries early ---
-    if (isGuideIntent(sanitizedPrompt)) {
+    // In YOLO mode, skip the guide intercept — the LLM handles everything.
+    if (!this.config.yoloMode && isGuideIntent(sanitizedPrompt)) {
       if (this.config.verbose) {
         console.error("[sportsclaw] guide intercept: handling meta-query");
       }
@@ -3274,6 +3339,23 @@ export class sportsclawEngine {
 
     this.messages.push({ role: "user", content: sanitizedPrompt });
 
+    // --- Context pruning: prevent memory bloat during continuous execution ---
+    // When the message history exceeds the configured threshold, drop older
+    // messages (keeping the most recent ones) to stay within context budget.
+    // Memory injections and thread history compound quickly in long-running
+    // sessions, so this is essential for autonomous / daemon modes.
+    const pruneThreshold = this.config.contextPruneThreshold;
+    if (pruneThreshold > 0 && this.messages.length > pruneThreshold) {
+      const keepCount = Math.floor(pruneThreshold * 0.6);
+      const dropped = this.messages.length - keepCount;
+      this.messages = this.messages.slice(-keepCount);
+      if (this.config.verbose) {
+        console.error(
+          `[sportsclaw] context pruned: dropped ${dropped} old messages, keeping ${this.messages.length}`
+        );
+      }
+    }
+
     let stepCount = 0;
     const emitProgress = options?.onProgress;
     const legacyUpdate = options?.onSpinnerUpdate;
@@ -3352,8 +3434,10 @@ export class sportsclawEngine {
     // --- Confidence-based clarification ---
     // Skip clarification on follow-up turns: the LLM already has conversation
     // history and can resolve ambiguity from prior context.
+    // YOLO mode: never pause to clarify — the loop must not stall.
     if (
       this.config.clarifyOnLowConfidence &&
+      !this.config.yoloMode &&
       !isFollowUp &&
       routing.decision &&
       routing.decision.confidence < this.config.clarifyThreshold &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1530,6 +1530,9 @@ function emitNdjson(event: Record<string, unknown>): void {
 async function cmdQuery(args: string[]): Promise<void> {
   const verbose = args.includes("--verbose") || args.includes("-v");
   const forcePipe = args.includes("--pipe");
+  if (forcePipe) {
+    console.error("[sportsclaw] WARNING: --pipe is deprecated, use --json instead.");
+  }
   const forceJson = args.includes("--json");
   const yoloMode = args.includes("--yolo");
   const explicitFormat = args.find((a) => a.startsWith("--format="))?.split("=")[1];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1271,6 +1271,7 @@ async function handleSlashMenu(): Promise<true | string> {
 
 async function cmdChat(args: string[]): Promise<void> {
   const verbose = args.includes("--verbose") || args.includes("-v");
+  const yoloMode = args.includes("--yolo");
   const userId = "cli-chat";
 
   // Merge config file + env vars, push into process.env
@@ -1302,13 +1303,14 @@ async function cmdChat(args: string[]): Promise<void> {
     routingAllowSpillover: resolved.routingAllowSpillover,
     verbose,
     allowTrading: true,
+    yoloMode,
   });
 
   // Clear screen for a fresh start
   process.stdout.write("\x1B[2J\x1B[H");
 
   console.log(pc.bold(pc.blue(ASCII_LOGO)));
-  p.intro("sportsclaw chat — type 'exit' or 'quit' to leave");
+  p.intro(`sportsclaw chat${yoloMode ? " [YOLO]" : ""} — type 'exit' or 'quit' to leave`);
 
   // Welcome message — evolves with the relationship
   const memory = new MemoryManager(userId);
@@ -1435,6 +1437,7 @@ async function cmdChat(args: string[]): Promise<void> {
         routingAllowSpillover: newConfig.routingAllowSpillover,
         verbose,
         allowTrading: true,
+        yoloMode,
       });
       console.log(pc.green("✔ Engine restarted successfully."));
       continue;
@@ -1527,8 +1530,10 @@ function emitNdjson(event: Record<string, unknown>): void {
 async function cmdQuery(args: string[]): Promise<void> {
   const verbose = args.includes("--verbose") || args.includes("-v");
   const forcePipe = args.includes("--pipe");
+  const forceJson = args.includes("--json");
+  const yoloMode = args.includes("--yolo");
   const explicitFormat = args.find((a) => a.startsWith("--format="))?.split("=")[1];
-  const formatArg = explicitFormat ?? (forcePipe ? "markdown" : "cli");
+  const formatArg = explicitFormat ?? (forcePipe || forceJson ? "markdown" : "cli");
 
   // Parse --user <id> flag (used by relay/pipe to enable memory & thread persistence)
   let userId: string | undefined;
@@ -1546,7 +1551,10 @@ async function cmdQuery(args: string[]): Promise<void> {
     args.splice(systemPromptIdx, 2);
   }
 
-  const filteredArgs = args.filter((a) => a !== "--verbose" && a !== "-v" && a !== "--pipe" && !a.startsWith("--format="));
+  const filteredArgs = args.filter((a) =>
+    a !== "--verbose" && a !== "-v" && a !== "--pipe" &&
+    a !== "--json" && a !== "--yolo" && !a.startsWith("--format=")
+  );
   const prompt = filteredArgs.join(" ");
 
   if (!prompt) {
@@ -1557,8 +1565,12 @@ async function cmdQuery(args: string[]): Promise<void> {
   // Merge config file + env vars (env wins), push into process.env
   let resolved = applyConfigToEnv();
 
-  // No API key anywhere → interactive setup
+  // No API key anywhere → interactive setup (skip in headless mode)
   if (!resolved.apiKey) {
+    if (forceJson || !process.stdout.isTTY) {
+      emitNdjson({ type: "error", error: "No API key configured. Run `sportsclaw config` interactively first." });
+      process.exit(1);
+    }
     await runConfigFlow();
     resolved = applyConfigToEnv();
   }
@@ -1581,13 +1593,15 @@ async function cmdQuery(args: string[]): Promise<void> {
     routingAllowSpillover: resolved.routingAllowSpillover,
     verbose,
     allowTrading: true,
+    yoloMode,
   });
 
-  // Pipe mode: emit NDJSON events (for relay/programmatic use)
-  const pipeMode = forcePipe || !process.stdout.isTTY;
+  // Headless NDJSON streaming: --json flag, --pipe flag, or non-TTY stdout.
+  // Strips all clack/spinners and emits structured NDJSON lines to stdout.
+  const headlessMode = forceJson || forcePipe || !process.stdout.isTTY;
 
-  if (pipeMode) {
-    emitNdjson({ type: "start", timestamp: new Date().toISOString() });
+  if (headlessMode) {
+    emitNdjson({ type: "start", timestamp: new Date().toISOString(), yolo: yoloMode });
     try {
       const result = await engine.run(prompt, {
         userId,
@@ -1921,6 +1935,9 @@ function printHelp(): void {
   console.log("");
   console.log("Options:");
   console.log("  --verbose, -v    Enable verbose logging");
+  console.log("  --yolo           Bypass all Y/n approval prompts (autonomous execution)");
+  console.log("  --json           Force headless NDJSON output (no spinners/clack)");
+  console.log("  --pipe           Alias for --json (legacy)");
   console.log("  --help, -h       Show this help message");
   console.log("");
   console.log("Configuration:");

--- a/src/router.ts
+++ b/src/router.ts
@@ -71,6 +71,20 @@ const SKILL_ALIASES: Record<string, string[]> = {
   cbb: ["college basketball", "march madness", "ncaab"],
 };
 
+/** MCP/pod intent patterns — matches queries targeting pod entities, not sports */
+const MCP_INTENT_PATTERNS = [
+  /\b(search|list|find|show|get|browse|create|save|store|update|delete|remove|execute|run)\b.*\b(document|workflow|agent|connector|prompt|template)\b/,
+  /\b(document|workflow|agent|connector|prompt|template)\b.*\b(search|list|find|show|get|create|save|store|update|delete|remove|execute|run)\b/,
+  /\b(pod|machina|mcp)\b/,
+  /\bwhat\b.*\b(document|workflow|agent|connector|capabilities?|installed|available)\b/,
+  /\b(install|import).*template\b/,
+  /\b(deep.?research|execute.?workflow|execute.?agent)\b/,
+];
+
+function isMcpIntent(normalizedPrompt: string): boolean {
+  return MCP_INTENT_PATTERNS.some((p) => p.test(normalizedPrompt));
+}
+
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -289,6 +303,30 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
   }
 
   const promptNorm = normalizeText(input.prompt);
+
+  // --- MCP intent early exit ---
+  // If the prompt targets pod/MCP entities and MCP tools are present in the
+  // tool specs, return immediately with high confidence and zero sport skills.
+  // This skips the expensive LLM router call for non-sport queries like
+  // "list my workflows", "what documents are stored?", or "execute agent X".
+  const hasMcpTools = input.toolSpecs.some((s) => s.name.startsWith("mcp__"));
+  if (hasMcpTools && isMcpIntent(promptNorm)) {
+    return {
+      decision: {
+        selectedSkills: [],
+        mode: "focused",
+        confidence: 0.95,
+        reason: "MCP pod intent detected — routing to MCP tools, skipping sport selection",
+      },
+      meta: {
+        modelUsed: null,
+        llmAttempted: false,
+        llmSucceeded: false,
+        llmDurationMs: 0,
+      },
+    };
+  }
+
   const helperSkills = inferHelperSkills(promptNorm, installedSet);
   const fanProfile = extractFanProfileSection(input.memoryBlock);
   const toolTokens = buildToolTokensBySkill(input.installedSkills, input.toolSpecs);

--- a/src/router.ts
+++ b/src/router.ts
@@ -71,14 +71,23 @@ const SKILL_ALIASES: Record<string, string[]> = {
   cbb: ["college basketball", "march madness", "ncaab"],
 };
 
-/** MCP/pod intent patterns — matches queries targeting pod entities, not sports */
+/** MCP/pod intent patterns — matches queries targeting pod entities, not sports.
+ *  Patterns use word boundaries and require MCP-specific entity nouns to avoid
+ *  false positives on sport queries like "search documents about basketball". */
 const MCP_INTENT_PATTERNS = [
-  /\b(search|list|find|show|get|browse|create|save|store|update|delete|remove|execute|run)\b.*\b(document|workflow|agent|connector|prompt|template)\b/,
-  /\b(document|workflow|agent|connector|prompt|template)\b.*\b(search|list|find|show|get|create|save|store|update|delete|remove|execute|run)\b/,
+  // Explicit MCP/pod keywords — always match
   /\b(pod|machina|mcp)\b/,
-  /\bwhat\b.*\b(document|workflow|agent|connector|capabilities?|installed|available)\b/,
-  /\b(install|import).*template\b/,
+  // CRUD verbs targeting MCP entities — require "my/the/stored/saved" qualifier
+  // or a possessive to disambiguate from general queries
+  /\b(list|show|get|browse|delete|remove)\b.*\b(my|the|stored|saved|all)\b.*\b(documents?|workflows?|agents?|connectors?|prompts?|templates?)\b/,
+  /\b(create|save|store|update)\b\s+(a\s+)?(new\s+)?(document|workflow|agent|connector|prompt|template)\b/,
+  // Entity-first patterns: "workflow list", "agent execute"
+  /\b(workflow|agent|connector)\b\s+(list|execute|run|delete|update|create|search)\b/,
+  // Unambiguous MCP operations
+  /\b(install|import)\b.*\btemplate\b/,
   /\b(deep.?research|execute.?workflow|execute.?agent)\b/,
+  // "what workflows/agents do I have" style
+  /\bwhat\b.*\b(workflows?|agents?|connectors?|capabilities?|installed|available)\b/,
 ];
 
 function isMcpIntent(normalizedPrompt: string): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,23 @@ export interface sportsclawConfig {
   tokenBudgets?: Partial<TokenBudgets>;
   /** Run multiple routed agents in parallel with synthesis. Default: false */
   parallelAgents?: boolean;
+  /**
+   * YOLO mode — bypass all interactive approval gates and clarification
+   * prompts without halting.  Dangerous tools (write_file, execute_command)
+   * execute immediately; ask_user_question auto-selects the first option.
+   * When a dangerous tool is called *without* yolo mode, the engine returns
+   * a hard error to the LLM instead of blocking on stdin.
+   *
+   * Designed for headless / CI / autonomous execution.  Default: false.
+   */
+  yoloMode?: boolean;
+  /**
+   * Maximum number of messages to keep in the conversation history before
+   * automatic context pruning kicks in.  When the message array exceeds
+   * this limit, older messages are dropped to stay within budget.
+   * Set to 0 to disable automatic pruning.  Default: 80.
+   */
+  contextPruneThreshold?: number;
 }
 
 export const DEFAULT_CONFIG: Required<sportsclawConfig> = {
@@ -166,6 +183,8 @@ export const DEFAULT_CONFIG: Required<sportsclawConfig> = {
   thinkingBudget: 8192,
   tokenBudgets: {},
   parallelAgents: false,
+  yoloMode: false,
+  contextPruneThreshold: 80,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Pivoting from the NemoClaw refactor to protect existing K8s production infrastructure. This PR adds three features to make sportsclaw safe for headless/autonomous execution:

- **`--yolo` flag**: Bypasses all Y/n interactive approval prompts. `write_file` and `execute_command` execute immediately; `ask_user_question` auto-selects first option. Without `--yolo`, dangerous tools fail fast with an error to the LLM instead of blocking on stdin.
- **`--json` headless NDJSON**: Forces structured NDJSON streaming output, stripping all clack/spinners. Also auto-detected when stdout is non-TTY (pipe). Supports `--pipe` as legacy alias.
- **Context pruning**: Automatic message history pruning when conversation exceeds `contextPruneThreshold` (default: 80 messages). Drops oldest 60% to prevent memory bloat during continuous daemon/relay execution.

### Abandons
- `feat/nemoclaw-agentic-refactor` branch — NemoClaw sandbox approach replaced by this lighter `--yolo` pattern that doesn't require new K8s infrastructure.

## Test plan

- [ ] `sportsclaw --yolo "write a file to /tmp/test.txt"` — should execute write_file without prompting
- [ ] `sportsclaw --json "NBA scores"` — should emit NDJSON lines with no ANSI/spinner output  
- [ ] `echo "NBA scores" | sportsclaw` — non-TTY auto-detected, NDJSON output
- [ ] `sportsclaw chat --yolo` — REPL shows `[YOLO]` in intro, no approval halts
- [ ] Verify context pruning kicks in after 80+ messages in a long chat session
- [ ] `sportsclaw "write a file"` (no --yolo) — should return error to LLM, not block

🤖 Generated with [Claude Code](https://claude.com/claude-code)