### PR TITLE
feat: add decision ledger primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sportsclaw ships with **14 sports data skills** out of the box, powered by [`spo
 
 ### Inspiration & Acknowledgements
 
-sportsclaw's execution engine draws direct inspiration from [NanoClaw](https://github.com/qwibitai/nanoclaw/), [pi.dev](https://pi.dev), and [OpenClaw](https://github.com/anthropics/openclaw). Built on the [Vercel AI SDK](https://sdk.vercel.ai) for multi-provider LLM support. The interactive CLI setup and reasoning spinner are powered by [@clack/prompts](https://github.com/natemoo-re/clack).
+sportsclaw's execution engine draws direct inspiration from [NanoClaw](https://github.com/qwibitai/nanoclaw/), [pi.dev](https://pi.dev), [OpenClaw](https://github.com/anthropics/openclaw), and [NemoClaw](https://github.com/NVIDIA/NemoClaw). Built on the [Vercel AI SDK](https://sdk.vercel.ai) for multi-provider LLM support. The interactive CLI setup and reasoning spinner are powered by [@clack/prompts](https://github.com/natemoo-re/clack).
 
 ### Questions?
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "docker:run": "docker run --rm --env-file .env sportsclaw",
     "test:version": "npm run build && node --test test/version-help.test.mjs",
     "test:tv-contracts": "npm run build && node --test test/tv-contracts.test.mjs",
-    "test:operator-health": "npm run build && node --test test/operator-health.test.mjs"
+    "test:operator-health": "npm run build && node --test test/operator-health.test.mjs",
+    "test:decision-ledger": "npm run build && node --test test/decision-ledger.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/decision-ledger.ts
+++ b/src/decision-ledger.ts
@@ -1,0 +1,116 @@
+/**
+ * Decision Ledger Primitives
+ *
+ * Append-only JSONL ledger for recording structured decision records.
+ * Data-only utilities — no engine wiring or behavior.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { DecisionRecord, ValidationResult } from "./schema/tv.js";
+
+// ---------------------------------------------------------------------------
+// validateDecisionRecord
+// ---------------------------------------------------------------------------
+
+const REQUIRED_STRING_FIELDS = ["id", "timestamp", "action", "reason"] as const;
+
+export function validateDecisionRecord(record: unknown): ValidationResult {
+  if (!record || typeof record !== "object") {
+    return { ok: false, error: "Record must be a non-null object." };
+  }
+
+  const r = record as Record<string, unknown>;
+
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (typeof r[field] !== "string" || r[field] === "") {
+      return { ok: false, error: `Record must have a non-empty ${field}.` };
+    }
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// serializeDecisionRecord
+// ---------------------------------------------------------------------------
+
+export function serializeDecisionRecord(record: DecisionRecord): string {
+  return JSON.stringify(record) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// parseDecisionRecordLine
+// ---------------------------------------------------------------------------
+
+export function parseDecisionRecordLine(line: string): DecisionRecord {
+  const trimmed = line.trim();
+  if (trimmed === "") {
+    throw new Error("Invalid JSON: empty line.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("Invalid JSON: could not parse line.");
+  }
+  const result = validateDecisionRecord(parsed);
+  if (!result.ok) {
+    throw new Error(`Invalid decision record: ${result.error}`);
+  }
+  return parsed as DecisionRecord;
+}
+
+// ---------------------------------------------------------------------------
+// appendDecisionRecord
+// ---------------------------------------------------------------------------
+
+export async function appendDecisionRecord(
+  filePath: string,
+  record: DecisionRecord,
+): Promise<void> {
+  const result = validateDecisionRecord(record);
+  if (!result.ok) {
+    throw new Error(`Invalid decision record: ${result.error}`);
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, serializeDecisionRecord(record), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// readDecisionLedger
+// ---------------------------------------------------------------------------
+
+export async function readDecisionLedger(
+  filePath: string,
+): Promise<DecisionRecord[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (err: any) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+
+  return content
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map(parseDecisionRecordLine);
+}
+
+// ---------------------------------------------------------------------------
+// readLatestDecisionRecords
+// ---------------------------------------------------------------------------
+
+export async function readLatestDecisionRecords(
+  filePath: string,
+  limit: number,
+): Promise<DecisionRecord[]> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("Limit must be a positive integer.");
+  }
+
+  const all = await readDecisionLedger(filePath);
+  return all.slice(-limit);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,6 +293,16 @@ export type {
   ValidationResult,
 } from "./schema/tv.js";
 
+// Decision Ledger Primitives
+export {
+  validateDecisionRecord,
+  serializeDecisionRecord,
+  parseDecisionRecordLine,
+  appendDecisionRecord,
+  readDecisionLedger,
+  readLatestDecisionRecords,
+} from "./decision-ledger.js";
+
 // ---------------------------------------------------------------------------
 // Markdown terminal renderer
 // ---------------------------------------------------------------------------

--- a/test/decision-ledger.test.mjs
+++ b/test/decision-ledger.test.mjs
@@ -1,0 +1,373 @@
+/**
+ * Decision Ledger Primitives — test suite
+ *
+ * Tests for append-only JSONL decision ledger utilities.
+ * Written test-first (TDD).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  validateDecisionRecord,
+  serializeDecisionRecord,
+  parseDecisionRecordLine,
+  appendDecisionRecord,
+  readDecisionLedger,
+  readLatestDecisionRecords,
+} from "../dist/decision-ledger.js";
+
+import * as publicEntry from "../dist/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validRecord(overrides = {}) {
+  return {
+    id: "rec-001",
+    timestamp: "2026-05-06T12:00:00.000Z",
+    action: "swap-block",
+    reason: "Source went stale",
+    ...overrides,
+  };
+}
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// validateDecisionRecord
+// ---------------------------------------------------------------------------
+
+describe("validateDecisionRecord", () => {
+  it("accepts a valid minimal record", () => {
+    const result = validateDecisionRecord(validRecord());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts a record with all optional fields", () => {
+    const result = validateDecisionRecord(
+      validRecord({ blockId: "blk-1", agentId: "agent-7", meta: { foo: 1 } }),
+    );
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects null", () => {
+    const result = validateDecisionRecord(null);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("rejects undefined", () => {
+    const result = validateDecisionRecord(undefined);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("rejects missing id", () => {
+    const { id, ...rest } = validRecord();
+    const result = validateDecisionRecord(rest);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("id"));
+  });
+
+  it("rejects empty id", () => {
+    const result = validateDecisionRecord(validRecord({ id: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("id"));
+  });
+
+  it("rejects missing timestamp", () => {
+    const { timestamp, ...rest } = validRecord();
+    const result = validateDecisionRecord(rest);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("timestamp"));
+  });
+
+  it("rejects empty timestamp", () => {
+    const result = validateDecisionRecord(validRecord({ timestamp: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("timestamp"));
+  });
+
+  it("rejects missing action", () => {
+    const { action, ...rest } = validRecord();
+    const result = validateDecisionRecord(rest);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("action"));
+  });
+
+  it("rejects empty action", () => {
+    const result = validateDecisionRecord(validRecord({ action: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("action"));
+  });
+
+  it("rejects missing reason", () => {
+    const { reason, ...rest } = validRecord();
+    const result = validateDecisionRecord(rest);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("reason"));
+  });
+
+  it("rejects empty reason", () => {
+    const result = validateDecisionRecord(validRecord({ reason: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("reason"));
+  });
+
+  it("rejects non-string id", () => {
+    const result = validateDecisionRecord(validRecord({ id: 123 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.toLowerCase().includes("id"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeDecisionRecord
+// ---------------------------------------------------------------------------
+
+describe("serializeDecisionRecord", () => {
+  it("produces a single line of JSON with a trailing newline", () => {
+    const line = serializeDecisionRecord(validRecord());
+    assert.ok(!line.includes("\n") || line.indexOf("\n") === line.length - 1);
+    assert.ok(line.endsWith("\n"));
+  });
+
+  it("round-trips through JSON.parse", () => {
+    const rec = validRecord({ blockId: "blk-1", meta: { x: 42 } });
+    const line = serializeDecisionRecord(rec);
+    const parsed = JSON.parse(line);
+    assert.deepStrictEqual(parsed, rec);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDecisionRecordLine
+// ---------------------------------------------------------------------------
+
+describe("parseDecisionRecordLine", () => {
+  it("parses a valid JSON line", () => {
+    const rec = validRecord();
+    const line = JSON.stringify(rec);
+    const parsed = parseDecisionRecordLine(line);
+    assert.deepStrictEqual(parsed, rec);
+  });
+
+  it("parses a line with trailing newline", () => {
+    const rec = validRecord();
+    const line = JSON.stringify(rec) + "\n";
+    const parsed = parseDecisionRecordLine(line);
+    assert.deepStrictEqual(parsed, rec);
+  });
+
+  it("throws on invalid JSON", () => {
+    assert.throws(() => parseDecisionRecordLine("{not json"), {
+      message: /invalid json/i,
+    });
+  });
+
+  it("throws on empty line", () => {
+    assert.throws(() => parseDecisionRecordLine(""), {
+      message: /invalid json|empty/i,
+    });
+  });
+
+  it("throws on whitespace-only line", () => {
+    assert.throws(() => parseDecisionRecordLine("   "), {
+      message: /invalid json|empty/i,
+    });
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// appendDecisionRecord
+// ---------------------------------------------------------------------------
+
+describe("appendDecisionRecord", () => {
+  it("creates file and parent dirs if they do not exist", async () => {
+    const filePath = path.join(tmpDir, "sub", "dir", "ledger.jsonl");
+    await appendDecisionRecord(filePath, validRecord());
+    assert.ok(fs.existsSync(filePath));
+  });
+
+  it("appends multiple records as separate lines", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    await appendDecisionRecord(filePath, validRecord({ id: "r1" }));
+    await appendDecisionRecord(filePath, validRecord({ id: "r2" }));
+    const lines = fs.readFileSync(filePath, "utf-8").trimEnd().split("\n");
+    assert.strictEqual(lines.length, 2);
+    assert.strictEqual(JSON.parse(lines[0]).id, "r1");
+    assert.strictEqual(JSON.parse(lines[1]).id, "r2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readDecisionLedger
+// ---------------------------------------------------------------------------
+
+describe("readDecisionLedger", () => {
+  it("returns empty array for missing file", async () => {
+    const filePath = path.join(tmpDir, "nope.jsonl");
+    const records = await readDecisionLedger(filePath);
+    assert.deepStrictEqual(records, []);
+  });
+
+  it("reads all records in order", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    await appendDecisionRecord(filePath, validRecord({ id: "a" }));
+    await appendDecisionRecord(filePath, validRecord({ id: "b" }));
+    await appendDecisionRecord(filePath, validRecord({ id: "c" }));
+    const records = await readDecisionLedger(filePath);
+    assert.strictEqual(records.length, 3);
+    assert.strictEqual(records[0].id, "a");
+    assert.strictEqual(records[1].id, "b");
+    assert.strictEqual(records[2].id, "c");
+  });
+
+  it("skips trailing empty lines", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    const line = JSON.stringify(validRecord()) + "\n\n";
+    fs.writeFileSync(filePath, line);
+    const records = await readDecisionLedger(filePath);
+    assert.strictEqual(records.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readLatestDecisionRecords
+// ---------------------------------------------------------------------------
+
+describe("readLatestDecisionRecords", () => {
+  it("returns last N records in ledger order", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    for (const id of ["a", "b", "c", "d", "e"]) {
+      await appendDecisionRecord(filePath, validRecord({ id }));
+    }
+    const latest = await readLatestDecisionRecords(filePath, 3);
+    assert.strictEqual(latest.length, 3);
+    assert.strictEqual(latest[0].id, "c");
+    assert.strictEqual(latest[1].id, "d");
+    assert.strictEqual(latest[2].id, "e");
+  });
+
+  it("returns all records when limit exceeds count", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    await appendDecisionRecord(filePath, validRecord({ id: "only" }));
+    const latest = await readLatestDecisionRecords(filePath, 10);
+    assert.strictEqual(latest.length, 1);
+    assert.strictEqual(latest[0].id, "only");
+  });
+
+  it("returns empty array for missing file", async () => {
+    const filePath = path.join(tmpDir, "nope.jsonl");
+    const latest = await readLatestDecisionRecords(filePath, 5);
+    assert.deepStrictEqual(latest, []);
+  });
+
+  it("throws on non-positive limit", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    await assert.rejects(() => readLatestDecisionRecords(filePath, 0), {
+      message: /positive/i,
+    });
+    await assert.rejects(() => readLatestDecisionRecords(filePath, -1), {
+      message: /positive/i,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public entrypoint exports
+// ---------------------------------------------------------------------------
+
+describe("public entrypoint exports", () => {
+  it("re-exports all decision ledger utilities from the package entrypoint", () => {
+    assert.strictEqual(typeof publicEntry.validateDecisionRecord, "function");
+    assert.strictEqual(typeof publicEntry.serializeDecisionRecord, "function");
+    assert.strictEqual(typeof publicEntry.parseDecisionRecordLine, "function");
+    assert.strictEqual(typeof publicEntry.appendDecisionRecord, "function");
+    assert.strictEqual(typeof publicEntry.readDecisionLedger, "function");
+    assert.strictEqual(typeof publicEntry.readLatestDecisionRecords, "function");
+  });
+
+  it("entrypoint utilities behave the same as direct imports", () => {
+    const directResult = validateDecisionRecord(validRecord());
+    const entryResult = publicEntry.validateDecisionRecord(validRecord());
+    assert.deepStrictEqual(directResult, entryResult);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendDecisionRecord — validation gate
+// ---------------------------------------------------------------------------
+
+describe("appendDecisionRecord validation", () => {
+  it("rejects an invalid record before writing", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    const bad = { id: "", timestamp: "t", action: "a", reason: "r" };
+    await assert.rejects(() => appendDecisionRecord(filePath, bad), {
+      message: /id|invalid|non-empty/i,
+    });
+    assert.strictEqual(fs.existsSync(filePath), false);
+  });
+
+  it("rejects null record without creating the file", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    await assert.rejects(() => appendDecisionRecord(filePath, null));
+    assert.strictEqual(fs.existsSync(filePath), false);
+  });
+
+  it("does not create parent dirs when validation fails", async () => {
+    const filePath = path.join(tmpDir, "nested", "dir", "ledger.jsonl");
+    const bad = { id: "x", timestamp: "t", action: "a" };
+    await assert.rejects(() => appendDecisionRecord(filePath, bad));
+    assert.strictEqual(fs.existsSync(path.join(tmpDir, "nested")), false);
+  });
+
+  it("preserves prior content when a later append is rejected", async () => {
+    const filePath = path.join(tmpDir, "ledger.jsonl");
+    await appendDecisionRecord(filePath, validRecord({ id: "ok-1" }));
+    const bad = { id: "x", timestamp: "t", action: "a" };
+    await assert.rejects(() => appendDecisionRecord(filePath, bad));
+    const records = await readDecisionLedger(filePath);
+    assert.strictEqual(records.length, 1);
+    assert.strictEqual(records[0].id, "ok-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDecisionRecordLine — validation gate
+// ---------------------------------------------------------------------------
+
+describe("parseDecisionRecordLine validation", () => {
+  it("throws a clear Error when JSON is valid but record fails validation", () => {
+    const badRecord = { id: "", timestamp: "t", action: "a", reason: "r" };
+    const line = JSON.stringify(badRecord);
+    assert.throws(() => parseDecisionRecordLine(line), {
+      message: /invalid decision record|non-empty|id/i,
+    });
+  });
+
+  it("throws when required fields are missing entirely", () => {
+    const line = JSON.stringify({ id: "x", timestamp: "t" });
+    assert.throws(() => parseDecisionRecordLine(line), {
+      message: /invalid decision record|action|reason/i,
+    });
+  });
+
+  it("still throws JSON-shaped error for malformed JSON (validation not reached)", () => {
+    assert.throws(() => parseDecisionRecordLine("{not json"), {
+      message: /invalid json/i,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add append-only JSONL decision ledger utilities
- Add validation, serialization, parsing, append, read, and latest-read helpers
- Export the utilities from the package entrypoint
- Add a focused npm test script

## Test Plan
- npm run test:decision-ledger
- npm run test:operator-health
- npm run test:version
- npm run test:tv-contracts
- npm run build