### PR TITLE
feat: add operator health snapshot utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "docker:build": "docker build -t sportsclaw .",
     "docker:run": "docker run --rm --env-file .env sportsclaw",
     "test:version": "npm run build && node --test test/version-help.test.mjs",
-    "test:tv-contracts": "npm run build && node --test test/tv-contracts.test.mjs"
+    "test:tv-contracts": "npm run build && node --test test/tv-contracts.test.mjs",
+    "test:operator-health": "npm run build && node --test test/operator-health.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,9 +268,11 @@ export type { DaemonPlatform } from "./daemon.js";
 // AI-native setup wizard
 export { runSetup } from "./setup.js";
 
-// TV Operator Contracts (Machina Sports TV)
+// TV Operator Contracts
 export {
   FRESHNESS_CLASSES,
+  buildHealthSnapshot,
+  validateHealthSnapshot,
   validatePlaylistBlock,
   validatePlaylistManifest,
   validateLiveContentMeta,
@@ -287,6 +289,7 @@ export type {
   DecisionRecord,
   AgentRunRecord,
   HealthSnapshot,
+  HealthSnapshotInput,
   ValidationResult,
 } from "./schema/tv.js";
 

--- a/src/schema/tv.ts
+++ b/src/schema/tv.ts
@@ -1,5 +1,5 @@
 /**
- * sportsclaw — TV Operator Contracts (Machina Sports TV)
+ * sportsclaw — TV Operator Contracts
  *
  * Typed contracts and lightweight runtime validators for broadcast operations.
  * These are data-only definitions — no engine wiring or behavior.
@@ -138,6 +138,76 @@ export interface HealthSnapshot {
 export type ValidationResult =
   | { ok: true }
   | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// HealthSnapshot input (omits derived status)
+// ---------------------------------------------------------------------------
+
+export type HealthSnapshotInput = Omit<HealthSnapshot, "status">;
+
+// ---------------------------------------------------------------------------
+// buildHealthSnapshot — derive status from input signals
+// ---------------------------------------------------------------------------
+
+const DOWN_KEYWORDS = /\bcritical\b|\bdown\b/i;
+
+export function buildHealthSnapshot(input: HealthSnapshotInput): HealthSnapshot {
+  const { timestamp, channelId, activeBlocks, staleSources, errors } = input;
+
+  let status: HealthSnapshot["status"];
+
+  const hasCriticalError = errors.some((e) => DOWN_KEYWORDS.test(e));
+
+  if (activeBlocks === 0 || hasCriticalError) {
+    status = "down";
+  } else if (staleSources > 0 || errors.length > 0) {
+    status = "degraded";
+  } else {
+    status = "healthy";
+  }
+
+  return { timestamp, channelId, status, activeBlocks, staleSources, errors };
+}
+
+// ---------------------------------------------------------------------------
+// validateHealthSnapshot — runtime validation
+// ---------------------------------------------------------------------------
+
+const VALID_STATUSES = new Set(["healthy", "degraded", "down"]);
+
+export function validateHealthSnapshot(snapshot: unknown): ValidationResult {
+  if (!snapshot || typeof snapshot !== "object") {
+    return { ok: false, error: "Snapshot must be a non-null object." };
+  }
+
+  const s = snapshot as Record<string, unknown>;
+
+  if (typeof s.timestamp !== "string" || s.timestamp === "") {
+    return { ok: false, error: "Snapshot must have a non-empty timestamp." };
+  }
+
+  if (typeof s.channelId !== "string" || s.channelId === "") {
+    return { ok: false, error: "Snapshot must have a non-empty channelId." };
+  }
+
+  if (!VALID_STATUSES.has(s.status as string)) {
+    return { ok: false, error: "Snapshot status must be healthy, degraded, or down." };
+  }
+
+  if (typeof s.activeBlocks !== "number" || s.activeBlocks < 0) {
+    return { ok: false, error: "Snapshot activeBlocks must be a non-negative number." };
+  }
+
+  if (typeof s.staleSources !== "number" || s.staleSources < 0) {
+    return { ok: false, error: "Snapshot staleSources must be a non-negative number." };
+  }
+
+  if (!Array.isArray(s.errors)) {
+    return { ok: false, error: "Snapshot errors must be an array." };
+  }
+
+  return { ok: true };
+}
 
 // ---------------------------------------------------------------------------
 // Validators — lightweight runtime safety checks

--- a/test/operator-health.test.mjs
+++ b/test/operator-health.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * Operator Health Snapshot — test suite
+ *
+ * Tests for buildHealthSnapshot and validateHealthSnapshot utilities.
+ * Written test-first (TDD).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildHealthSnapshot,
+  validateHealthSnapshot,
+} from "../dist/schema/tv.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validInput(overrides = {}) {
+  return {
+    timestamp: "2026-05-06T12:00:00.000Z",
+    channelId: "channel-1",
+    activeBlocks: 3,
+    staleSources: 0,
+    errors: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildHealthSnapshot — status derivation
+// ---------------------------------------------------------------------------
+
+describe("buildHealthSnapshot", () => {
+  it("returns healthy when errors=0 and staleSources=0", () => {
+    const snap = buildHealthSnapshot(validInput());
+    assert.strictEqual(snap.status, "healthy");
+    assert.strictEqual(snap.channelId, "channel-1");
+    assert.strictEqual(snap.activeBlocks, 3);
+    assert.strictEqual(snap.staleSources, 0);
+    assert.deepStrictEqual(snap.errors, []);
+    assert.strictEqual(snap.timestamp, "2026-05-06T12:00:00.000Z");
+  });
+
+  it("returns degraded when staleSources > 0", () => {
+    const snap = buildHealthSnapshot(validInput({ staleSources: 2 }));
+    assert.strictEqual(snap.status, "degraded");
+  });
+
+  it("returns degraded when non-critical errors exist", () => {
+    const snap = buildHealthSnapshot(
+      validInput({ errors: ["timeout fetching scores"] }),
+    );
+    assert.strictEqual(snap.status, "degraded");
+  });
+
+  it("returns down when activeBlocks = 0", () => {
+    const snap = buildHealthSnapshot(validInput({ activeBlocks: 0 }));
+    assert.strictEqual(snap.status, "down");
+  });
+
+  it("returns down when errors contain a critical keyword", () => {
+    const snap = buildHealthSnapshot(
+      validInput({ errors: ["CRITICAL: pipeline failure"] }),
+    );
+    assert.strictEqual(snap.status, "down");
+  });
+
+  it("returns down when errors contain a down keyword", () => {
+    const snap = buildHealthSnapshot(
+      validInput({ errors: ["source is DOWN"] }),
+    );
+    assert.strictEqual(snap.status, "down");
+  });
+
+  it("down takes precedence over degraded signals", () => {
+    const snap = buildHealthSnapshot(
+      validInput({ staleSources: 1, activeBlocks: 0 }),
+    );
+    assert.strictEqual(snap.status, "down");
+  });
+
+  it("passes through all input fields", () => {
+    const snap = buildHealthSnapshot(validInput({
+      timestamp: "2026-01-01T00:00:00Z",
+      channelId: "ch-42",
+      activeBlocks: 7,
+      staleSources: 1,
+      errors: ["stale cache"],
+    }));
+    assert.strictEqual(snap.timestamp, "2026-01-01T00:00:00Z");
+    assert.strictEqual(snap.channelId, "ch-42");
+    assert.strictEqual(snap.activeBlocks, 7);
+    assert.strictEqual(snap.staleSources, 1);
+    assert.deepStrictEqual(snap.errors, ["stale cache"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateHealthSnapshot
+// ---------------------------------------------------------------------------
+
+describe("validateHealthSnapshot", () => {
+  it("accepts a valid snapshot", () => {
+    const snap = buildHealthSnapshot(validInput());
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects missing timestamp", () => {
+    const snap = buildHealthSnapshot(validInput());
+    delete snap.timestamp;
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("timestamp"));
+  });
+
+  it("rejects empty string timestamp", () => {
+    const snap = { ...buildHealthSnapshot(validInput()), timestamp: "" };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("timestamp"));
+  });
+
+  it("rejects missing channelId", () => {
+    const snap = buildHealthSnapshot(validInput());
+    delete snap.channelId;
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("channelid"));
+  });
+
+  it("rejects empty string channelId", () => {
+    const snap = { ...buildHealthSnapshot(validInput()), channelId: "" };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("channelid"));
+  });
+
+  it("rejects invalid status", () => {
+    const snap = { ...buildHealthSnapshot(validInput()), status: "unknown" };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("status"));
+  });
+
+  it("rejects negative activeBlocks", () => {
+    const snap = { ...buildHealthSnapshot(validInput()), activeBlocks: -1 };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("activeblocks"));
+  });
+
+  it("rejects negative staleSources", () => {
+    const snap = { ...buildHealthSnapshot(validInput()), staleSources: -1 };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("stalesources"));
+  });
+
+  it("rejects errors that is not an array", () => {
+    const snap = { ...buildHealthSnapshot(validInput()), errors: "not-array" };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("errors"));
+  });
+
+  it("rejects null input", () => {
+    const result = validateHealthSnapshot(null);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("rejects undefined input", () => {
+    const result = validateHealthSnapshot(undefined);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("accepts activeBlocks = 0 as valid (validator only checks non-negative)", () => {
+    const snap = { ...buildHealthSnapshot(validInput({ activeBlocks: 0 })) };
+    const result = validateHealthSnapshot(snap);
+    assert.strictEqual(result.ok, true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add helpers for building operator health snapshots
- Add runtime validation for health snapshot shape and status fields
- Export the new helpers from the package entrypoint
- Add a focused npm test script

## Test Plan
- npm run test:operator-health
- npm run test:version
- npm run test:tv-contracts