### PR TITLE
feat: add operator run record primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:tv-contracts": "npm run build && node --test test/tv-contracts.test.mjs",
     "test:operator-health": "npm run build && node --test test/operator-health.test.mjs",
     "test:decision-ledger": "npm run build && node --test test/decision-ledger.test.mjs",
-    "test:manifest-coverage": "npm run build && node --test test/manifest-coverage.test.mjs"
+    "test:manifest-coverage": "npm run build && node --test test/manifest-coverage.test.mjs",
+    "test:operator-runs": "npm run build && node --test test/operator-runs.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,16 @@ export {
   readLatestDecisionRecords,
 } from "./decision-ledger.js";
 
+// Operator Run Record Primitives
+export {
+  validateAgentRunRecord,
+  serializeAgentRunRecord,
+  parseAgentRunRecordLine,
+  appendAgentRunRecord,
+  readAgentRunLedger,
+  readLatestAgentRunRecords,
+} from "./operator-runs.js";
+
 // ---------------------------------------------------------------------------
 // Markdown terminal renderer
 // ---------------------------------------------------------------------------

--- a/src/operator-runs.ts
+++ b/src/operator-runs.ts
@@ -1,0 +1,167 @@
+/**
+ * Operator Run Record Primitives
+ *
+ * Append-only JSONL ledger for recording structured agent/operator run records.
+ * Data-only utilities — no engine wiring or behavior.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { AgentRunRecord, ValidationResult } from "./schema/tv.js";
+import { validateDecisionRecord } from "./decision-ledger.js";
+
+// ---------------------------------------------------------------------------
+// validateAgentRunRecord
+// ---------------------------------------------------------------------------
+
+const REQUIRED_STRING_FIELDS = ["id", "agentId", "startedAt"] as const;
+const VALID_STATUSES = new Set(["running", "completed", "failed"]);
+
+function isValidDateString(value: string): boolean {
+  return Number.isFinite(Date.parse(value));
+}
+
+export function validateAgentRunRecord(record: unknown): ValidationResult {
+  if (!record || typeof record !== "object") {
+    return { ok: false, error: "Record must be a non-null object." };
+  }
+
+  const r = record as Record<string, unknown>;
+
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (typeof r[field] !== "string" || r[field] === "") {
+      return { ok: false, error: `Record must have a non-empty ${field}.` };
+    }
+  }
+
+  if (!isValidDateString(r.startedAt as string)) {
+    return { ok: false, error: "Record startedAt must be a valid date string." };
+  }
+
+  if (typeof r.status !== "string" || !VALID_STATUSES.has(r.status)) {
+    return { ok: false, error: "Record status must be running, completed, or failed." };
+  }
+
+  if (!Array.isArray(r.decisions)) {
+    return { ok: false, error: "Record decisions must be an array." };
+  }
+
+  for (let i = 0; i < r.decisions.length; i += 1) {
+    const decisionResult = validateDecisionRecord(r.decisions[i]);
+    if (!decisionResult.ok) {
+      return {
+        ok: false,
+        error: `Record decisions[${i}] is invalid: ${decisionResult.error}`,
+      };
+    }
+  }
+
+  if (r.status === "completed" || r.status === "failed") {
+    if (typeof r.endedAt !== "string" || r.endedAt === "") {
+      return {
+        ok: false,
+        error: "Record must have a non-empty endedAt when status is completed or failed.",
+      };
+    }
+  }
+
+  if (r.endedAt !== undefined) {
+    if (typeof r.endedAt !== "string" || r.endedAt === "") {
+      return { ok: false, error: "Record endedAt must be a valid date string." };
+    }
+    if (!isValidDateString(r.endedAt)) {
+      return { ok: false, error: "Record endedAt must be a valid date string." };
+    }
+    if (Date.parse(r.endedAt) < Date.parse(r.startedAt as string)) {
+      return { ok: false, error: "Record endedAt must be greater than or equal to startedAt." };
+    }
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// serializeAgentRunRecord
+// ---------------------------------------------------------------------------
+
+export function serializeAgentRunRecord(record: AgentRunRecord): string {
+  return JSON.stringify(record) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// parseAgentRunRecordLine
+// ---------------------------------------------------------------------------
+
+export function parseAgentRunRecordLine(line: string): AgentRunRecord {
+  const trimmed = line.trim();
+  if (trimmed === "") {
+    throw new Error("Invalid JSON: empty line.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("Invalid JSON: could not parse line.");
+  }
+
+  const result = validateAgentRunRecord(parsed);
+  if (!result.ok) {
+    throw new Error(`Invalid agent run record: ${result.error}`);
+  }
+
+  return parsed as AgentRunRecord;
+}
+
+// ---------------------------------------------------------------------------
+// appendAgentRunRecord
+// ---------------------------------------------------------------------------
+
+export async function appendAgentRunRecord(
+  filePath: string,
+  record: AgentRunRecord,
+): Promise<void> {
+  const result = validateAgentRunRecord(record);
+  if (!result.ok) {
+    throw new Error(`Invalid agent run record: ${result.error}`);
+  }
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, serializeAgentRunRecord(record), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// readAgentRunLedger
+// ---------------------------------------------------------------------------
+
+export async function readAgentRunLedger(filePath: string): Promise<AgentRunRecord[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (err: any) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+
+  return content
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map(parseAgentRunRecordLine);
+}
+
+// ---------------------------------------------------------------------------
+// readLatestAgentRunRecords
+// ---------------------------------------------------------------------------
+
+export async function readLatestAgentRunRecords(
+  filePath: string,
+  limit: number,
+): Promise<AgentRunRecord[]> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("Limit must be a positive integer.");
+  }
+
+  const all = await readAgentRunLedger(filePath);
+  return all.slice(-limit);
+}

--- a/test/operator-runs.test.mjs
+++ b/test/operator-runs.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  appendAgentRunRecord,
+  parseAgentRunRecordLine,
+  readAgentRunLedger,
+  readLatestAgentRunRecords,
+  serializeAgentRunRecord,
+  validateAgentRunRecord,
+} from "../dist/index.js";
+
+const validDecision = {
+  id: "decision-1",
+  timestamp: "2026-05-06T22:00:00.000Z",
+  action: "select-next-block",
+  reason: "scheduled block is ready",
+};
+
+const validRun = {
+  id: "run-1",
+  agentId: "agent-1",
+  startedAt: "2026-05-06T22:00:00.000Z",
+  endedAt: "2026-05-06T22:01:30.000Z",
+  decisions: [validDecision],
+  status: "completed",
+};
+
+async function tempFile() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "sportsclaw-runs-"));
+  return path.join(dir, "runs.jsonl");
+}
+
+test("validateAgentRunRecord accepts a valid completed run", () => {
+  assert.deepEqual(validateAgentRunRecord(validRun), { ok: true });
+});
+
+test("validateAgentRunRecord accepts a running run without endedAt", () => {
+  assert.deepEqual(
+    validateAgentRunRecord({ ...validRun, status: "running", endedAt: undefined }),
+    { ok: true },
+  );
+});
+
+test("validateAgentRunRecord rejects non-object values", () => {
+  assert.deepEqual(validateAgentRunRecord(null), {
+    ok: false,
+    error: "Record must be a non-null object.",
+  });
+});
+
+test("validateAgentRunRecord requires id, agentId, and startedAt", () => {
+  for (const field of ["id", "agentId", "startedAt"]) {
+    const record = { ...validRun, [field]: "" };
+    assert.deepEqual(validateAgentRunRecord(record), {
+      ok: false,
+      error: `Record must have a non-empty ${field}.`,
+    });
+  }
+});
+
+test("validateAgentRunRecord rejects unknown status values", () => {
+  assert.deepEqual(validateAgentRunRecord({ ...validRun, status: "queued" }), {
+    ok: false,
+    error: "Record status must be running, completed, or failed.",
+  });
+});
+
+test("validateAgentRunRecord requires decisions to be an array", () => {
+  assert.deepEqual(validateAgentRunRecord({ ...validRun, decisions: {} }), {
+    ok: false,
+    error: "Record decisions must be an array.",
+  });
+});
+
+test("validateAgentRunRecord rejects invalid decision records", () => {
+  assert.deepEqual(
+    validateAgentRunRecord({ ...validRun, decisions: [{ ...validDecision, reason: "" }] }),
+    {
+      ok: false,
+      error: "Record decisions[0] is invalid: Record must have a non-empty reason.",
+    },
+  );
+});
+
+test("validateAgentRunRecord requires endedAt when status is completed", () => {
+  assert.deepEqual(validateAgentRunRecord({ ...validRun, endedAt: undefined }), {
+    ok: false,
+    error: "Record must have a non-empty endedAt when status is completed or failed.",
+  });
+});
+
+test("validateAgentRunRecord requires endedAt when status is failed", () => {
+  assert.deepEqual(validateAgentRunRecord({ ...validRun, status: "failed", endedAt: "" }), {
+    ok: false,
+    error: "Record must have a non-empty endedAt when status is completed or failed.",
+  });
+});
+
+test("validateAgentRunRecord rejects endedAt before startedAt", () => {
+  assert.deepEqual(
+    validateAgentRunRecord({
+      ...validRun,
+      startedAt: "2026-05-06T22:02:00.000Z",
+      endedAt: "2026-05-06T22:01:00.000Z",
+    }),
+    {
+      ok: false,
+      error: "Record endedAt must be greater than or equal to startedAt.",
+    },
+  );
+});
+
+test("serializeAgentRunRecord returns newline-delimited JSON", () => {
+  assert.equal(serializeAgentRunRecord(validRun), `${JSON.stringify(validRun)}\n`);
+});
+
+test("parseAgentRunRecordLine parses valid JSONL", () => {
+  assert.deepEqual(parseAgentRunRecordLine(JSON.stringify(validRun)), validRun);
+});
+
+test("parseAgentRunRecordLine rejects empty lines", () => {
+  assert.throws(() => parseAgentRunRecordLine("   "), /Invalid JSON: empty line\./);
+});
+
+test("parseAgentRunRecordLine rejects malformed JSON", () => {
+  assert.throws(() => parseAgentRunRecordLine("{"), /Invalid JSON: could not parse line\./);
+});
+
+test("parseAgentRunRecordLine rejects parsed records with invalid shape", () => {
+  assert.throws(
+    () => parseAgentRunRecordLine(JSON.stringify({ ...validRun, agentId: "" })),
+    /Invalid agent run record: Record must have a non-empty agentId\./,
+  );
+});
+
+test("appendAgentRunRecord writes valid JSONL and creates parent directories", async () => {
+  const filePath = await tempFile();
+  await appendAgentRunRecord(filePath, validRun);
+  await appendAgentRunRecord(filePath, { ...validRun, id: "run-2" });
+
+  const content = await fs.readFile(filePath, "utf-8");
+  assert.equal(content.split("\n").filter(Boolean).length, 2);
+  assert.deepEqual(await readAgentRunLedger(filePath), [validRun, { ...validRun, id: "run-2" }]);
+});
+
+test("appendAgentRunRecord rejects invalid records before writing", async () => {
+  const filePath = await tempFile();
+  await assert.rejects(
+    () => appendAgentRunRecord(filePath, { ...validRun, id: "" }),
+    /Invalid agent run record: Record must have a non-empty id\./,
+  );
+  await assert.rejects(() => fs.stat(filePath), { code: "ENOENT" });
+});
+
+test("readAgentRunLedger returns empty array for missing file", async () => {
+  const filePath = await tempFile();
+  assert.deepEqual(await readAgentRunLedger(filePath), []);
+});
+
+test("readLatestAgentRunRecords returns the latest records", async () => {
+  const filePath = await tempFile();
+  await appendAgentRunRecord(filePath, { ...validRun, id: "run-1" });
+  await appendAgentRunRecord(filePath, { ...validRun, id: "run-2" });
+  await appendAgentRunRecord(filePath, { ...validRun, id: "run-3" });
+
+  assert.deepEqual(await readLatestAgentRunRecords(filePath, 2), [
+    { ...validRun, id: "run-2" },
+    { ...validRun, id: "run-3" },
+  ]);
+});
+
+test("readLatestAgentRunRecords rejects invalid limits", async () => {
+  const filePath = await tempFile();
+  await assert.rejects(() => readLatestAgentRunRecords(filePath, 0), /Limit must be a positive integer\./);
+  await assert.rejects(() => readLatestAgentRunRecords(filePath, 1.5), /Limit must be a positive integer\./);
+});


### PR DESCRIPTION
## Summary
- Add append-only JSONL utilities for agent run records
- Add runtime validation, serialization, parsing, append, read, and latest-read helpers
- Export the new utilities from the package entrypoint

## Test Plan
- npm run test:operator-runs
- npm run test:manifest-coverage
- npm run test:decision-ledger
- npm run test:operator-health
- npm run test:tv-contracts
- npm run test:version
- npm run build