### PR TITLE
feat: persistent nav row on all responses i.e "button-only" browsing

### DIFF
--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -250,9 +250,9 @@ export function getFilteredButtons(
     return FOOTBALL_STANDINGS_BUTTONS;
   }
 
-  // Unknown league (e.g. Paulista, Carioca, regional cup) → no data buttons
+  // Unknown league (e.g. Paulista, Carioca, regional cup) → standings fallback
   if (league) {
-    return [];
+    return FOOTBALL_STANDINGS_BUTTONS;
   }
 
   // Football detected but no specific league → default full set
@@ -595,3 +595,109 @@ export const SPORT_QUICK_ACTION_ROWS: Record<string, MenuButtonDef[][]> = {
     ],
   ],
 };
+
+// ---------------------------------------------------------------------------
+// Post-response navigation row — shown after every engine response
+// ---------------------------------------------------------------------------
+
+/**
+ * A single row of quick-nav buttons shown at the bottom of every response.
+ * Reuses sc_qa_* callbacks so no new handler code is needed.
+ * Max 5 buttons to stay within Discord's per-row limit.
+ */
+export const SPORT_NAV_ROW: Record<string, MenuButtonDef[]> = {
+  football: [
+    { callback: "sc_qa_football_matches",   label: "📅 Matches" },
+    { callback: "sc_qa_football_standings", label: "🏆 Standings" },
+    { callback: "sc_qa_football_leaders",   label: "⚽ Scorers" },
+    { callback: "sc_qa_football_odds",      label: "💰 Odds" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  nfl: [
+    { callback: "sc_qa_nfl_scores",         label: "🎯 Scores" },
+    { callback: "sc_qa_nfl_standings",      label: "🏆 Standings" },
+    { callback: "sc_qa_nfl_leaders",        label: "📈 Leaders" },
+    { callback: "sc_qa_nfl_odds",           label: "💰 Odds" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  nba: [
+    { callback: "sc_qa_nba_scores",         label: "🎯 Scores" },
+    { callback: "sc_qa_nba_standings",      label: "🏆 Standings" },
+    { callback: "sc_qa_nba_leaders",        label: "📈 Leaders" },
+    { callback: "sc_qa_nba_odds",           label: "💰 Odds" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  nhl: [
+    { callback: "sc_qa_nhl_scores",         label: "🎯 Scores" },
+    { callback: "sc_qa_nhl_standings",      label: "🏆 Standings" },
+    { callback: "sc_qa_nhl_leaders",        label: "📈 Leaders" },
+    { callback: "sc_qa_nhl_odds",           label: "💰 Odds" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  mlb: [
+    { callback: "sc_qa_mlb_scores",         label: "🎯 Scores" },
+    { callback: "sc_qa_mlb_standings",      label: "🏆 Standings" },
+    { callback: "sc_qa_mlb_leaders",        label: "📈 Leaders" },
+    { callback: "sc_qa_mlb_odds",           label: "💰 Odds" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  wnba: [
+    { callback: "sc_qa_wnba_scores",        label: "🎯 Scores" },
+    { callback: "sc_qa_wnba_standings",     label: "🏆 Standings" },
+    { callback: "sc_qa_wnba_leaders",       label: "📈 Leaders" },
+    { callback: "sc_qa_wnba_news",          label: "📰 News" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  cfb: [
+    { callback: "sc_qa_cfb_scores",         label: "🎯 Scores" },
+    { callback: "sc_qa_cfb_standings",      label: "🏆 Standings" },
+    { callback: "sc_qa_cfb_leaders",        label: "📈 Leaders" },
+    { callback: "sc_qa_cfb_news",           label: "📰 News" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  cbb: [
+    { callback: "sc_qa_cbb_scores",         label: "🎯 Scores" },
+    { callback: "sc_qa_cbb_standings",      label: "🏆 Standings" },
+    { callback: "sc_qa_cbb_leaders",        label: "📈 Leaders" },
+    { callback: "sc_qa_cbb_news",           label: "📰 News" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  tennis: [
+    { callback: "sc_qa_tennis_matches",     label: "🎾 Matches" },
+    { callback: "sc_qa_tennis_rankings",    label: "🏆 Rankings" },
+    { callback: "sc_qa_tennis_news",        label: "📰 News" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  golf: [
+    { callback: "sc_qa_golf_leaderboard",   label: "📊 Leaderboard" },
+    { callback: "sc_qa_golf_schedule",      label: "📅 Schedule" },
+    { callback: "sc_qa_golf_news",          label: "📰 News" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  f1: [
+    { callback: "sc_qa_f1_raceresults",     label: "🏁 Results" },
+    { callback: "sc_qa_f1_driverstnd",      label: "🏆 Standings" },
+    { callback: "sc_qa_f1_laptimes",        label: "⏱️ Lap Times" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+  volleyball: [
+    { callback: "sc_qa_volleyball_standings", label: "🏐 Standings" },
+    { callback: "sc_qa_volleyball_schedule",  label: "📅 Schedule" },
+    { callback: "sc_qa_volleyball_results",   label: "📋 Results" },
+    { callback: "sc_menu",                    label: "⬅️ Menu" },
+  ],
+  markets: [
+    { callback: "sc_qa_markets_markets",    label: "📊 Markets" },
+    { callback: "sc_qa_markets_search",     label: "🔍 Search" },
+    { callback: "sc_menu",                  label: "⬅️ Menu" },
+  ],
+};
+
+/**
+ * Return the nav row for a sport, or a bare Menu button if the sport is
+ * unknown or null.
+ */
+export function getSportNavRow(sport: DetectedSport | string | null): MenuButtonDef[] {
+  if (!sport) return [{ callback: "sc_menu", label: "⬅️ Menu" }];
+  return SPORT_NAV_ROW[sport] ?? [{ callback: "sc_menu", label: "⬅️ Menu" }];
+}

--- a/src/listeners/discord.ts
+++ b/src/listeners/discord.ts
@@ -26,7 +26,7 @@ import { splitMessage, saveImageToDisk, saveVideoToDisk } from "../utils.js";
 import { isGameRelatedResponse, formatTextForDiscord } from "../formatters/index.js";
 import {
   detectSport, detectLeague, getFilteredButtons, getFollowUpPrompt,
-  getSportDisplayName, getQuickActionPrompt,
+  getSportDisplayName, getQuickActionPrompt, getSportNavRow,
   SPORT_MENU_ROWS, SPORT_QUICK_ACTION_ROWS,
 } from "../buttons.js";
 import type { DetectedSport } from "../buttons.js";
@@ -242,6 +242,46 @@ export async function startDiscordListener(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
+  // Unified response component builder — action row + persistent nav row
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build all Discord ActionRows for an engine response.
+   * - Prepends sport-specific action buttons (box score, stats, etc.) when the
+   *   response is game-related.
+   * - Always appends the sport's nav row so users can keep browsing.
+   */
+  function buildDiscordComponents(
+    response: string,
+    prompt: string,
+    userId: string
+  ): import("discord.js").ActionRowBuilder<import("discord.js").ButtonBuilder>[] {
+    if (!features.buttons) return [];
+    const sport = detectSport(response, prompt);
+    const components: import("discord.js").ActionRowBuilder<import("discord.js").ButtonBuilder>[] = [];
+
+    if (isGameRelatedResponse(response, prompt) && sport) {
+      const contextKey = storeButtonContext(prompt, userId, sport);
+      const actionRow = buildActionRow(contextKey, sport, response, prompt);
+      if (actionRow) components.push(actionRow);
+    }
+
+    const navButtons = getSportNavRow(sport);
+    const navRow = new ActionRowBuilder<import("discord.js").ButtonBuilder>();
+    for (const btn of navButtons) {
+      navRow.addComponents(
+        new ButtonBuilder()
+          .setCustomId(btn.callback)
+          .setLabel(btn.label)
+          .setStyle(ButtonStyle.Secondary)
+      );
+    }
+    components.push(navRow);
+
+    return components;
+  }
+
+  // ---------------------------------------------------------------------------
   // Sport picker menu builders
   // ---------------------------------------------------------------------------
 
@@ -376,12 +416,25 @@ export async function startDiscordListener(): Promise<void> {
       await interaction.deferReply();
 
       try {
-        // Resume the engine with the selected value injected as context
         const resumePrompt = `${suspended.originalPrompt}\n\n[User selected: ${selectedOption.value}]`;
         const engine = new sportsclawEngine(engineConfig);
         const response = await engine.run(resumePrompt, { userId, sessionId: userId });
 
-        await sendGameResponse(response, suspended.originalPrompt, userId, interaction as unknown as import("discord.js").Message);
+        const formatted = formatTextForDiscord(response);
+        const chunks = splitMessage(formatted, 2000);
+        const askComponents = buildDiscordComponents(response, suspended.originalPrompt, userId);
+
+        await interaction.editReply({
+          content: chunks[0] ?? "No data available.",
+          ...(chunks.length === 1 && askComponents.length > 0 ? { components: askComponents } : {}),
+        });
+        for (let i = 1; i < chunks.length; i++) {
+          const isLast = i === chunks.length - 1;
+          await interaction.followUp({
+            content: chunks[i],
+            ...(isLast && askComponents.length > 0 ? { components: askComponents } : {}),
+          });
+        }
       } catch (error: unknown) {
         const errMsg = error instanceof Error ? error.message : String(error);
         console.error(`[sportsclaw] AskUserQuestion resume error: ${errMsg}`);
@@ -429,9 +482,18 @@ export async function startDiscordListener(): Promise<void> {
         const response = await engine.run(followUp, { userId, sessionId: userId });
         const formatted = formatTextForDiscord(response);
         const chunks = splitMessage(formatted, 2000);
-        await interaction.editReply(chunks[0] ?? "No data available.");
-        for (const chunk of chunks.slice(1)) {
-          await interaction.followUp(chunk);
+        const qaComponents = buildDiscordComponents(response, followUp, userId);
+
+        await interaction.editReply({
+          content: chunks[0] ?? "No data available.",
+          ...(chunks.length === 1 && qaComponents.length > 0 ? { components: qaComponents } : {}),
+        });
+        for (let i = 1; i < chunks.length; i++) {
+          const isLast = i === chunks.length - 1;
+          await interaction.followUp({
+            content: chunks[i],
+            ...(isLast && qaComponents.length > 0 ? { components: qaComponents } : {}),
+          });
         }
       } catch (error: unknown) {
         const errMsg = error instanceof Error ? error.message : String(error);
@@ -467,9 +529,18 @@ export async function startDiscordListener(): Promise<void> {
 
       const formatted = formatTextForDiscord(response);
       const chunks = splitMessage(formatted, 2000);
-      await interaction.editReply(chunks[0] ?? "No data available.");
-      for (const chunk of chunks.slice(1)) {
-        await interaction.followUp(chunk);
+      const followUpComponents = buildDiscordComponents(response, followUpPrompt, ctx.userId);
+
+      await interaction.editReply({
+        content: chunks[0] ?? "No data available.",
+        ...(chunks.length === 1 && followUpComponents.length > 0 ? { components: followUpComponents } : {}),
+      });
+      for (let i = 1; i < chunks.length; i++) {
+        const isLast = i === chunks.length - 1;
+        await interaction.followUp({
+          content: chunks[i],
+          ...(isLast && followUpComponents.length > 0 ? { components: followUpComponents } : {}),
+        });
       }
     } catch (error: unknown) {
       const errMsg = error instanceof Error ? error.message : String(error);
@@ -678,23 +749,12 @@ export async function startDiscordListener(): Promise<void> {
     const formatted = formatTextForDiscord(response);
     const chunks = splitMessage(formatted, 2000);
 
-    // Build action buttons for game-related responses
-    let actionRow: import("discord.js").ActionRowBuilder<import("discord.js").ButtonBuilder> | null = null;
-    if (features.buttons && isGameRelatedResponse(response, prompt)) {
-      const sport = detectSport(response, prompt);
-      const contextKey = storeButtonContext(prompt, userId, sport);
-      actionRow = buildActionRow(contextKey, sport, response, prompt);
-    }
+    const components = buildDiscordComponents(response, prompt, userId);
 
-    // Send all chunks; attach buttons to the last one
     for (let i = 0; i < chunks.length; i++) {
       const isLast = i === chunks.length - 1;
-      const options: import("discord.js").MessageCreateOptions = {
-        content: chunks[i],
-      };
-      if (isLast && actionRow) {
-        options.components = [actionRow];
-      }
+      const options: import("discord.js").MessageCreateOptions = { content: chunks[i] };
+      if (isLast && components.length > 0) options.components = components;
       await safeSend(message, options);
     }
   }

--- a/src/listeners/telegram.ts
+++ b/src/listeners/telegram.ts
@@ -25,7 +25,7 @@ import { splitMessage, saveImageToDisk, saveVideoToDisk } from "../utils.js";
 import { formatResponse, isGameRelatedResponse } from "../formatters/index.js";
 import {
   detectSport, detectLeague, getFilteredButtons, getFollowUpPrompt,
-  getSportDisplayName, getQuickActionPrompt,
+  getSportDisplayName, getQuickActionPrompt, getSportNavRow,
   SPORT_MENU_ROWS, SPORT_QUICK_ACTION_ROWS,
 } from "../buttons.js";
 import type { DetectedSport, MenuButtonDef } from "../buttons.js";
@@ -117,6 +117,38 @@ function buildInlineKeyboard(
       })),
     ],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Unified response markup builder — action buttons + persistent nav row
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the full inline keyboard for any engine response.
+ * - If the response is game-related, prepends sport-specific action buttons
+ *   (box score, stats, etc.) as the first row.
+ * - Always appends the sport's quick-nav row so users can keep browsing
+ *   without typing.
+ */
+function buildResponseMarkup(
+  response: string,
+  prompt: string,
+  userId: string,
+  sport: DetectedSport
+): object {
+  const rows: InlineKeyboardButton[][] = [];
+
+  if (isGameRelatedResponse(response, prompt)) {
+    const contextKey = storeButtonContext(prompt, userId, sport);
+    const actionKeyboard = buildInlineKeyboard(contextKey, sport, response, prompt);
+    if (actionKeyboard) rows.push(...actionKeyboard.inline_keyboard);
+  }
+
+  rows.push(
+    getSportNavRow(sport).map((btn) => ({ text: btn.label, callback_data: btn.callback }))
+  );
+
+  return { inline_keyboard: rows };
 }
 
 // ---------------------------------------------------------------------------
@@ -625,36 +657,8 @@ async function processMessage(
     const formatted = formatResponse(response, "telegram");
     const textToSend = formatted.telegram || formatted.text;
 
-    // Build inline keyboard for game-related responses with supported data
-    let replyMarkup: object | undefined;
     const sport = detectSport(response, prompt);
-    if (isGameRelatedResponse(response, prompt) && sport) {
-      const contextKey = storeButtonContext(prompt, userId, sport);
-      const keyboard = buildInlineKeyboard(contextKey, sport, response, prompt);
-      // Share button: opens inline query mode pre-filled with the sport name
-      const shareRow: InlineKeyboardButton[] = [
-        {
-          text: "📤 Share",
-          switch_inline_query: getSportDisplayName(sport).toLowerCase(),
-        },
-      ];
-      replyMarkup = {
-        inline_keyboard: [
-          ...(keyboard?.inline_keyboard ?? []),
-          shareRow,
-        ],
-      };
-    } else if (sport) {
-      // Sport detected but not game-related — still show share button alone
-      replyMarkup = {
-        inline_keyboard: [[
-          {
-            text: "📤 Share",
-            switch_inline_query: getSportDisplayName(sport).toLowerCase(),
-          },
-        ]],
-      };
-    }
+    const replyMarkup = sport ? buildResponseMarkup(response, prompt, userId, sport) : undefined;
 
     // Telegram has a 4096 char limit — split if needed
     const chunks = splitMessage(textToSend, 4096);
@@ -790,12 +794,18 @@ async function processCallbackQuery(
 
       const formatted = formatResponse(response, "telegram");
       const textToSend = formatted.telegram || formatted.text;
-
       const chunks = splitMessage(textToSend, 4096);
-      for (const chunk of chunks) {
-        await sendMessage(apiBase, cqMessage.chat.id, chunk, {
+
+      const resumeSport = detectSport(response, suspended.originalPrompt);
+      const resumeReplyMarkup = resumeSport
+        ? buildResponseMarkup(response, suspended.originalPrompt, userId, resumeSport)
+        : undefined;
+
+      for (let idx = 0; idx < chunks.length; idx++) {
+        await sendMessage(apiBase, cqMessage.chat.id, chunks[idx], {
           parseMode: formatted.telegram ? "HTML" : undefined,
           replyToMessageId: cqMessage.message_id,
+          replyMarkup: idx === chunks.length - 1 ? resumeReplyMarkup : undefined,
         });
       }
     } catch (resumeErr: unknown) {
@@ -880,9 +890,16 @@ async function processCallbackQuery(
       const formatted = formatResponse(response, "telegram");
       const textToSend = formatted.telegram || formatted.text;
       const chunks = splitMessage(textToSend, 4096);
-      for (const chunk of chunks) {
-        await sendMessage(apiBase, cqMessage.chat.id, chunk, {
+
+      const qaSport = detectSport(response, followUp);
+      const qaReplyMarkup = qaSport
+        ? buildResponseMarkup(response, followUp, userId, qaSport)
+        : undefined;
+
+      for (let idx = 0; idx < chunks.length; idx++) {
+        await sendMessage(apiBase, cqMessage.chat.id, chunks[idx], {
           parseMode: formatted.telegram ? "HTML" : undefined,
+          replyMarkup: idx === chunks.length - 1 ? qaReplyMarkup : undefined,
         });
       }
     } catch (error: unknown) {
@@ -946,12 +963,18 @@ async function processCallbackQuery(
 
     const formatted = formatResponse(response, "telegram");
     const textToSend = formatted.telegram || formatted.text;
-
     const chunks = splitMessage(textToSend, 4096);
-    for (const chunk of chunks) {
-      await sendMessage(apiBase, cqMessage.chat.id, chunk, {
+
+    // Show nav row so the user can keep browsing after a drill-down
+    const followUpMarkup = ctx.sport
+      ? buildResponseMarkup(response, followUpPrompt, ctx.userId, ctx.sport)
+      : undefined;
+
+    for (let idx = 0; idx < chunks.length; idx++) {
+      await sendMessage(apiBase, cqMessage.chat.id, chunks[idx], {
         parseMode: formatted.telegram ? "HTML" : undefined,
         replyToMessageId: cqMessage.message_id,
+        replyMarkup: idx === chunks.length - 1 ? followUpMarkup : undefined,
       });
     }
   } catch (error: unknown) {


### PR DESCRIPTION
 ## Summary                                                      

  - **`src/buttons.ts`**: Added `SPORT_NAV_ROW` (one row per sport, max 5 for Discord's limit) and `getSportNavRow()` export. Buttons reuse existing `sc_qa_*` callbacks — no new handler code needed.
                                                                                                                                 
  - **`src/listeners/telegram.ts`**: Added `buildResponseMarkup()` helper that composes action buttons (game-related only) + the `sc_qa_*` handler, the `sc_ask_*` resume handler, and the stored-context follow-up handler. Removed the Share button (superseded by the nav row).                                                                                                   
                                                                  
  - **`src/listeners/discord.ts`**: Added `buildDiscordComponents()` helper with the same logic, returning `ActionRowBuilder[]`. Wired into `sendGameResponse` and all 3 interaction-based handlers (`sc_ask_*`, `sc_qa_*`, stored-context follow-up).          
                                                                                                                       
  ## Result                                                                                                                      
                                                                  
Every engine response on both platforms now shows a persistent nav row at the bottom. Users can browse Sport → Action → Response → Action → Response indefinitely without typing a single character.                                                   
                                                                              
User experience after this change:                              
                                                                                                                                 
  /menu                                                                                                                          
    → ⚽ Football                                                                                                                
      → 📅 Today's Matches       ← pre-crafted prompt fires                                                                      
                                                                                                                                 
  Response text here...                                                                                                          
                                                                                                                                 
  [📊 Match Stats]  [📋 Lineup]  [🏆 Standings]   ← only if live/game-related                                                    
  [📅 Matches] [🏆 Standings] [⚽ Scorers] [💰 Odds] [⬅️  Menu]   ← always present