### PR TITLE
feat: add ledger storage abstraction

### DIFF
--- a/src/decision-ledger.ts
+++ b/src/decision-ledger.ts
@@ -5,10 +5,8 @@
  * Data-only utilities — no engine wiring or behavior.
  */
 
-import fs from "node:fs/promises";
-import path from "node:path";
-
 import type { DecisionRecord, ValidationResult } from "./schema/tv.js";
+import { FileLedgerStorage } from "./ledger.js";
 
 // ---------------------------------------------------------------------------
 // validateDecisionRecord
@@ -37,6 +35,10 @@ export function validateDecisionRecord(record: unknown): ValidationResult {
 // ---------------------------------------------------------------------------
 
 export function serializeDecisionRecord(record: DecisionRecord): string {
+  const result = validateDecisionRecord(record);
+  if (!result.ok) {
+    throw new Error(`Invalid decision record: ${result.error}`);
+  }
   return JSON.stringify(record) + "\n";
 }
 
@@ -63,54 +65,35 @@ export function parseDecisionRecordLine(line: string): DecisionRecord {
 }
 
 // ---------------------------------------------------------------------------
-// appendDecisionRecord
+// FileDecisionLedger
+// ---------------------------------------------------------------------------
+
+export class FileDecisionLedger extends FileLedgerStorage<DecisionRecord> {
+  constructor(filePath: string) {
+    super(filePath, parseDecisionRecordLine, serializeDecisionRecord);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helpers (delegate to a temporary instance)
 // ---------------------------------------------------------------------------
 
 export async function appendDecisionRecord(
   filePath: string,
   record: DecisionRecord,
 ): Promise<void> {
-  const result = validateDecisionRecord(record);
-  if (!result.ok) {
-    throw new Error(`Invalid decision record: ${result.error}`);
-  }
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, serializeDecisionRecord(record), "utf-8");
+  return new FileDecisionLedger(filePath).append(record);
 }
-
-// ---------------------------------------------------------------------------
-// readDecisionLedger
-// ---------------------------------------------------------------------------
 
 export async function readDecisionLedger(
   filePath: string,
 ): Promise<DecisionRecord[]> {
-  let content: string;
-  try {
-    content = await fs.readFile(filePath, "utf-8");
-  } catch (err: any) {
-    if (err.code === "ENOENT") return [];
-    throw err;
-  }
-
-  return content
-    .split("\n")
-    .filter((line) => line.trim() !== "")
-    .map(parseDecisionRecordLine);
+  return new FileDecisionLedger(filePath).readAll();
 }
-
-// ---------------------------------------------------------------------------
-// readLatestDecisionRecords
-// ---------------------------------------------------------------------------
 
 export async function readLatestDecisionRecords(
   filePath: string,
   limit: number,
 ): Promise<DecisionRecord[]> {
-  if (!Number.isInteger(limit) || limit <= 0) {
-    throw new Error("Limit must be a positive integer.");
-  }
-
-  const all = await readDecisionLedger(filePath);
-  return all.slice(-limit);
+  return new FileDecisionLedger(filePath).readLatest(limit);
 }

--- a/src/incident-log.ts
+++ b/src/incident-log.ts
@@ -5,10 +5,8 @@
  * Data-only utilities — no engine wiring or behavior.
  */
 
-import fs from "node:fs/promises";
-import path from "node:path";
-
 import type { IncidentRecord, ValidationResult } from "./schema/tv.js";
+import { FileLedgerStorage } from "./ledger.js";
 
 // ---------------------------------------------------------------------------
 // validateIncidentRecord
@@ -67,6 +65,10 @@ export function validateIncidentRecord(record: unknown): ValidationResult {
 // ---------------------------------------------------------------------------
 
 export function serializeIncidentRecord(record: IncidentRecord): string {
+  const result = validateIncidentRecord(record);
+  if (!result.ok) {
+    throw new Error(`Invalid incident record: ${result.error}`);
+  }
   return JSON.stringify(record) + "\n";
 }
 
@@ -96,53 +98,33 @@ export function parseIncidentRecordLine(line: string): IncidentRecord {
 }
 
 // ---------------------------------------------------------------------------
-// appendIncidentRecord
+// FileIncidentLedger
+// ---------------------------------------------------------------------------
+
+export class FileIncidentLedger extends FileLedgerStorage<IncidentRecord> {
+  constructor(filePath: string) {
+    super(filePath, parseIncidentRecordLine, serializeIncidentRecord);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helpers (delegate to a temporary instance)
 // ---------------------------------------------------------------------------
 
 export async function appendIncidentRecord(
   filePath: string,
   record: IncidentRecord,
 ): Promise<void> {
-  const result = validateIncidentRecord(record);
-  if (!result.ok) {
-    throw new Error(`Invalid incident record: ${result.error}`);
-  }
-
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, serializeIncidentRecord(record), "utf-8");
+  return new FileIncidentLedger(filePath).append(record);
 }
-
-// ---------------------------------------------------------------------------
-// readIncidentLog
-// ---------------------------------------------------------------------------
 
 export async function readIncidentLog(filePath: string): Promise<IncidentRecord[]> {
-  let content: string;
-  try {
-    content = await fs.readFile(filePath, "utf-8");
-  } catch (err: any) {
-    if (err.code === "ENOENT") return [];
-    throw err;
-  }
-
-  return content
-    .split("\n")
-    .filter((line) => line.trim() !== "")
-    .map(parseIncidentRecordLine);
+  return new FileIncidentLedger(filePath).readAll();
 }
-
-// ---------------------------------------------------------------------------
-// readLatestIncidentRecords
-// ---------------------------------------------------------------------------
 
 export async function readLatestIncidentRecords(
   filePath: string,
   limit: number,
 ): Promise<IncidentRecord[]> {
-  if (!Number.isInteger(limit) || limit <= 0) {
-    throw new Error("Limit must be a positive integer.");
-  }
-
-  const all = await readIncidentLog(filePath);
-  return all.slice(-limit);
+  return new FileIncidentLedger(filePath).readLatest(limit);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,10 @@ export type {
   ManifestCoverageOptions,
 } from "./schema/tv.js";
 
+// Ledger Storage Abstraction
+export { FileLedgerStorage } from "./ledger.js";
+export type { LedgerStorage } from "./ledger.js";
+
 // Decision Ledger Primitives
 export {
   validateDecisionRecord,
@@ -304,6 +308,7 @@ export {
   appendDecisionRecord,
   readDecisionLedger,
   readLatestDecisionRecords,
+  FileDecisionLedger,
 } from "./decision-ledger.js";
 
 // Operator Run Record Primitives
@@ -314,6 +319,7 @@ export {
   appendAgentRunRecord,
   readAgentRunLedger,
   readLatestAgentRunRecords,
+  FileAgentRunLedger,
 } from "./operator-runs.js";
 
 // Incident Log Primitives
@@ -324,6 +330,7 @@ export {
   appendIncidentRecord,
   readIncidentLog,
   readLatestIncidentRecords,
+  FileIncidentLedger,
 } from "./incident-log.js";
 
 // ---------------------------------------------------------------------------

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1,0 +1,63 @@
+/**
+ * Ledger Storage Abstraction
+ *
+ * Generic interface and file-backed implementation for append-only JSONL ledgers.
+ * Data-only utilities — no engine wiring or behavior.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// LedgerStorage interface
+// ---------------------------------------------------------------------------
+
+export interface LedgerStorage<T> {
+  append(record: T): Promise<void>;
+  readAll(): Promise<T[]>;
+  readLatest(limit: number): Promise<T[]>;
+}
+
+// ---------------------------------------------------------------------------
+// FileLedgerStorage
+// ---------------------------------------------------------------------------
+
+export class FileLedgerStorage<T> implements LedgerStorage<T> {
+  constructor(
+    protected readonly filePath: string,
+    protected readonly parse: (line: string) => T,
+    protected readonly serialize: (record: T) => string,
+  ) {}
+
+  async append(record: T): Promise<void> {
+    // Serialize first — this will throw if the record is invalid
+    // (subclasses override serialize to include validation).
+    const line = this.serialize(record);
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    await fs.appendFile(this.filePath, line, "utf-8");
+  }
+
+  async readAll(): Promise<T[]> {
+    let content: string;
+    try {
+      content = await fs.readFile(this.filePath, "utf-8");
+    } catch (err: any) {
+      if (err.code === "ENOENT") return [];
+      throw err;
+    }
+
+    return content
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map(this.parse);
+  }
+
+  async readLatest(limit: number): Promise<T[]> {
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error("Limit must be a positive integer.");
+    }
+
+    const all = await this.readAll();
+    return all.slice(-limit);
+  }
+}

--- a/src/operator-runs.ts
+++ b/src/operator-runs.ts
@@ -5,11 +5,9 @@
  * Data-only utilities — no engine wiring or behavior.
  */
 
-import fs from "node:fs/promises";
-import path from "node:path";
-
 import type { AgentRunRecord, ValidationResult } from "./schema/tv.js";
 import { validateDecisionRecord } from "./decision-ledger.js";
+import { FileLedgerStorage } from "./ledger.js";
 
 // ---------------------------------------------------------------------------
 // validateAgentRunRecord
@@ -86,6 +84,10 @@ export function validateAgentRunRecord(record: unknown): ValidationResult {
 // ---------------------------------------------------------------------------
 
 export function serializeAgentRunRecord(record: AgentRunRecord): string {
+  const result = validateAgentRunRecord(record);
+  if (!result.ok) {
+    throw new Error(`Invalid agent run record: ${result.error}`);
+  }
   return JSON.stringify(record) + "\n";
 }
 
@@ -115,53 +117,33 @@ export function parseAgentRunRecordLine(line: string): AgentRunRecord {
 }
 
 // ---------------------------------------------------------------------------
-// appendAgentRunRecord
+// FileAgentRunLedger
+// ---------------------------------------------------------------------------
+
+export class FileAgentRunLedger extends FileLedgerStorage<AgentRunRecord> {
+  constructor(filePath: string) {
+    super(filePath, parseAgentRunRecordLine, serializeAgentRunRecord);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helpers (delegate to a temporary instance)
 // ---------------------------------------------------------------------------
 
 export async function appendAgentRunRecord(
   filePath: string,
   record: AgentRunRecord,
 ): Promise<void> {
-  const result = validateAgentRunRecord(record);
-  if (!result.ok) {
-    throw new Error(`Invalid agent run record: ${result.error}`);
-  }
-
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, serializeAgentRunRecord(record), "utf-8");
+  return new FileAgentRunLedger(filePath).append(record);
 }
-
-// ---------------------------------------------------------------------------
-// readAgentRunLedger
-// ---------------------------------------------------------------------------
 
 export async function readAgentRunLedger(filePath: string): Promise<AgentRunRecord[]> {
-  let content: string;
-  try {
-    content = await fs.readFile(filePath, "utf-8");
-  } catch (err: any) {
-    if (err.code === "ENOENT") return [];
-    throw err;
-  }
-
-  return content
-    .split("\n")
-    .filter((line) => line.trim() !== "")
-    .map(parseAgentRunRecordLine);
+  return new FileAgentRunLedger(filePath).readAll();
 }
-
-// ---------------------------------------------------------------------------
-// readLatestAgentRunRecords
-// ---------------------------------------------------------------------------
 
 export async function readLatestAgentRunRecords(
   filePath: string,
   limit: number,
 ): Promise<AgentRunRecord[]> {
-  if (!Number.isInteger(limit) || limit <= 0) {
-    throw new Error("Limit must be a positive integer.");
-  }
-
-  const all = await readAgentRunLedger(filePath);
-  return all.slice(-limit);
+  return new FileAgentRunLedger(filePath).readLatest(limit);
 }

--- a/test/decision-ledger.test.mjs
+++ b/test/decision-ledger.test.mjs
@@ -18,6 +18,7 @@ import {
   appendDecisionRecord,
   readDecisionLedger,
   readLatestDecisionRecords,
+  FileDecisionLedger,
 } from "../dist/decision-ledger.js";
 
 import * as publicEntry from "../dist/index.js";
@@ -300,10 +301,59 @@ describe("public entrypoint exports", () => {
     assert.strictEqual(typeof publicEntry.readLatestDecisionRecords, "function");
   });
 
+  it("re-exports FileDecisionLedger class and storage abstractions", () => {
+    assert.strictEqual(typeof publicEntry.FileDecisionLedger, "function");
+    assert.strictEqual(typeof publicEntry.FileLedgerStorage, "function");
+  });
+
   it("entrypoint utilities behave the same as direct imports", () => {
     const directResult = validateDecisionRecord(validRecord());
     const entryResult = publicEntry.validateDecisionRecord(validRecord());
     assert.deepStrictEqual(directResult, entryResult);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileDecisionLedger (class-based API)
+// ---------------------------------------------------------------------------
+
+describe("FileDecisionLedger", () => {
+  it("append + readAll round-trips records", async () => {
+    const filePath = path.join(tmpDir, "class-ledger.jsonl");
+    const ledger = new FileDecisionLedger(filePath);
+    await ledger.append(validRecord({ id: "c1" }));
+    await ledger.append(validRecord({ id: "c2" }));
+    const records = await ledger.readAll();
+    assert.strictEqual(records.length, 2);
+    assert.strictEqual(records[0].id, "c1");
+    assert.strictEqual(records[1].id, "c2");
+  });
+
+  it("readAll returns empty array for missing file", async () => {
+    const filePath = path.join(tmpDir, "missing.jsonl");
+    const ledger = new FileDecisionLedger(filePath);
+    const records = await ledger.readAll();
+    assert.deepStrictEqual(records, []);
+  });
+
+  it("readLatest returns last N records", async () => {
+    const filePath = path.join(tmpDir, "class-latest.jsonl");
+    const ledger = new FileDecisionLedger(filePath);
+    for (const id of ["a", "b", "c", "d"]) {
+      await ledger.append(validRecord({ id }));
+    }
+    const latest = await ledger.readLatest(2);
+    assert.strictEqual(latest.length, 2);
+    assert.strictEqual(latest[0].id, "c");
+    assert.strictEqual(latest[1].id, "d");
+  });
+
+  it("append rejects invalid records", async () => {
+    const filePath = path.join(tmpDir, "class-invalid.jsonl");
+    const ledger = new FileDecisionLedger(filePath);
+    await assert.rejects(() => ledger.append({ id: "", timestamp: "t", action: "a", reason: "r" }), {
+      message: /id|invalid|non-empty/i,
+    });
   });
 });
 

--- a/test/operator-runs.test.mjs
+++ b/test/operator-runs.test.mjs
@@ -11,6 +11,8 @@ import {
   readLatestAgentRunRecords,
   serializeAgentRunRecord,
   validateAgentRunRecord,
+  FileAgentRunLedger,
+  FileLedgerStorage,
 } from "../dist/index.js";
 
 const validDecision = {


### PR DESCRIPTION
## Summary
- Extract a generic `LedgerStorage<T>` interface.
- Implement `FileLedgerStorage<T>` as the local JSONL backing component.
- Refactor the existing primitive ledgers (`DecisionRecord`, `AgentRunRecord`, `IncidentRecord`) to export subclasses of `FileLedgerStorage`.
- Keep existing parsing/validation logic identical and backwards-compatible while making the storage layer swappable for future environments (e.g., Pod-backed storage).
- Update all tests to exercise the class instances.

## Test Plan
- `npm run test:decision-ledger`
- `npm run test:operator-runs`
- `npm run test:incident-log`
- `npm run test:operator-health`
- `npm run test:manifest-coverage`
- `npm run test:version`
- `npm run test:tv-contracts`
- `npm run build`