### PR TITLE
feat: Pod-backed Ledger Storage

### DIFF
--- a/src/decision-ledger.ts
+++ b/src/decision-ledger.ts
@@ -97,3 +97,12 @@ export async function readLatestDecisionRecords(
 ): Promise<DecisionRecord[]> {
   return new FileDecisionLedger(filePath).readLatest(limit);
 }
+
+import { PodLedgerStorage } from "./ledger.js";
+import type { McpManager } from "./mcp.js";
+
+export class PodDecisionLedger extends PodLedgerStorage<DecisionRecord> {
+  constructor(mcpManager: McpManager, serverName: string, ledgerName: string = "decision-ledger") {
+    super(mcpManager, serverName, ledgerName, parseDecisionRecordLine, serializeDecisionRecord);
+  }
+}

--- a/src/incident-log.ts
+++ b/src/incident-log.ts
@@ -128,3 +128,12 @@ export async function readLatestIncidentRecords(
 ): Promise<IncidentRecord[]> {
   return new FileIncidentLedger(filePath).readLatest(limit);
 }
+
+import { PodLedgerStorage } from "./ledger.js";
+import type { McpManager } from "./mcp.js";
+
+export class PodIncidentLedger extends PodLedgerStorage<IncidentRecord> {
+  constructor(mcpManager: McpManager, serverName: string, ledgerName: string = "incident-ledger") {
+    super(mcpManager, serverName, ledgerName, parseIncidentRecordLine, serializeIncidentRecord);
+  }
+}

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -61,3 +61,99 @@ export class FileLedgerStorage<T> implements LedgerStorage<T> {
     return all.slice(-limit);
   }
 }
+
+// ---------------------------------------------------------------------------
+// PodLedgerStorage
+// ---------------------------------------------------------------------------
+
+import type { McpManager } from "./mcp.js";
+
+export class PodLedgerStorage<T> implements LedgerStorage<T> {
+  // A cache for the document ID so we don't have to search every time we append.
+  private docId: string | null = null;
+  private inFlightSync: Promise<void> | null = null;
+
+  constructor(
+    private readonly mcpManager: McpManager,
+    private readonly serverName: string,
+    private readonly ledgerName: string,
+    private readonly parse: (line: string) => T,
+    private readonly serialize: (record: T) => string
+  ) {}
+
+  private async callPod(toolName: string, args: Record<string, unknown>): Promise<any> {
+    const result = await this.mcpManager.callToolDirect(this.serverName, toolName, args);
+    if (result.isError) return {};
+    try {
+      return JSON.parse(result.content || "{}");
+    } catch {
+      return {};
+    }
+  }
+
+  private async loadDoc(): Promise<{ id: string | null; records: T[] }> {
+    const res = await this.callPod("search_documents", {
+      filters: { name: this.ledgerName },
+      fields: ["_id", "value"],
+      page_size: 1,
+    });
+    const hit = res?.data?.data?.[0];
+    if (!hit) {
+      return { id: null, records: [] };
+    }
+    const rawArray = hit?.value?.records || [];
+    // Convert back from strings if they were serialized
+    const records = (Array.isArray(rawArray) ? rawArray : []).map((r: any) => {
+      if (typeof r === "string") return this.parse(r);
+      return r as T;
+    });
+    return { id: hit._id, records };
+  }
+
+  async append(record: T): Promise<void> {
+    // Wait for any existing sync to finish
+    while (this.inFlightSync) await this.inFlightSync;
+
+    this.inFlightSync = (async () => {
+      const { id, records } = await this.loadDoc();
+      const serialized = this.serialize(record).trim();
+      records.push(this.parse(serialized));
+
+      const rawRecords = records.map(r => this.serialize(r).trim());
+
+      if (id) {
+        await this.callPod("update_document", {
+          item_id: id,
+          content: { value: { records: rawRecords } },
+        });
+        this.docId = id;
+      } else {
+        const createRes = await this.callPod("create_document", {
+          name: this.ledgerName,
+          content: { value: { records: rawRecords } },
+          metadata: { type: "ledger", ledger_name: this.ledgerName },
+        });
+        this.docId = createRes?.data?.data?._id || null;
+      }
+    })();
+    
+    try {
+      await this.inFlightSync;
+    } finally {
+      this.inFlightSync = null;
+    }
+  }
+
+  async readAll(): Promise<T[]> {
+    const { records } = await this.loadDoc();
+    return records;
+  }
+
+  async readLatest(limit: number): Promise<T[]> {
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error("Limit must be a positive integer.");
+    }
+    const all = await this.readAll();
+    return all.slice(-limit);
+  }
+}

--- a/src/operator-runs.ts
+++ b/src/operator-runs.ts
@@ -147,3 +147,12 @@ export async function readLatestAgentRunRecords(
 ): Promise<AgentRunRecord[]> {
   return new FileAgentRunLedger(filePath).readLatest(limit);
 }
+
+import { PodLedgerStorage } from "./ledger.js";
+import type { McpManager } from "./mcp.js";
+
+export class PodOperatorRunsLedger extends PodLedgerStorage<AgentRunRecord> {
+  constructor(mcpManager: McpManager, serverName: string, ledgerName: string = "operator-runs-ledger") {
+    super(mcpManager, serverName, ledgerName, parseAgentRunRecordLine, serializeAgentRunRecord);
+  }
+}


### PR DESCRIPTION
Implements `PodLedgerStorage` via the MCP document APIs and provides `PodDecisionLedger`, `PodIncidentLedger`, and `PodOperatorRunsLedger` for Machina integration.