### PR TITLE
feat: add TV operator contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "listen:discord": "tsc && node dist/index.js listen discord",
     "listen:telegram": "tsc && node dist/index.js listen telegram",
     "docker:build": "docker build -t sportsclaw .",
-    "docker:run": "docker run --rm --env-file .env sportsclaw"
+    "docker:run": "docker run --rm --env-file .env sportsclaw",
+    "test:tv-contracts": "npm run build && node --test test/tv-contracts.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,28 @@ export type { DaemonPlatform } from "./daemon.js";
 // AI-native setup wizard
 export { runSetup } from "./setup.js";
 
+// TV Operator Contracts (Machina Sports TV)
+export {
+  FRESHNESS_CLASSES,
+  validatePlaylistBlock,
+  validatePlaylistManifest,
+  validateLiveContentMeta,
+} from "./schema/tv.js";
+export type {
+  FreshnessClass,
+  ReviewState,
+  FallbackPolicy,
+  PlaylistBlock,
+  PlaylistManifest,
+  ChannelState,
+  OnAirBlock,
+  OnAirState,
+  DecisionRecord,
+  AgentRunRecord,
+  HealthSnapshot,
+  ValidationResult,
+} from "./schema/tv.js";
+
 // ---------------------------------------------------------------------------
 // Markdown terminal renderer
 // ---------------------------------------------------------------------------

--- a/src/schema/tv.ts
+++ b/src/schema/tv.ts
@@ -1,0 +1,203 @@
+/**
+ * sportsclaw — TV Operator Contracts (Machina Sports TV)
+ *
+ * Typed contracts and lightweight runtime validators for broadcast operations.
+ * These are data-only definitions — no engine wiring or behavior.
+ */
+
+// ---------------------------------------------------------------------------
+// FreshnessClass — how stale is this content?
+// ---------------------------------------------------------------------------
+
+export const FRESHNESS_CLASSES = [
+  "LIVE",
+  "HOT_SYNC",
+  "FRESH",
+  "EVERGREEN",
+] as const;
+
+export type FreshnessClass = (typeof FRESHNESS_CLASSES)[number];
+
+// ---------------------------------------------------------------------------
+// ReviewState — editorial approval state
+// ---------------------------------------------------------------------------
+
+export type ReviewState = "pending" | "approved" | "rejected" | "expired";
+
+// ---------------------------------------------------------------------------
+// FallbackPolicy — what to air when a block's source is unavailable
+// ---------------------------------------------------------------------------
+
+export interface FallbackPolicy {
+  blockId: string;
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// PlaylistBlock — a single segment in a broadcast playlist
+// ---------------------------------------------------------------------------
+
+export interface PlaylistBlock {
+  id: string;
+  title: string;
+  durationSec: number;
+  freshness: FreshnessClass;
+  fallback: FallbackPolicy;
+  sourceRef?: string;
+  freshnessTimestamp?: string;
+  review?: ReviewState;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// PlaylistManifest — ordered list of blocks for a channel
+// ---------------------------------------------------------------------------
+
+export interface PlaylistManifest {
+  id: string;
+  channelId: string;
+  blocks: PlaylistBlock[];
+  createdAt: string;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// ChannelState — snapshot of a broadcast channel
+// ---------------------------------------------------------------------------
+
+export interface ChannelState {
+  channelId: string;
+  status: "idle" | "on-air" | "error";
+  currentBlockId?: string;
+  manifestId?: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// OnAirBlock / OnAirState — what is currently playing
+// ---------------------------------------------------------------------------
+
+export interface OnAirBlock {
+  blockId: string;
+  startedAt: string;
+  elapsedSec: number;
+  remainingSec: number;
+}
+
+export interface OnAirState {
+  channelId: string;
+  current: OnAirBlock | null;
+  next: OnAirBlock | null;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// DecisionRecord — audit trail for automated broadcast decisions
+// ---------------------------------------------------------------------------
+
+export interface DecisionRecord {
+  id: string;
+  timestamp: string;
+  action: string;
+  reason: string;
+  blockId?: string;
+  agentId?: string;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// AgentRunRecord — record of an agent run that produced broadcast actions
+// ---------------------------------------------------------------------------
+
+export interface AgentRunRecord {
+  id: string;
+  agentId: string;
+  startedAt: string;
+  endedAt?: string;
+  decisions: DecisionRecord[];
+  status: "running" | "completed" | "failed";
+}
+
+// ---------------------------------------------------------------------------
+// HealthSnapshot — point-in-time health of the broadcast pipeline
+// ---------------------------------------------------------------------------
+
+export interface HealthSnapshot {
+  timestamp: string;
+  channelId: string;
+  status: "healthy" | "degraded" | "down";
+  activeBlocks: number;
+  staleSources: number;
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Validation result
+// ---------------------------------------------------------------------------
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Validators — lightweight runtime safety checks
+// ---------------------------------------------------------------------------
+
+/** Every playlist block must have positive duration and a fallback. */
+export function validatePlaylistBlock(block: unknown): ValidationResult {
+  const b = block as Record<string, unknown>;
+
+  if (typeof b?.durationSec !== "number" || b.durationSec <= 0) {
+    return { ok: false, error: "Block must have a positive duration (durationSec > 0)." };
+  }
+
+  if (!b.fallback || typeof b.fallback !== "object") {
+    return { ok: false, error: "Block must have a fallback policy." };
+  }
+
+  return { ok: true };
+}
+
+/** Manifest must have at least one block and positive total duration. */
+export function validatePlaylistManifest(manifest: unknown): ValidationResult {
+  const m = manifest as Record<string, unknown>;
+  const blocks = m?.blocks;
+
+  if (!Array.isArray(blocks) || blocks.length === 0) {
+    return { ok: false, error: "Manifest must contain at least one block." };
+  }
+
+  for (const block of blocks) {
+    const blockResult = validatePlaylistBlock(block);
+    if (!blockResult.ok) return blockResult;
+    const metaResult = validateLiveContentMeta(block);
+    if (!metaResult.ok) return metaResult;
+  }
+
+  const totalDuration = blocks.reduce(
+    (sum: number, b: Record<string, unknown>) => sum + (Number(b.durationSec) || 0),
+    0,
+  );
+  if (totalDuration <= 0) {
+    return { ok: false, error: "Manifest total duration must be positive." };
+  }
+
+  return { ok: true };
+}
+
+/** LIVE and HOT_SYNC content must carry sourceRef and freshnessTimestamp. */
+export function validateLiveContentMeta(block: unknown): ValidationResult {
+  const b = block as Record<string, unknown>;
+  const freshness = b?.freshness as string | undefined;
+
+  if (freshness === "LIVE" || freshness === "HOT_SYNC") {
+    if (!b.sourceRef || typeof b.sourceRef !== "string") {
+      return { ok: false, error: `${freshness} block must have a source reference (sourceRef).` };
+    }
+    if (!b.freshnessTimestamp || typeof b.freshnessTimestamp !== "string") {
+      return { ok: false, error: `${freshness} block must have a freshness timestamp (freshnessTimestamp).` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/test/tv-contracts.test.mjs
+++ b/test/tv-contracts.test.mjs
@@ -1,0 +1,216 @@
+/**
+ * TV Operator Contracts — test suite
+ *
+ * Tests for typed contracts and runtime validators for Machina Sports TV
+ * broadcast operations. Written test-first (TDD).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// Import will fail until src/schema/tv.ts is implemented
+import {
+  // Enums / constants
+  FRESHNESS_CLASSES,
+
+  // Validators
+  validatePlaylistBlock,
+  validatePlaylistManifest,
+  validateLiveContentMeta,
+} from "../dist/schema/tv.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal valid PlaylistBlock */
+function validBlock(overrides = {}) {
+  return {
+    id: "block-1",
+    title: "Halftime Highlights",
+    durationSec: 120,
+    freshness: "FRESH",
+    fallback: { blockId: "block-evergreen-1", reason: "source-down" },
+    sourceRef: "espn:nba:highlights:2024-01-15",
+    ...overrides,
+  };
+}
+
+/** Minimal valid PlaylistManifest */
+function validManifest(overrides = {}) {
+  return {
+    id: "manifest-1",
+    channelId: "machina-tv-1",
+    blocks: [validBlock()],
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FreshnessClass constants
+// ---------------------------------------------------------------------------
+
+describe("FreshnessClass", () => {
+  it("exports exactly the four expected freshness classes", () => {
+    assert.deepStrictEqual(
+      [...FRESHNESS_CLASSES].sort(),
+      ["EVERGREEN", "FRESH", "HOT_SYNC", "LIVE"].sort(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePlaylistBlock
+// ---------------------------------------------------------------------------
+
+describe("validatePlaylistBlock", () => {
+  it("accepts a valid block", () => {
+    const result = validatePlaylistBlock(validBlock());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects block with zero duration", () => {
+    const result = validatePlaylistBlock(validBlock({ durationSec: 0 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("duration"));
+  });
+
+  it("rejects block with negative duration", () => {
+    const result = validatePlaylistBlock(validBlock({ durationSec: -10 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("duration"));
+  });
+
+  it("rejects block without fallback", () => {
+    const block = validBlock();
+    delete block.fallback;
+    const result = validatePlaylistBlock(block);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("fallback"));
+  });
+
+  it("rejects block with null fallback", () => {
+    const result = validatePlaylistBlock(validBlock({ fallback: null }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("fallback"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePlaylistManifest
+// ---------------------------------------------------------------------------
+
+describe("validatePlaylistManifest", () => {
+  it("accepts a valid manifest", () => {
+    const result = validatePlaylistManifest(validManifest());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects manifest with zero blocks", () => {
+    const result = validatePlaylistManifest(validManifest({ blocks: [] }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("block"));
+  });
+
+  it("rejects manifest when a contained block is invalid", () => {
+    const badBlock = validBlock({ durationSec: -1 });
+    const result = validatePlaylistManifest(validManifest({ blocks: [badBlock] }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("duration"));
+  });
+
+  it("rejects manifest whose total duration is zero (all blocks positive is already enforced but manifest-level check)", () => {
+    const result = validatePlaylistManifest(validManifest());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects manifest containing a LIVE block without freshnessTimestamp", () => {
+    const block = validBlock({ freshness: "LIVE", sourceRef: "espn:live:nba" });
+    delete block.freshnessTimestamp;
+    const result = validatePlaylistManifest(validManifest({ blocks: [block] }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("freshness"));
+  });
+
+  it("rejects manifest containing a HOT_SYNC block without sourceRef", () => {
+    const block = validBlock({
+      freshness: "HOT_SYNC",
+      freshnessTimestamp: new Date().toISOString(),
+    });
+    delete block.sourceRef;
+    const result = validatePlaylistManifest(validManifest({ blocks: [block] }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("source"));
+  });
+
+  it("accepts manifest with a valid LIVE block", () => {
+    const block = validBlock({
+      freshness: "LIVE",
+      sourceRef: "espn:live:nba-game-123",
+      freshnessTimestamp: new Date().toISOString(),
+    });
+    const result = validatePlaylistManifest(validManifest({ blocks: [block] }));
+    assert.strictEqual(result.ok, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateLiveContentMeta — LIVE and HOT_SYNC content must carry source + freshnessTimestamp
+// ---------------------------------------------------------------------------
+
+describe("validateLiveContentMeta", () => {
+  it("accepts LIVE block with source and freshnessTimestamp", () => {
+    const block = validBlock({
+      freshness: "LIVE",
+      sourceRef: "espn:live:nba-game-123",
+      freshnessTimestamp: new Date().toISOString(),
+    });
+    const result = validateLiveContentMeta(block);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts HOT_SYNC block with source and freshnessTimestamp", () => {
+    const block = validBlock({
+      freshness: "HOT_SYNC",
+      sourceRef: "espn:hot:scores",
+      freshnessTimestamp: new Date().toISOString(),
+    });
+    const result = validateLiveContentMeta(block);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects LIVE block without freshnessTimestamp", () => {
+    const block = validBlock({ freshness: "LIVE", sourceRef: "espn:live:nba" });
+    delete block.freshnessTimestamp;
+    const result = validateLiveContentMeta(block);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("freshness"));
+  });
+
+  it("rejects HOT_SYNC block without sourceRef", () => {
+    const block = validBlock({
+      freshness: "HOT_SYNC",
+      freshnessTimestamp: new Date().toISOString(),
+    });
+    delete block.sourceRef;
+    const result = validateLiveContentMeta(block);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("source"));
+  });
+
+  it("allows FRESH block without freshnessTimestamp (not required)", () => {
+    const block = validBlock({ freshness: "FRESH" });
+    delete block.freshnessTimestamp;
+    const result = validateLiveContentMeta(block);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("allows EVERGREEN block without sourceRef or freshnessTimestamp", () => {
+    const block = validBlock({ freshness: "EVERGREEN" });
+    delete block.sourceRef;
+    delete block.freshnessTimestamp;
+    const result = validateLiveContentMeta(block);
+    assert.strictEqual(result.ok, true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add reusable TV operator data contracts
- Add lightweight runtime validators for playlist duration, fallback presence, manifest validity, and live/hot source freshness metadata
- Export the contracts from the public package entrypoint
- Add an npm script for the contract tests

## Test Plan
- npm run test:tv-contracts