### PR TITLE
feat(router): intent-tag matching for purpose-built agents

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -47,6 +47,12 @@ export interface AgentDef {
   name: string;
   /** Skills this agent can use. Empty = all skills (no filter). */
   skills: string[];
+  /**
+   * Intent tags this agent claims (e.g. "visual", "data", "briefing").
+   * Used by the router to prefer purpose-built agents on intent matches
+   * before falling back to skill-overlap scoring. Empty = no claims.
+   */
+  tags: string[];
   /** The full markdown body (directives + voice), injected into system prompt */
   body: string;
 }
@@ -65,7 +71,7 @@ function parseAgentFile(id: string, raw: string): AgentDef {
   const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!fmMatch) {
     // No frontmatter — treat entire file as body
-    return { id, name: id, skills: [], body: raw.trim() };
+    return { id, name: id, skills: [], tags: [], body: raw.trim() };
   }
 
   const frontmatter = fmMatch[1];
@@ -75,26 +81,26 @@ function parseAgentFile(id: string, raw: string): AgentDef {
   const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
   const name = nameMatch ? nameMatch[1].trim() : id;
 
-  // Parse skills array: skills: [a, b, c] or skills:\n  - a\n  - b
-  let skills: string[] = [];
-  const inlineMatch = frontmatter.match(/^skills:\s*\[([^\]]*)\]/m);
-  if (inlineMatch) {
-    skills = inlineMatch[1]
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  } else {
-    // Check for YAML list style
-    const listMatch = frontmatter.match(/^skills:\s*\n((?:\s+-\s+.+\n?)+)/m);
-    if (listMatch) {
-      skills = listMatch[1]
+  // Parse a YAML list field (inline `[a, b, c]` or block `\n  - a\n  - b`)
+  const parseList = (key: string): string[] => {
+    const inline = frontmatter.match(new RegExp(`^${key}:\\s*\\[([^\\]]*)\\]`, "m"));
+    if (inline) {
+      return inline[1].split(",").map((s) => s.trim()).filter(Boolean);
+    }
+    const block = frontmatter.match(new RegExp(`^${key}:\\s*\\n((?:\\s+-\\s+.+\\n?)+)`, "m"));
+    if (block) {
+      return block[1]
         .split("\n")
         .map((line) => line.replace(/^\s*-\s*/, "").trim())
         .filter(Boolean);
     }
-  }
+    return [];
+  };
 
-  return { id, name, skills, body };
+  const skills = parseList("skills");
+  const tags = parseList("tags");
+
+  return { id, name, skills, tags, body };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3142,7 +3142,12 @@ export class sportsclawEngine {
 
     // --- Agent routing: pick the best agent(s) for this prompt ---
     const selectedSkills = routing.decision?.selectedSkills ?? [];
-    const agentRoutes = routeToAgents(this.agents, selectedSkills, sanitizedPrompt);
+    // Detect special intents so the router can prefer purpose-built agents
+    // (e.g. visual-generation prompts → an agent tagged `visual`) over the
+    // skill-overlap fallback which biases toward broad-skill generalists.
+    const intentTags: string[] = [];
+    if (isVisualIntent(sanitizedPrompt)) intentTags.push("visual");
+    const agentRoutes = routeToAgents(this.agents, selectedSkills, sanitizedPrompt, intentTags);
     const activeAgents = agentRoutes.map((r) => r.agent);
 
     if (this.config.verbose && routing.decision) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -529,9 +529,16 @@ export interface AgentRouteResult {
  * and return the top matches. Uses a simple overlap-based heuristic:
  *
  *   1. If prompt explicitly mentions an agent name → that agent wins (solo)
- *   2. Otherwise, score = (agent.skills ∩ selectedSkills).size / selectedSkills.size
- *   3. Agents with empty skills[] are generalists (score = 0.3 baseline)
- *   4. Tie-break: agent with broader coverage (more skills) wins
+ *   2. If `intentTags` are provided, prefer agents that claim a matching tag
+ *      in their frontmatter (e.g. visual prompts → an agent tagged `visual`)
+ *   3. Otherwise, score = (agent.skills ∩ selectedSkills).size / selectedSkills.size
+ *   4. Agents with empty skills[] are generalists (score = 0.3 baseline)
+ *   5. Tie-break: agent with broader coverage (more skills) wins
+ *
+ * `intentTags` lets the engine pre-classify a prompt (e.g. "visual" via
+ * `isVisualIntent`) and route it to a purpose-built agent regardless of
+ * whether any sport skills matched. Empty array (default) preserves the
+ * legacy two-phase behavior.
  *
  * Returns up to `maxAgents` agents with score > 0.5 (at least 1 if any exist).
  * Returns empty array if no agents are available.
@@ -540,6 +547,7 @@ export function routeToAgents(
   agents: AgentDef[],
   selectedSkills: string[],
   prompt: string,
+  intentTags: string[] = [],
   maxAgents = 2
 ): AgentRouteResult[] {
   if (agents.length === 0) return [];
@@ -560,6 +568,27 @@ export function routeToAgents(
       promptLower.includes(`@${idLower}`)
     ) {
       return [{ agent, score: 1, reason: `Explicit mention: "${agent.name}"` }];
+    }
+  }
+
+  // Phase 1.5: Intent-tag match — purpose-built agents win on intent hits.
+  // Prefer the most narrowly-scoped agent (fewest skills) to surface
+  // specialists like a creative-only "visual" agent over a multi-skill
+  // generalist that happens to share the tag.
+  if (intentTags.length > 0) {
+    const tagSet = new Set(intentTags);
+    const matched = agents.filter((a) => a.tags.some((t) => tagSet.has(t)));
+    if (matched.length > 0) {
+      matched.sort((a, b) => a.skills.length - b.skills.length);
+      const winner = matched[0];
+      const matchedTags = winner.tags.filter((t) => tagSet.has(t));
+      return [
+        {
+          agent: winner,
+          score: 1,
+          reason: `Intent tag match: ${matchedTags.join(", ")}`,
+        },
+      ];
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds optional `tags: string[]` to `AgentDef`, parsed from a `tags: [...]` frontmatter field in agent `.md` files (mirrors the existing `skills:` shape).
- Adds **Phase 1.5** to `routeToAgents` in `router.ts` between explicit-mention (Phase 1) and skill-overlap (Phase 2): when the engine passes `intentTags`, agents whose `tags` overlap win at score 1.0. Tie-breaks to the most narrowly-scoped match (fewest skills) so specialists beat generalists — the inverse of Phase 2's tiebreak.
- Wires the call site in `engine.run()` to build `intentTags` from the existing intent-detection helpers. Currently `isVisualIntent` (introduced in v0.25.1) → `"visual"`. Slot is open for `data`, `briefing`, etc. as helpers land.

## The bug

`routeToAgents` Phase 2 scores by `(agent.skills ∩ selectedSkills) / selectedSkills.size` and tiebreaks by `skills.length` — **broader-skilled agents win ties.** That's correct for sport queries, but wrong for prompts that don't carry a sport keyword at all: every agent ties at the 0.3 "no skills to match" baseline (router.ts:580), and the agent with the most skills wins.

Concrete failure on a downstream Adidas roster (Scout/Radar/Brief/Sentinel/Studio):

```
Prompt:  "make a hype poster for Lindsey"
Phase 1: no agent name in prompt → miss
Phase 2: every agent scores 0.3 (no skill match)
Tiebreak: Radar (11 skills) > Studio (1 skill: news)
Winner:  Radar — Studio's `generate_image` directives never load
```

The v0.25.1 PR fixed the **clarification gate** so visual prompts no longer return *"I'm not sure which sport you mean"*, but routing still picks the wrong agent because there's no mechanism to express *"this agent is purpose-built for X"*.

## The shape

Generalize via tags rather than special-casing:

```yaml
---
name: The Studio
skills: [news]
tags: [visual]   # NEW — claims any prompt tagged `visual` by the engine
---
```

Engine builds `intentTags` from the same helpers it already uses for clarification bypass:

```ts
const intentTags: string[] = [];
if (isVisualIntent(sanitizedPrompt)) intentTags.push("visual");

const agentRoutes = routeToAgents(this.agents, selectedSkills, sanitizedPrompt, intentTags);
```

Router prefers the narrowest match:

```ts
if (intentTags.length > 0) {
  const tagSet = new Set(intentTags);
  const matched = agents.filter((a) => a.tags.some((t) => tagSet.has(t)));
  if (matched.length > 0) {
    matched.sort((a, b) => a.skills.length - b.skills.length);
    return [{ agent: matched[0], score: 1, reason: `Intent tag match: ...` }];
  }
}
```

The narrowness sort is deliberate: a creative-only `tags: [visual]` agent should beat a multi-skill generalist that happens to also claim `visual`. This is the *opposite* of Phase 2's tiebreak (specialist wins where Phase 2 picks the generalist) — and that's the right call for intent matches.

## Backwards compatibility

- `tags` defaults to `[]` for any frontmatter without it. All existing agents (analyst/scoreboard/newsdesk + any third-party) parse unchanged.
- `intentTags` is an optional new parameter on `routeToAgents` (default `[]`). Legacy callers and tests continue to work.
- Empty `intentTags` skips Phase 1.5 entirely → identical behavior to v0.25.1.
- No public API removal. No system-prompt change (tags are router-only metadata; `prompts/system.ts:agentsSection` still surfaces only `name`/`skills`/`body`).

## Test plan

Inline regression with five-agent roster (Scout/Radar/Brief/Sentinel + visual-tagged Studio), verified 8 cases:

- [x] Visual prompt + `intentTags=["visual"]` + visual-tagged Studio → routes to Studio (score 1.0, reason `Intent tag match: visual`)
- [x] Multiple visual phrasings (`"make a hype poster"`, `"render a 16:9 social tile"`, `"generate an image with..."`) all route to Studio
- [x] Phase 1 still wins on explicit name (`"use studio agent"` routes to Studio via `Explicit mention` reason, not via Phase 1.5)
- [x] Explicit `@scout` mention routes to Scout, ignoring intent tags
- [x] Sport prompts with no intent tags fall through to Phase 2 unchanged (`"who won the lakers game"` → tiebreak between Scout/Radar)
- [x] Conversational prompt with no intent tags falls through (`"whats up"` → tiebreak between Scout/Radar)
- [x] Visual prompt **without** any visual-tagged agent in the roster → falls through to Phase 2 (no regression for users who haven't opted in)
- [x] `npm run build` clean

## Follow-up

Once merged, downstream agent definitions can opt in by adding `tags: [visual]`. The Adidas tracker template will set this on its Studio agent in adidas-templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)