### PR TITLE
feat: intent classification, response templates, and clarification-first prompting

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -88,6 +88,8 @@ import {
 } from "./bracket-sim.js";
 import { subagentManager, type SubagentResult } from "./subagent.js";
 import { heartbeatService } from "./heartbeat.js";
+import { buildTemplatePrompt, type QueryIntent } from "./response-templates.js";
+import { evaluateResponse } from "./evaluator.js";
 
 // ---------------------------------------------------------------------------
 // Package version (read once at import time)
@@ -128,7 +130,7 @@ Your core directives:
 4. CITE THE SOURCE — At the end of your answer, add a small italicized source line naming the actual data providers used. Map skill prefixes to providers:
    football → Transfermarkt & FBref, nfl/nba/nhl/mlb/wnba/cfb/cbb/golf/tennis → ESPN, f1 → FastF1, news → Google News & RSS feeds, kalshi → Kalshi, polymarket → Polymarket, betting → Betting Analysis, markets → ESPN + Kalshi + Polymarket.
    Example: *Source: ESPN, Google News (2025-03-15)*. Only list providers you actually called.
-5. DO NOT ASK CLARIFYING QUESTIONS in one-shot mode. If a prompt is vague (e.g. "how is the premier league"), assume they want current standings and recent news, fetch it, and summarize.
+5. CLARIFICATION: If the user's intent is genuinely unclear and there is no prior conversation history, ask ONE focused question (e.g. "Are you looking for live scores, standings, or today's schedule?"). If the query is reasonably interpretable — or conversation history exists — just answer it directly. Never ask multiple questions. Never ask when you already have enough context to answer.
 6. IDs ARE REQUIRED: If a tool requires a \`season_id\`, \`competition_id\`, etc., DO NOT GUESS. Use lookup tools like \`get_competitions\` or \`get_competition_seasons\` first if you do not know the exact string (e.g. \`premier-league-2025\`). A raw year like \`2025\` will fail.
 7. PARALLEL TOOL CALLS — When a query involves multiple data dimensions (e.g., "tell me about [team]"), call MULTIPLE tools in a SINGLE response step:
    - Recent/upcoming matches
@@ -503,7 +505,7 @@ export class sportsclawEngine {
   }
 
   /** Full system prompt (base + dynamic tool info + strategy + agent directives + user-supplied) */
-  private buildSystemPrompt(hasMemory: boolean, agents?: AgentDef[], strategyContent?: string, callerSystemPrompt?: string): string {
+  private buildSystemPrompt(hasMemory: boolean, agents?: AgentDef[], strategyContent?: string, callerSystemPrompt?: string, queryIntent?: string): string {
     let basePrompt = BASE_SYSTEM_PROMPT;
 
     // Strip fan profile update directive when skipFanProfile is active
@@ -785,6 +787,16 @@ export class sportsclawEngine {
 
     if (this.config.systemPrompt) {
       parts.push("", this.config.systemPrompt);
+    }
+
+    // Inject response shape template for the detected query intent.
+    // Placed last so it's fresh in the model's context window right before
+    // it generates — closer to the end = higher attention weight.
+    if (queryIntent && queryIntent !== "ambiguous") {
+      const templateSection = buildTemplatePrompt(queryIntent as QueryIntent);
+      if (templateSection) {
+        parts.push("", templateSection);
+      }
     }
 
     return parts.join("\n");
@@ -3499,6 +3511,37 @@ export class sportsclawEngine {
       return clarification;
     }
 
+    // --- Intent clarification (sport known, query purpose unclear) ---
+    // Fires when the router explicitly sets needs_clarification=true,
+    // meaning the sport is identified but what the user wants is genuinely
+    // ambiguous (e.g. bare "NBA" with no context). Skip in YOLO and on
+    // follow-up turns where conversation history provides enough context.
+    if (
+      !this.config.yoloMode &&
+      !isFollowUp &&
+      routing.decision?.needsClarification &&
+      routing.decision.mode !== "ambiguous" &&
+      routing.decision.selectedSkills.length > 0 &&
+      !isInternalToolIntent(sanitizedPrompt) &&
+      !isConversationalIntent(sanitizedPrompt)
+    ) {
+      const sport = routing.decision.selectedSkills[0];
+      const intentQ = `What would you like to know about ${sport}? For example:\n- Live scores or game updates\n- Standings\n- Today's schedule\n- Betting odds or best bets\n- Player or team stats\n- Recent news`;
+      this.messages.push({ role: "assistant", content: [{ type: "text", text: intentQ }] });
+      if (memory) {
+        await memory.appendToThread(sanitizedPrompt, intentQ);
+        await memory.appendExchange(sanitizedPrompt, intentQ);
+      }
+      return intentQ;
+    }
+
+    // Capture detected intent for response template injection and evaluation
+    const queryIntent = (routing.decision?.intent ?? "ambiguous") as QueryIntent;
+
+    if (this.config.verbose && routing.decision?.intent) {
+      console.error(`[sportsclaw] intent=${queryIntent} needs_clarification=${routing.decision.needsClarification ?? false}`);
+    }
+
     // --- Parallel agent execution ---
     // When parallelAgents is enabled and multiple agents were routed,
     // run each agent as an independent lane and synthesize the results.
@@ -3655,7 +3698,7 @@ export class sportsclawEngine {
     const callLLM = (messagesOverride?: Message[]) =>
       generateText({
         model: this.mainModel,
-        system: this.buildSystemPrompt(!!memory, activeAgents.length > 0 ? activeAgents : undefined, strategyContent, options?.systemPrompt),
+        system: this.buildSystemPrompt(!!memory, activeAgents.length > 0 ? activeAgents : undefined, strategyContent, options?.systemPrompt, queryIntent),
         messages: messagesOverride ?? this.messages,
         tools,
         ...(activeTools ? { activeTools } : {}),
@@ -3880,6 +3923,27 @@ export class sportsclawEngine {
         toolOutputs,
         maxOutputTokens: budgets.synthesis,
       });
+    }
+
+    // Evaluator: soft quality gate — logs mismatches in verbose mode.
+    // No user-facing impact; used to detect routing/template gaps over time.
+    if (this.config.verbose) {
+      const evalResult = evaluateResponse(
+        responseText,
+        Array.from(succeededToolNames),
+        queryIntent
+      );
+      if (!evalResult.passed || evalResult.toolsNotCalled.length > 0) {
+        console.error(
+          `[sportsclaw] eval intent=${queryIntent}` +
+            (evalResult.missingKeywords.length > 0
+              ? ` missing_kw=[${evalResult.missingKeywords.join(",")}]`
+              : "") +
+            (evalResult.toolsNotCalled.length > 0
+              ? ` tools_not_called=[${evalResult.toolsNotCalled.join(",")}]`
+              : "")
+        );
+      }
     }
 
     if (netFailures.length > 0) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -90,6 +90,7 @@ import { subagentManager, type SubagentResult } from "./subagent.js";
 import { heartbeatService } from "./heartbeat.js";
 import { buildTemplatePrompt, type QueryIntent } from "./response-templates.js";
 import { evaluateResponse } from "./evaluator.js";
+import { getSportDisplayName } from "./buttons.js";
 
 // ---------------------------------------------------------------------------
 // Package version (read once at import time)
@@ -3526,7 +3527,8 @@ export class sportsclawEngine {
       !isConversationalIntent(sanitizedPrompt)
     ) {
       const sport = routing.decision.selectedSkills[0];
-      const intentQ = `What would you like to know about ${sport}? For example:\n- Live scores or game updates\n- Standings\n- Today's schedule\n- Betting odds or best bets\n- Player or team stats\n- Recent news`;
+      const sportLabel = getSportDisplayName(sport);
+      const intentQ = `What would you like to know about ${sportLabel}? For example:\n- Live scores or game updates\n- Standings\n- Today's schedule\n- Betting odds or best bets\n- Player or team stats\n- Recent news`;
       this.messages.push({ role: "assistant", content: [{ type: "text", text: intentQ }] });
       if (memory) {
         await memory.appendToThread(sanitizedPrompt, intentQ);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,0 +1,63 @@
+/**
+ * sportsclaw — Response Evaluator
+ *
+ * Soft post-generation quality gate. Checks whether the response aligns with
+ * the detected query intent. Pure string/set operations — no LLM calls.
+ *
+ * This is diagnostic, not blocking: failures are logged in verbose mode but
+ * do not modify the user-facing response. The data helps identify patterns
+ * where the prompt injection or tool routing needs tuning.
+ */
+
+import { getTemplate, type QueryIntent } from "./response-templates.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EvalResult {
+  passed: boolean;
+  /** Required keywords absent from the response */
+  missingKeywords: string[];
+  /** Expected tool patterns that had no matching tool calls */
+  toolsNotCalled: string[];
+}
+
+// ---------------------------------------------------------------------------
+// evaluateResponse
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a final response against the expected shape for its query intent.
+ *
+ * @param response    The final response text returned to the user.
+ * @param toolsUsed   Names of tools that succeeded this turn.
+ * @param intent      The query intent detected by the router.
+ */
+export function evaluateResponse(
+  response: string,
+  toolsUsed: string[],
+  intent: QueryIntent
+): EvalResult {
+  const template = getTemplate(intent);
+  const lower = response.toLowerCase();
+
+  // Check required keywords (only for intents that specify them)
+  const missingKeywords = template.requiredKeywords.filter(
+    (kw) => !lower.includes(kw.toLowerCase())
+  );
+
+  // Check that at least one expected tool pattern matched
+  const toolsNotCalled = template.expectedToolPatterns.filter(
+    (pattern) => !toolsUsed.some((t) => t.toLowerCase().includes(pattern))
+  );
+
+  // Pass if: no required keywords missing, OR at least one tool was called
+  // (A response can be valid even without keyword matches if tools ran and
+  // returned data — the LLM may phrase things differently across sports.)
+  const passed =
+    missingKeywords.length === 0 ||
+    toolsUsed.length > 0;
+
+  return { passed, missingKeywords, toolsNotCalled };
+}

--- a/src/response-templates.ts
+++ b/src/response-templates.ts
@@ -1,0 +1,124 @@
+/**
+ * sportsclaw — Response Shape Templates
+ *
+ * Maps detected query intents to format hints injected into the system prompt.
+ * No LLM calls — pure static configuration that shapes how the model formats responses.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type QueryIntent =
+  | "live_scores"
+  | "standings"
+  | "schedule"
+  | "odds"
+  | "best_bets"
+  | "player_stats"
+  | "team_stats"
+  | "news"
+  | "roster"
+  | "analysis"
+  | "prediction"
+  | "ambiguous";
+
+interface ResponseTemplate {
+  /** Injected into system prompt as a format directive */
+  hint: string;
+  /** Substrings to match against tool names (for evaluator) */
+  expectedToolPatterns: string[];
+  /** Keywords the response should contain for live data intents */
+  requiredKeywords: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+const TEMPLATES: Record<QueryIntent, ResponseTemplate> = {
+  live_scores: {
+    hint: "Lead with the current score and game status (quarter/period/half/inning). Include key performers. Keep it under 5 lines unless asked for more.",
+    expectedToolPatterns: ["score", "live", "game"],
+    requiredKeywords: ["score", "Q1", "Q2", "Q3", "Q4", "period", "half", "inning", "final", "live"],
+  },
+  standings: {
+    hint: "Show standings as a ranked list: position, team, W-L record, and one key stat (GB, PCT, or points). Highlight the user's team if in Fan Profile.",
+    expectedToolPatterns: ["standing", "table", "rank"],
+    requiredKeywords: [],
+  },
+  schedule: {
+    hint: "List games chronologically: date/time, matchup, venue if relevant. Use TODAY or TONIGHT for today's games. Keep it scannable — one game per line.",
+    expectedToolPatterns: ["schedule", "fixture", "game"],
+    requiredKeywords: [],
+  },
+  odds: {
+    hint: "Show the spread/line, moneyline, and over/under. Include the sportsbook name. Format: '[Team A] -4.5 vs [Team B], O/U 225.5 (DraftKings)'.",
+    expectedToolPatterns: ["odds", "bet", "line"],
+    requiredKeywords: [],
+  },
+  best_bets: {
+    hint: "Give up to 3 picks. Format each as: '[Pick] [Line] — [1-sentence reason based on actual data]'. Lead with the strongest pick. No hedging.",
+    expectedToolPatterns: ["odds", "bet", "stat", "form"],
+    requiredKeywords: [],
+  },
+  player_stats: {
+    hint: "Lead with player name + team. Show stats relevant to the query (season averages, recent game, career milestone). Cite the data source.",
+    expectedToolPatterns: ["player", "stat", "athlete"],
+    requiredKeywords: [],
+  },
+  team_stats: {
+    hint: "Cover offense and defense with 2-3 key metrics each. Compare to league average where the data supports it.",
+    expectedToolPatterns: ["team", "stat"],
+    requiredKeywords: [],
+  },
+  news: {
+    hint: "Bullet each story: '• [Headline] — [1-sentence context/impact]'. Most recent first. Include date for each item.",
+    expectedToolPatterns: ["news", "article"],
+    requiredKeywords: [],
+  },
+  roster: {
+    hint: "Group by position. Name, number, and one key stat or note per player. Flag active injuries prominently.",
+    expectedToolPatterns: ["roster", "player", "team"],
+    requiredKeywords: [],
+  },
+  analysis: {
+    hint: "Structure: situation → data → take. Back every claim with actual numbers from tools. End with a clear verdict. No wishy-washy conclusions.",
+    expectedToolPatterns: [],
+    requiredKeywords: [],
+  },
+  prediction: {
+    hint: "Give a clear pick with supporting data. State confidence (high/medium/low). Don't hedge — commit to a take and explain why.",
+    expectedToolPatterns: [],
+    requiredKeywords: [],
+  },
+  ambiguous: {
+    hint: "",
+    expectedToolPatterns: [],
+    requiredKeywords: [],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export function getTemplate(intent: QueryIntent): ResponseTemplate {
+  return TEMPLATES[intent] ?? TEMPLATES.ambiguous;
+}
+
+/**
+ * Build the "## Response Shape" section injected into buildSystemPrompt().
+ * Returns empty string for ambiguous intent (no hint to inject).
+ */
+export function buildTemplatePrompt(intent: QueryIntent): string {
+  const t = getTemplate(intent);
+  if (!t.hint) return "";
+  return [
+    "## Response Shape",
+    "",
+    `Detected query type: **${intent.replace(/_/g, " ")}**`,
+    "",
+    t.hint,
+  ].join("\n");
+}

--- a/src/response-templates.ts
+++ b/src/response-templates.ts
@@ -40,7 +40,7 @@ const TEMPLATES: Record<QueryIntent, ResponseTemplate> = {
   live_scores: {
     hint: "Lead with the current score and game status (quarter/period/half/inning). Include key performers. Keep it under 5 lines unless asked for more.",
     expectedToolPatterns: ["score", "live", "game"],
-    requiredKeywords: ["score", "Q1", "Q2", "Q3", "Q4", "period", "half", "inning", "final", "live"],
+    requiredKeywords: [],
   },
   standings: {
     hint: "Show standings as a ranked list: position, team, W-L record, and one key stat (GB, PCT, or points). Highlight the user's team if in Fan Profile.",

--- a/src/router.ts
+++ b/src/router.ts
@@ -212,6 +212,8 @@ function parseRouterJson(text: string): Partial<RouteDecision> | null {
       mode?: unknown;
       confidence?: unknown;
       reason?: unknown;
+      intent?: unknown;
+      needs_clarification?: unknown;
     };
     const selectedSkills = Array.isArray(parsed.selected_skills)
       ? parsed.selected_skills.filter(
@@ -225,11 +227,18 @@ function parseRouterJson(text: string): Partial<RouteDecision> | null {
     const confidence =
       typeof parsed.confidence === "number" ? clamp01(parsed.confidence) : 0;
     const reason = typeof parsed.reason === "string" ? parsed.reason : "";
+    const intent = typeof parsed.intent === "string" ? parsed.intent : undefined;
+    const needsClarification =
+      typeof parsed.needs_clarification === "boolean"
+        ? parsed.needs_clarification
+        : false;
     return {
       selectedSkills,
       ...(mode ? { mode } : {}),
       confidence,
       reason,
+      ...(intent ? { intent } : {}),
+      needsClarification,
     };
   } catch {
     return null;
@@ -259,6 +268,8 @@ async function runLlmRouter(
         "Choose only from allowed skills. Keep selection minimal.",
         "If one sport is explicit, mode must be focused.",
         "If prompt is broad/vague, mode may be ambiguous.",
+        "Also classify the query intent as one of: live_scores, standings, schedule, odds, best_bets, player_stats, team_stats, news, roster, analysis, prediction, ambiguous.",
+        "Set needs_clarification to true ONLY when the user's intent is genuinely unclear even after knowing the sport (e.g. bare sport name with no context). Do NOT set it for any query that is reasonably interpretable.",
       ].join(" "),
       prompt: [
         `Allowed skills: ${allowedSkills}`,
@@ -266,7 +277,7 @@ async function runLlmRouter(
         `Memory preference ranking: ${memoryHint}`,
         ...(input.recentContext ? [`Recent conversation context: ${input.recentContext}`] : []),
         `User prompt: ${input.prompt}`,
-        `Return JSON schema: {"selected_skills":["skill"],"mode":"focused|ambiguous","confidence":0.0,"reason":"short reason"}`,
+        `Return JSON schema: {"selected_skills":["skill"],"mode":"focused|ambiguous","confidence":0.0,"reason":"short reason","intent":"live_scores|standings|schedule|odds|best_bets|player_stats|team_stats|news|roster|analysis|prediction|ambiguous","needs_clarification":false}`,
       ].join("\n"),
       maxOutputTokens: input.config.tokenBudgets?.router ?? DEFAULT_TOKEN_BUDGETS.router,
       ...(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -373,6 +373,10 @@ export interface RouteDecision {
   mode: "focused" | "ambiguous";
   confidence: number;
   reason: string;
+  /** Query intent classified by the router (e.g. "live_scores", "standings") */
+  intent?: string;
+  /** True when the router determines the query needs a clarifying question */
+  needsClarification?: boolean;
 }
 
 export interface RouteMeta {


### PR DESCRIPTION
  - **Intent classification**: The router now classifies query type (`live_scores`, `standings`, `odds`, `best_bets`, `player_stats`,  etc.) alongside sport skill selection — zero extra LLM calls, piggybacked on the existing router call
  - **Response shape templates**: Per-intent format hints are injected at the end of the system prompt (high attention position),      
  telling the model exactly how to structure its response for each query type                                                          
  - **Clarification-first flow**: When the router detects `needs_clarification=true` (sport known, intent genuinely ambiguous — e.g.
  bare "NBA" with no context), the engine returns a focused question instead of guessing; Rule #5 updated from hard "NO CLARIFYING  QUESTIONS" to a nuanced policy                                           
  - **Post-response evaluator**: Soft quality gate checks that expected tools were called and response contains signal keywords for the detected intent; logs mismatches in `--verbose` mode for tuning (no user-facing impact) 