### PR TITLE
feat: add incident log primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:operator-health": "npm run build && node --test test/operator-health.test.mjs",
     "test:decision-ledger": "npm run build && node --test test/decision-ledger.test.mjs",
     "test:manifest-coverage": "npm run build && node --test test/manifest-coverage.test.mjs",
-    "test:operator-runs": "npm run build && node --test test/operator-runs.test.mjs"
+    "test:operator-runs": "npm run build && node --test test/operator-runs.test.mjs",
+    "test:incident-log": "npm run build && node --test test/incident-log.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/incident-log.ts
+++ b/src/incident-log.ts
@@ -1,0 +1,148 @@
+/**
+ * Incident Log Primitives
+ *
+ * Append-only JSONL ledger for recording structured operational incidents.
+ * Data-only utilities — no engine wiring or behavior.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { IncidentRecord, ValidationResult } from "./schema/tv.js";
+
+// ---------------------------------------------------------------------------
+// validateIncidentRecord
+// ---------------------------------------------------------------------------
+
+const REQUIRED_STRING_FIELDS = ["id", "timestamp", "message", "component"] as const;
+const VALID_LEVELS = new Set(["warning", "error", "critical"]);
+
+function isValidDateString(value: string): boolean {
+  return Number.isFinite(Date.parse(value));
+}
+
+export function validateIncidentRecord(record: unknown): ValidationResult {
+  if (!record || typeof record !== "object") {
+    return { ok: false, error: "Record must be a non-null object." };
+  }
+
+  const r = record as Record<string, unknown>;
+
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (typeof r[field] !== "string" || r[field] === "") {
+      return { ok: false, error: `Record must have a non-empty ${field}.` };
+    }
+  }
+
+  if (!isValidDateString(r.timestamp as string)) {
+    return { ok: false, error: "Record timestamp must be a valid date string." };
+  }
+
+  if (typeof r.level !== "string" || !VALID_LEVELS.has(r.level)) {
+    return { ok: false, error: "Record level must be warning, error, or critical." };
+  }
+
+  if (r.resolvedAt !== undefined) {
+    if (typeof r.resolvedAt !== "string" || r.resolvedAt === "") {
+      return { ok: false, error: "Record resolvedAt must be a valid date string." };
+    }
+    if (!isValidDateString(r.resolvedAt)) {
+      return { ok: false, error: "Record resolvedAt must be a valid date string." };
+    }
+    if (Date.parse(r.resolvedAt) < Date.parse(r.timestamp as string)) {
+      return { ok: false, error: "Record resolvedAt must be greater than or equal to timestamp." };
+    }
+    if (typeof r.resolution !== "string" || r.resolution === "") {
+      return { ok: false, error: "Record must have a non-empty resolution when resolvedAt is present." };
+    }
+  } else if (r.resolution !== undefined) {
+    return { ok: false, error: "Record cannot have a resolution without resolvedAt." };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// serializeIncidentRecord
+// ---------------------------------------------------------------------------
+
+export function serializeIncidentRecord(record: IncidentRecord): string {
+  return JSON.stringify(record) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// parseIncidentRecordLine
+// ---------------------------------------------------------------------------
+
+export function parseIncidentRecordLine(line: string): IncidentRecord {
+  const trimmed = line.trim();
+  if (trimmed === "") {
+    throw new Error("Invalid JSON: empty line.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("Invalid JSON: could not parse line.");
+  }
+
+  const result = validateIncidentRecord(parsed);
+  if (!result.ok) {
+    throw new Error(`Invalid incident record: ${result.error}`);
+  }
+
+  return parsed as IncidentRecord;
+}
+
+// ---------------------------------------------------------------------------
+// appendIncidentRecord
+// ---------------------------------------------------------------------------
+
+export async function appendIncidentRecord(
+  filePath: string,
+  record: IncidentRecord,
+): Promise<void> {
+  const result = validateIncidentRecord(record);
+  if (!result.ok) {
+    throw new Error(`Invalid incident record: ${result.error}`);
+  }
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, serializeIncidentRecord(record), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// readIncidentLog
+// ---------------------------------------------------------------------------
+
+export async function readIncidentLog(filePath: string): Promise<IncidentRecord[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (err: any) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+
+  return content
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map(parseIncidentRecordLine);
+}
+
+// ---------------------------------------------------------------------------
+// readLatestIncidentRecords
+// ---------------------------------------------------------------------------
+
+export async function readLatestIncidentRecords(
+  filePath: string,
+  limit: number,
+): Promise<IncidentRecord[]> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("Limit must be a positive integer.");
+  }
+
+  const all = await readIncidentLog(filePath);
+  return all.slice(-limit);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,7 @@ export type {
   AgentRunRecord,
   HealthSnapshot,
   HealthSnapshotInput,
+  IncidentRecord,
   ValidationResult,
   ManifestCoverageOptions,
 } from "./schema/tv.js";
@@ -314,6 +315,16 @@ export {
   readAgentRunLedger,
   readLatestAgentRunRecords,
 } from "./operator-runs.js";
+
+// Incident Log Primitives
+export {
+  validateIncidentRecord,
+  serializeIncidentRecord,
+  parseIncidentRecordLine,
+  appendIncidentRecord,
+  readIncidentLog,
+  readLatestIncidentRecords,
+} from "./incident-log.js";
 
 // ---------------------------------------------------------------------------
 // Markdown terminal renderer

--- a/src/schema/tv.ts
+++ b/src/schema/tv.ts
@@ -119,6 +119,21 @@ export interface AgentRunRecord {
 }
 
 // ---------------------------------------------------------------------------
+// IncidentRecord — record of an operational incident or pipeline issue
+// ---------------------------------------------------------------------------
+
+export interface IncidentRecord {
+  id: string;
+  timestamp: string;
+  level: "warning" | "error" | "critical";
+  message: string;
+  component: string;
+  resolvedAt?: string;
+  resolution?: string;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
 // HealthSnapshot — point-in-time health of the broadcast pipeline
 // ---------------------------------------------------------------------------
 

--- a/test/incident-log.test.mjs
+++ b/test/incident-log.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  appendIncidentRecord,
+  parseIncidentRecordLine,
+  readIncidentLog,
+  readLatestIncidentRecords,
+  serializeIncidentRecord,
+  validateIncidentRecord,
+} from "../dist/index.js";
+
+const validIncident = {
+  id: "inc-1",
+  timestamp: "2026-05-06T22:00:00.000Z",
+  level: "error",
+  message: "Failed to connect to MCP server.",
+  component: "mcp",
+};
+
+const resolvedIncident = {
+  ...validIncident,
+  resolvedAt: "2026-05-06T22:05:00.000Z",
+  resolution: "Reconnected to MCP server.",
+};
+
+async function tempFile() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "sportsclaw-incidents-"));
+  return path.join(dir, "incidents.jsonl");
+}
+
+test("validateIncidentRecord accepts a valid unresolved incident", () => {
+  assert.deepEqual(validateIncidentRecord(validIncident), { ok: true });
+});
+
+test("validateIncidentRecord accepts a valid resolved incident", () => {
+  assert.deepEqual(validateIncidentRecord(resolvedIncident), { ok: true });
+});
+
+test("validateIncidentRecord rejects non-object values", () => {
+  assert.deepEqual(validateIncidentRecord(null), {
+    ok: false,
+    error: "Record must be a non-null object.",
+  });
+});
+
+test("validateIncidentRecord requires id, timestamp, message, and component", () => {
+  for (const field of ["id", "timestamp", "message", "component"]) {
+    const record = { ...validIncident, [field]: "" };
+    assert.deepEqual(validateIncidentRecord(record), {
+      ok: false,
+      error: `Record must have a non-empty ${field}.`,
+    });
+  }
+});
+
+test("validateIncidentRecord rejects invalid timestamp", () => {
+  assert.deepEqual(validateIncidentRecord({ ...validIncident, timestamp: "not-a-date" }), {
+    ok: false,
+    error: "Record timestamp must be a valid date string.",
+  });
+});
+
+test("validateIncidentRecord rejects unknown level values", () => {
+  assert.deepEqual(validateIncidentRecord({ ...validIncident, level: "info" }), {
+    ok: false,
+    error: "Record level must be warning, error, or critical.",
+  });
+});
+
+test("validateIncidentRecord rejects resolvedAt before timestamp", () => {
+  assert.deepEqual(
+    validateIncidentRecord({
+      ...resolvedIncident,
+      timestamp: "2026-05-06T22:05:00.000Z",
+      resolvedAt: "2026-05-06T22:00:00.000Z",
+    }),
+    {
+      ok: false,
+      error: "Record resolvedAt must be greater than or equal to timestamp.",
+    },
+  );
+});
+
+test("validateIncidentRecord requires resolution when resolvedAt is present", () => {
+  assert.deepEqual(
+    validateIncidentRecord({ ...resolvedIncident, resolution: undefined }),
+    {
+      ok: false,
+      error: "Record must have a non-empty resolution when resolvedAt is present.",
+    },
+  );
+});
+
+test("validateIncidentRecord rejects resolution without resolvedAt", () => {
+  assert.deepEqual(
+    validateIncidentRecord({ ...validIncident, resolution: "Fixed it" }),
+    {
+      ok: false,
+      error: "Record cannot have a resolution without resolvedAt.",
+    },
+  );
+});
+
+test("serializeIncidentRecord returns newline-delimited JSON", () => {
+  assert.equal(serializeIncidentRecord(validIncident), `${JSON.stringify(validIncident)}\n`);
+});
+
+test("parseIncidentRecordLine parses valid JSONL", () => {
+  assert.deepEqual(parseIncidentRecordLine(JSON.stringify(validIncident)), validIncident);
+});
+
+test("parseIncidentRecordLine rejects empty lines", () => {
+  assert.throws(() => parseIncidentRecordLine("   "), /Invalid JSON: empty line\./);
+});
+
+test("parseIncidentRecordLine rejects malformed JSON", () => {
+  assert.throws(() => parseIncidentRecordLine("{"), /Invalid JSON: could not parse line\./);
+});
+
+test("parseIncidentRecordLine rejects parsed records with invalid shape", () => {
+  assert.throws(
+    () => parseIncidentRecordLine(JSON.stringify({ ...validIncident, level: "info" })),
+    /Invalid incident record: Record level must be warning, error, or critical\./,
+  );
+});
+
+test("appendIncidentRecord writes valid JSONL and creates parent directories", async () => {
+  const filePath = await tempFile();
+  await appendIncidentRecord(filePath, validIncident);
+  await appendIncidentRecord(filePath, { ...validIncident, id: "inc-2" });
+
+  const content = await fs.readFile(filePath, "utf-8");
+  assert.equal(content.split("\n").filter(Boolean).length, 2);
+  assert.deepEqual(await readIncidentLog(filePath), [validIncident, { ...validIncident, id: "inc-2" }]);
+});
+
+test("appendIncidentRecord rejects invalid records before writing", async () => {
+  const filePath = await tempFile();
+  await assert.rejects(
+    () => appendIncidentRecord(filePath, { ...validIncident, id: "" }),
+    /Invalid incident record: Record must have a non-empty id\./,
+  );
+  await assert.rejects(() => fs.stat(filePath), { code: "ENOENT" });
+});
+
+test("readIncidentLog returns empty array for missing file", async () => {
+  const filePath = await tempFile();
+  assert.deepEqual(await readIncidentLog(filePath), []);
+});
+
+test("readLatestIncidentRecords returns the latest records", async () => {
+  const filePath = await tempFile();
+  await appendIncidentRecord(filePath, { ...validIncident, id: "inc-1" });
+  await appendIncidentRecord(filePath, { ...validIncident, id: "inc-2" });
+  await appendIncidentRecord(filePath, { ...validIncident, id: "inc-3" });
+
+  assert.deepEqual(await readLatestIncidentRecords(filePath, 2), [
+    { ...validIncident, id: "inc-2" },
+    { ...validIncident, id: "inc-3" },
+  ]);
+});
+
+test("readLatestIncidentRecords rejects invalid limits", async () => {
+  const filePath = await tempFile();
+  await assert.rejects(() => readLatestIncidentRecords(filePath, 0), /Limit must be a positive integer\./);
+  await assert.rejects(() => readLatestIncidentRecords(filePath, 1.5), /Limit must be a positive integer\./);
+});


### PR DESCRIPTION
## Summary
- Add append-only JSONL utilities for operational incident records
- Add runtime validation, serialization, parsing, append, read, and latest-read helpers
- Export the new utilities from the package entrypoint

## Test Plan
- npm run test:incident-log
- npm run test:operator-runs
- npm run test:manifest-coverage
- npm run test:decision-ledger
- npm run test:operator-health
- npm run test:tv-contracts
- npm run test:version
- npm run build