### PR TITLE
fix(memory): unwrap double-nested response from Machina Core API

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -240,7 +240,10 @@ export class PodMemoryStorage implements MemoryStorage {
       page_size: 1,
     });
 
-    const raw = result?.data?.[0];
+    // Machina Core API returns search results double-nested:
+    // { status, message, data: { data: [...], status, total_documents } }
+    // — so the array lives at result.data.data, not result.data.
+    const raw = result?.data?.data?.[0];
     if (raw) {
       const doc = raw?.value ?? raw?.content ?? {};
       const entry = { doc, docId: raw._id ?? null, dirty: false };
@@ -285,7 +288,7 @@ export class PodMemoryStorage implements MemoryStorage {
           fields: ["_id", "value", "content", "text"],
           page_size: 1,
         });
-        const oldDoc = res?.data?.[0];
+        const oldDoc = res?.data?.data?.[0];
         if (oldDoc) {
           const text = oldDoc?.value?.text ?? oldDoc?.content?.text ?? oldDoc?.text ?? "";
           if (text) {
@@ -306,7 +309,7 @@ export class PodMemoryStorage implements MemoryStorage {
         fields: ["_id", "value", "content", "text"],
         page_size: 1,
       });
-      const dailyDoc = dailyRes?.data?.[0];
+      const dailyDoc = dailyRes?.data?.data?.[0];
       if (dailyDoc) {
         const text = dailyDoc?.value?.text ?? dailyDoc?.content?.text ?? dailyDoc?.text ?? "";
         if (text) {
@@ -325,7 +328,8 @@ export class PodMemoryStorage implements MemoryStorage {
       content: { value: doc },
       metadata: { type: "user-memory", user_id: userId },
     });
-    const docId = createResult?.data?._id ?? null;
+    // create_document also double-nests: { data: { data: { _id, ... } } }
+    const docId = createResult?.data?.data?._id ?? null;
 
     // Fire-and-forget: delete old individual docs
     for (const id of oldDocIds) {
@@ -431,7 +435,7 @@ export class PodMemoryStorage implements MemoryStorage {
           content: { value: entry.doc },
           metadata: { type: "user-memory", user_id: userId },
         });
-        entry.docId = result?.data?._id ?? null;
+        entry.docId = result?.data?.data?._id ?? null;
       }
       entry.dirty = false;
     } catch {


### PR DESCRIPTION
## Summary

`PodMemoryStorage` was reading `result.data[0]` to find existing memory docs, but the Machina Core API `search_documents` response is double-nested:

\`\`\`json
{
  \"status\": \"success\",
  \"message\": \"Document search completed\",
  \"data\": {
    \"data\": [...],
    \"status\": true,
    \"total_documents\": N
  }
}
\`\`\`

So \`result.data[0]\` was always \`undefined\` (objects don't have numeric keys). This made every engine invocation:

1. \`loadCached()\` fail to find the existing memory doc
2. Fall through to \`migrateOldDocs()\`, which always created a brand-new \`memory-{userId}\` doc
3. \`createResult.data._id\` was also undefined → cached \`docId: null\` → next \`flush()\` also took the create branch

**Production impact:** the deployed adidas dashboard accumulated **50+ duplicate \`memory-adidas-dashboard\` docs**, all empty (the migrate-then-create path stores the empty \`{}\` from the failed migration), and zero functional memory persistence. Users observed agents \"losing context\" between turns and forgetting prior comparisons.

## Fix

Unwrap the inner \`.data\` everywhere \`PodMemoryStorage\` parses a search or create response. Five sites in \`src/memory.ts\`:

- \`:243\` — \`loadCached()\` search_documents
- \`:288\` — \`migrateOldDocs()\` per-old-type search
- \`:309\` — \`migrateOldDocs()\` today's daily log search
- \`:328\` — \`migrateOldDocs()\` create_document
- \`:434\` — \`flush()\` create_document

Comment added near the first call site explaining the double-nested shape so the chain isn't stripped later thinking it's redundant.

## Test plan

- [x] \`npm run build\` clean
- Manual repro on the deployed adidas-tracker tenant — observed the dupe explosion in the MCP (50+ \`memory-adidas-dashboard\` docs, mostly with \`value-keys=[]\`). No memory writes since 2026-04-27 despite continuous chat usage. Pulling the latest non-empty doc shows partial \`thread\` content from the dupe disaster era.
- Post-fix verification will require redeploying the relay with this change, then validating that:
  - A second/third turn in the same chat retains conversation context
  - Only ONE \`memory-{userId}\` doc exists per user, and gets \`update_document\`d on each turn rather than recreated

## Out of scope

Cleanup of the existing 50+ duplicate \`memory-adidas-dashboard\` docs in the deployed adidas tenant is an operational task — delete dupes keeping only the most-recent non-empty one. Not part of this engine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)