### PR TITLE
fix(memory): cache promises + sort by recency to fix dupe creation race

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, and Google.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -217,45 +217,64 @@ function fileToField(file: string): { field: string; date?: string } {
  * Single-document pod storage. All memory fields for a user live in one
  * document named `memory-{userId}` with fields as top-level value keys.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MemoryEntry = { doc: Record<string, any>; docId: string | null; dirty: boolean };
+
 export class PodMemoryStorage implements MemoryStorage {
-  // Per-turn in-memory cache: avoids repeated pod searches for the same doc.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private cache = new Map<string, { doc: Record<string, any>; docId: string | null; dirty: boolean }>();
+  // Per-turn in-memory cache. Stores PROMISES (not resolved entries) so
+  // concurrent loadCached calls within the same turn share one search/create
+  // round-trip — without this, Promise.all([buildMemoryBlock(), readStrategy()])
+  // races and each branch creates its own duplicate memory doc.
+  private cache = new Map<string, Promise<MemoryEntry>>();
 
   constructor(private mcpManager: McpManager, private serverName: string) {}
 
   /**
    * Load (or create) the single consolidated memory document for a user.
    * Includes auto-migration from old multi-doc layout on first access.
+   * Concurrent calls share one in-flight promise to prevent duplicate-doc creation.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async loadCached(userId: string): Promise<{ doc: Record<string, any>; docId: string | null; dirty: boolean }> {
+  private loadCached(userId: string): Promise<MemoryEntry> {
     const cached = this.cache.get(userId);
     if (cached) return cached;
+    const promise = this.loadFromPod(userId);
+    this.cache.set(userId, promise);
+    return promise;
+  }
 
-    // Try to find existing consolidated doc
+  private async loadFromPod(userId: string): Promise<MemoryEntry> {
+    // Search for the most-recently-updated consolidated doc with a non-empty
+    // value. This handles two failure modes from earlier engine versions:
+    //   (1) zombie empty docs from prior race-condition migrations, and
+    //   (2) accidental dupes from non-deterministic create paths.
+    // We always prefer the freshest doc that actually has content; if every
+    // hit is empty, we fall back to the freshest empty hit (still better than
+    // re-creating).
     const result = await this.callPod("search_documents", {
       filters: { name: `memory-${userId}` },
-      fields: ["_id", "value", "content"],
-      page_size: 1,
+      fields: ["_id", "value", "content", "updated"],
+      sorters: [["updated", -1]],
+      page_size: 10,
     });
 
     // Machina Core API returns search results double-nested:
     // { status, message, data: { data: [...], status, total_documents } }
     // — so the array lives at result.data.data, not result.data.
-    const raw = result?.data?.data?.[0];
-    if (raw) {
-      const doc = raw?.value ?? raw?.content ?? {};
-      const entry = { doc, docId: raw._id ?? null, dirty: false };
-      this.cache.set(userId, entry);
-      return entry;
+    const hits = (result?.data?.data ?? []) as Array<Record<string, unknown>>;
+    if (hits.length > 0) {
+      const pickContent = (h: Record<string, unknown>): boolean => {
+        const v = (h?.value ?? h?.content ?? {}) as Record<string, unknown>;
+        return Object.keys(v).length > 0;
+      };
+      const chosen = hits.find(pickContent) ?? hits[0];
+      const doc = ((chosen?.value ?? chosen?.content ?? {}) as Record<string, unknown>) as Record<string, unknown>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return { doc: doc as Record<string, any>, docId: (chosen?._id as string) ?? null, dirty: false };
     }
 
-    // No consolidated doc — attempt migration from old multi-doc layout
+    // No consolidated doc anywhere — attempt migration from old multi-doc layout
     const migrated = await this.migrateOldDocs(userId);
-    const entry = { doc: migrated.doc, docId: migrated.docId, dirty: false };
-    this.cache.set(userId, entry);
-    return entry;
+    return { doc: migrated.doc, docId: migrated.docId, dirty: false };
   }
 
   /**
@@ -420,7 +439,9 @@ export class PodMemoryStorage implements MemoryStorage {
 
   /** Write cached doc back to pod if dirty. */
   async flush(userId: string): Promise<void> {
-    const entry = this.cache.get(userId);
+    const cachedPromise = this.cache.get(userId);
+    if (!cachedPromise) return;
+    const entry = await cachedPromise;
     if (!entry?.dirty) return;
 
     try {


### PR DESCRIPTION
## Summary

Follow-up to #25 (v0.26.1). Two remaining gaps observed in production:

1. **Concurrent first-load race.** `engine.run()` launches `Promise.all([memory.buildMemoryBlock(), memory.readStrategy()])`. Both branches call `loadCached`, both see empty cache, both run search→migrate→create. Result: 5-9 duplicate empty memory docs per fresh user_id session.

2. **Read picks the wrong doc.** Once dupes exist, `search_documents({name: 'memory-{userId}'}, page_size: 1)` returns the first one — often an empty zombie. The actual content doc (created later in the same turn after writes occurred) is missed entirely. Agent reports "no memory" on turn 2 even though writes succeeded on turn 1.

## Fix

Two-part:

1. **Cache the in-flight Promise instead of the resolved entry.** Concurrent callers within the same turn share one search/create round-trip. Eliminates the dupe-creation race on fresh user_ids.

2. **Read the most-recently-updated doc with content.** The search now sorts by `updated` desc, fetches up to 10 hits, and prefers the first non-empty hit. This handles already-existing zombie dupes from earlier engine versions without requiring an operational cleanup pass — the engine self-heals on read.

## Test plan

- [x] `npm run build` clean
- [x] Smoke test on deployed adidas tenant pre-fix: turn 1 "remember I want to focus on Mendoza" → 7 memory docs created (5 empty + 2 with content); turn 2 "who did I say I want to focus on?" → agent says "I don't have your previous focus recorded." Reproducible.
- Post-deploy verification will require: smoke test the same two-turn sequence and observe (a) only ONE memory doc gets created on turn 1, and (b) turn 2 successfully retrieves the recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)