### PR TITLE
fix: use package version in CLI help

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "listen:discord": "tsc && node dist/index.js listen discord",
     "listen:telegram": "tsc && node dist/index.js listen telegram",
     "docker:build": "docker build -t sportsclaw .",
-    "docker:run": "docker run --rm --env-file .env sportsclaw"
+    "docker:run": "docker run --rm --env-file .env sportsclaw",
+    "test:version": "npm run build && node --test test/version-help.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@
  */
 
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
@@ -107,6 +108,8 @@ import {
 import { WatchManager } from "./watch.js";
 import type { WatchOutputMode, WatcherConfig } from "./types.js";
 
+const require = createRequire(import.meta.url);
+const PKG_VERSION: string = require("../package.json").version;
 
 // ---------------------------------------------------------------------------
 // Re-exports for library usage
@@ -2127,7 +2130,7 @@ async function cmdMcp(args: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 function printHelp(): void {
-  console.log("sportsclaw Engine v0.4.1");
+  console.log(`sportsclaw Engine v${PKG_VERSION}`);
   console.log("");
   console.log("Usage:");
   console.log('  sportsclaw "<prompt>"              Run a one-shot sports query');

--- a/test/version-help.test.mjs
+++ b/test/version-help.test.mjs
@@ -1,0 +1,19 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json");
+
+describe("CLI --help version", () => {
+  it("should print the version from package.json", () => {
+    const output = execFileSync("node", ["dist/index.js", "--help"], {
+      encoding: "utf-8",
+    });
+    assert.ok(
+      output.includes(`v${pkg.version}`),
+      `Expected help output to contain "v${pkg.version}" but got:\n${output.split("\n")[0]}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace hardcoded CLI help version with the package metadata version
- Add a regression test for --help output
- Add an npm script for the version test

## Test Plan
- npm run build
- npm run test:version
- node dist/index.js --help | sed -n '1,3p'