### PR TITLE
fix(router): bypass sport clarification for visual-generation prompts

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -167,6 +167,23 @@ function isMcpIntent(prompt: string): boolean {
   return MCP_INTENT_PATTERNS.some((p) => p.test(prompt));
 }
 
+/** Patterns that indicate visual-generation intents — bypass sport clarification */
+const VISUAL_INTENT_PATTERNS = [
+  // Direct mentions of unambiguous visual-artifact nouns
+  /\b(image|images|poster|posters|infographic|infographics|illustration|illustrations|wallpaper|wallpapers|mockup|mock-?up|mockups)\b/i,
+  // Compound visual artifacts (generic alone, unambiguous when paired)
+  /\b(social\s+tiles?|cover\s+art|concept\s+art|hype\s+(reel|video|poster|tile)|key\s+art)\b/i,
+  // Verb + visual-artifact noun ("generate a banner", "make a graphic", "design a hype tile")
+  /\b(generate|create|make|design|draw|render|produce|mock\s*up)\b\s+(a|an|some|the)?\s*[\w:.-]*\s*(banner|graphic|visual|visuals|picture|photo|teaser|reveal)\b/i,
+  // Explicit tool reference
+  /\bgenerate_image\b/i,
+];
+
+/** Returns true when the prompt is a visual-generation request (poster, image, infographic, etc.) */
+function isVisualIntent(prompt: string): boolean {
+  return VISUAL_INTENT_PATTERNS.some((p) => p.test(prompt));
+}
+
 /** Filter out undefined values so they don't override defaults during merge */
 function filterDefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   const result: Partial<T> = {};
@@ -3158,7 +3175,8 @@ export class sportsclawEngine {
       routing.decision.mode === "ambiguous" &&
       !isInternalToolIntent(sanitizedPrompt) &&
       !isConversationalIntent(sanitizedPrompt) &&
-      !isMcpIntent(sanitizedPrompt)
+      !isMcpIntent(sanitizedPrompt) &&
+      !isVisualIntent(sanitizedPrompt)
     ) {
       const clarification = `I'm not sure which sport you mean. Did you want:\n\n${routing.decision.selectedSkills.map((skill) => `- ${skill}`).join("\n")}\n\nPlease clarify your question.`;
       // Push a matching assistant message so history stays coherent
@@ -3184,7 +3202,8 @@ export class sportsclawEngine {
       routing.decision?.needsClarification &&
       routing.decision.selectedSkills.length > 0 &&
       !isInternalToolIntent(sanitizedPrompt) &&
-      !isConversationalIntent(sanitizedPrompt)
+      !isConversationalIntent(sanitizedPrompt) &&
+      !isVisualIntent(sanitizedPrompt)
     ) {
       const sport = routing.decision.selectedSkills[0];
       const sportLabel = getSportDisplayName(sport);


### PR DESCRIPTION
## Summary

- Adds `isVisualIntent(prompt)` alongside the existing `isInternalToolIntent` / `isConversationalIntent` / `isMcpIntent` bypass helpers in `engine.ts`.
- Wires it into both clarification gates in `engine.run()` (sport-ambiguity gate and intent-ambiguity gate).
- Stops the engine from returning *"I'm not sure which sport you mean..."* on prompts like *"generate an image with the top 3 activation ideas"* before a visual-creative agent (e.g. a `generate_image`-using agent) ever gets a turn.

## The bug

Visual-generation prompts rarely mention a sport. The skill router scores them as low-confidence ambiguous, and the clarification gate at `engine.ts` short-circuits the request with a sport-clarification message — even when the user's installed agent set includes a creative agent built explicitly around `generate_image` / `generate_video`.

Reproduction (downstream Adidas tracker, on v0.25.0):

| Prompt | Before | After |
|---|---|---|
| `generate an image with the top 3 activation ideas for next month` | "I'm not sure which sport you mean..." | Routes to creative agent → `generate_image` fires |
| `generate an infographic with the best athlete now` | Generic data response, no image emitted | Routes to creative agent → infographic generated |
| `use studio agent` | "I'm not sure which sport you mean..." | (unchanged — explicit agent mention is handled by `routeToAgents` Phase 1) |

Verified working against the live relay by appending the magic word `mcp` to bypass the gate (which triggers `isMcpIntent`) — confirmed The Studio agent fires and an `image` NDJSON event is emitted with a base64 JPEG. This PR codifies the same bypass for visual prompts without a magic-word workaround.

## What's matched

```
// Direct artifact nouns
image, images, poster, posters, infographic, infographics,
illustration, illustrations, wallpaper, wallpapers, mockup, mock-up

// Compound artifacts (generic alone, unambiguous when paired)
social tile, cover art, concept art, hype reel/video/poster/tile, key art

// Verb + artifact ("create a banner", "render a 16:9 social tile",
// "design a teaser", "generate a graphic", etc.)
(generate|create|make|design|draw|render|produce|mock up) [...] (banner|graphic|visual|picture|photo|teaser|reveal)

// Explicit tool-name reference
generate_image
```

## Test plan

Inline regex sanity-check against 18 sample prompts (commit body has the full list):

- [x] Positive: `image`, `infographic`, `hype poster`, `banner`, `social tile`, `teaser`, `cover art`, `concept art`
- [x] Negative — sport queries unaffected: `who won the NBA game`, `show me NFL standings`, `score of the Lakers game`
- [x] Negative — conversational unaffected: `hi how are you`
- [x] Negative — internal/config unaffected: `upgrade sports-skills`
- [x] Adversarial: `the player tiled the bathroom`, `the team revealed the new jersey`, `picture this scenario`
- [x] `npm run build` clean

All 18 cases match expected.

## Risk

- New regex array; no changes to existing routing logic, agent loading, or tool dispatch.
- Bypass is one-way (skip clarification → run normally). Worst case on a false positive: a user's mostly-sport prompt that happens to contain an artifact noun (e.g. `picture this scenario`) skips the sport-clarify dialog and runs through normal agent routing — agents handle it. Net effect: one fewer interruption.
- No public API change; no version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)