### PR TITLE
feat: export buttons module from public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,20 @@ export { applySimulationToBracket, autoFillBracketFromSim } from "./bracket.js";
 
 // Monte Carlo bracket simulation
 export { simulateBracket, fetchTournamentField } from "./bracket-sim.js";
+
+// Buttons — sport detection, contextual follow-ups, sport picker menus
+export {
+  detectSport,
+  detectLeague,
+  getButtons,
+  getFilteredButtons,
+  getFollowUpPrompt,
+  getQuickActionPrompt,
+  getSportDisplayName,
+  SPORT_MENU_ROWS,
+  SPORT_QUICK_ACTION_ROWS,
+} from "./buttons.js";
+export type { DetectedSport, DetectedLeague, ButtonDef, MenuButtonDef } from "./buttons.js";
 export type { SimTeam, SimConfig, SimulationResult } from "./bracket-sim.js";
 
 // Sprint 3: Subagent spawning


### PR DESCRIPTION
## Summary
- Re-exports `buttons.ts` (sport detection, contextual follow-up buttons, sport picker menus) from the package's public API
- Enables downstream consumers like `sportsclaw-machina` bridge to render Telegram inline keyboard buttons without vendoring the logic

## Exports added
- `detectSport`, `detectLeague`, `getButtons`, `getFilteredButtons`, `getFollowUpPrompt`, `getQuickActionPrompt`, `getSportDisplayName`
- `SPORT_MENU_ROWS`, `SPORT_QUICK_ACTION_ROWS`
- Types: `DetectedSport`, `DetectedLeague`, `ButtonDef`, `MenuButtonDef`

## Test plan
- [x] `tsc --noEmit` passes (no new errors)
- [ ] Verify import works from consuming package after merge + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)