### PR TITLE
fix: small bugs

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1076,11 +1076,9 @@ export class sportsclawEngine {
       )
       .join("\n\n");
 
-    // Import inline to avoid circular dependency issues at module load time
-    const { buildTemplatePrompt } = await import("./response-templates.js");
     const intentHint =
       queryIntent && queryIntent !== "ambiguous"
-        ? buildTemplatePrompt(queryIntent as import("./response-templates.js").QueryIntent)
+        ? buildTemplatePrompt(queryIntent as QueryIntent)
         : "";
 
     try {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1063,8 +1063,9 @@ export class sportsclawEngine {
     failedTools: string[];
     toolOutputs: Array<{ toolName: string; output: string }>;
     maxOutputTokens: number;
+    queryIntent?: string;
   }): Promise<string> {
-    const { userPrompt, draft, successfulTools, failedTools, toolOutputs, maxOutputTokens } = params;
+    const { userPrompt, draft, successfulTools, failedTools, toolOutputs, maxOutputTokens, queryIntent } = params;
     if (toolOutputs.length === 0) return draft;
 
     const serialized = toolOutputs
@@ -1074,6 +1075,13 @@ export class sportsclawEngine {
           `Tool ${idx + 1} (${item.toolName}) output:\n${item.output}`
       )
       .join("\n\n");
+
+    // Import inline to avoid circular dependency issues at module load time
+    const { buildTemplatePrompt } = await import("./response-templates.js");
+    const intentHint =
+      queryIntent && queryIntent !== "ambiguous"
+        ? buildTemplatePrompt(queryIntent as import("./response-templates.js").QueryIntent)
+        : "";
 
     try {
       const res = await generateText({
@@ -1085,6 +1093,7 @@ export class sportsclawEngine {
           "Do not ask a follow-up question.",
           "If required data is missing, explicitly mark that section unavailable.",
           "Keep the response concise.",
+          ...(intentHint ? [intentHint] : []),
         ].join(" "),
         prompt: [
           `User request: ${userPrompt}`,
@@ -3515,13 +3524,14 @@ export class sportsclawEngine {
     // --- Intent clarification (sport known, query purpose unclear) ---
     // Fires when the router explicitly sets needs_clarification=true,
     // meaning the sport is identified but what the user wants is genuinely
-    // ambiguous (e.g. bare "NBA" with no context). Skip in YOLO and on
-    // follow-up turns where conversation history provides enough context.
+    // ambiguous (e.g. bare "NBA" with no context). Gated behind the same
+    // clarifyOnLowConfidence flag as the sport-ambiguity gate above for
+    // consistency. Skip in YOLO and on follow-up turns.
     if (
+      this.config.clarifyOnLowConfidence &&
       !this.config.yoloMode &&
       !isFollowUp &&
       routing.decision?.needsClarification &&
-      routing.decision.mode !== "ambiguous" &&
       routing.decision.selectedSkills.length > 0 &&
       !isInternalToolIntent(sanitizedPrompt) &&
       !isConversationalIntent(sanitizedPrompt)
@@ -3924,6 +3934,7 @@ export class sportsclawEngine {
         failedTools: netFailures.map((f) => f.toolName),
         toolOutputs,
         maxOutputTokens: budgets.synthesis,
+        queryIntent,
       });
     }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -42,22 +42,25 @@ export function evaluateResponse(
   const template = getTemplate(intent);
   const lower = response.toLowerCase();
 
-  // Check required keywords (only for intents that specify them)
+  // Check required keywords: at least ONE must appear in the response.
+  // The list represents signal words for the intent — not an exhaustive
+  // checklist. (A cricket score may say "over" not "quarter".)
   const missingKeywords = template.requiredKeywords.filter(
     (kw) => !lower.includes(kw.toLowerCase())
   );
+  const anyKeywordFound =
+    template.requiredKeywords.length === 0 ||
+    missingKeywords.length < template.requiredKeywords.length;
 
   // Check that at least one expected tool pattern matched
   const toolsNotCalled = template.expectedToolPatterns.filter(
     (pattern) => !toolsUsed.some((t) => t.toLowerCase().includes(pattern))
   );
 
-  // Pass if: no required keywords missing, OR at least one tool was called
-  // (A response can be valid even without keyword matches if tools ran and
-  // returned data — the LLM may phrase things differently across sports.)
-  const passed =
-    missingKeywords.length === 0 ||
-    toolsUsed.length > 0;
+  // Pass if: at least one signal keyword found, OR at least one tool ran.
+  // Tools running is the strongest signal — if data was fetched the response is valid
+  // regardless of how the LLM phrased it.
+  const passed = anyKeywordFound || toolsUsed.length > 0;
 
   return { passed, missingKeywords, toolsNotCalled };
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -416,6 +416,9 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
       ? `Explicit intent detected for: ${Array.from(explicitSkills).join(", ")}`
       : "No explicit sport detected; using broad routing.";
 
+  let llmIntent: string | undefined;
+  let llmNeedsClarification = false;
+
   if (llmDecision?.selectedSkills && llmDecision.selectedSkills.length > 0) {
     const valid = llmDecision.selectedSkills.filter((skill) =>
       installedSet.has(skill)
@@ -428,6 +431,9 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
       confidence = clamp01(llmDecision.confidence);
     }
     if (llmDecision.reason) reason = llmDecision.reason;
+    // Propagate intent classification and clarification signal
+    if (llmDecision.intent) llmIntent = llmDecision.intent;
+    if (llmDecision.needsClarification) llmNeedsClarification = llmDecision.needsClarification;
   }
 
   let primarySkills: string[] = [];
@@ -496,6 +502,8 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
       mode,
       confidence: clamp01(confidence),
       reason,
+      ...(llmIntent ? { intent: llmIntent } : {}),
+      needsClarification: llmNeedsClarification,
     },
     meta: {
       modelUsed,


### PR DESCRIPTION
  Fix 1 — router.ts (critical): intent and needsClarification now propagate from llmDecision all the way into the returned             
  RouteDecision.                                                                                                                       
                                                                                                                                       
  Fix 2 — engine.ts: Removed the mode !== "ambiguous" condition from the intent clarification gate.                                                                                                   
                                                                  
  Fix 3 — evaluator.ts: Restored the "any keyword found" logic — pass if at least one signal keyword appears, not all of them.                                                                              
                                                                  
  Fix 4 — engine.ts: synthesizeFromToolOutputs now accepts queryIntent and injects the matching response shape template into its system prompt. 
                                                                                                                                       
  Fix 5 — engine.ts: Intent clarification gate now checks this.config.clarifyOnLowConfidence, matching the existing sport-ambiguity gate. 