### PR TITLE
feat: heartbeat wake gate (cheap pre-check before LLM machinery)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:prompts": "npm run build && node --test test/prompts.test.mjs",
     "test:guardrails": "npm run build && node --test test/guardrails.test.mjs",
     "test:heartbeat-state": "npm run build && node --test test/heartbeat-state.test.mjs",
-    "test:heartbeat": "npm run build && node --test test/heartbeat.test.mjs"
+    "test:heartbeat": "npm run build && node --test test/heartbeat.test.mjs",
+    "test:heartbeat-wake-gate": "npm run build && node --test test/heartbeat-wake-gate.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/heartbeat-state.ts
+++ b/src/heartbeat-state.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 export type CronJobLifecycle = "active" | "paused" | "completed" | "error";
 
 /** Outcome of the most recent tick of a cron job. */
-export type CronJobLastStatus = "succeeded" | "failed" | "running";
+export type CronJobLastStatus = "succeeded" | "failed" | "running" | "skipped";
 
 /** Persisted per-job runtime state. */
 export interface CronJobState {
@@ -38,12 +38,18 @@ export interface CronJobState {
   nextRunAt: string;
   /** ISO timestamp of the most recent fire start. */
   lastRunAt?: string;
-  /** Number of times this job has fired (best effort across restarts). */
+  /** Number of times this job has actually fired (work began). Skips are NOT counted here. */
   runCount: number;
+  /** Number of times this job's wake gate denied the tick. */
+  skipCount: number;
   /** Status of the most recent run. */
   lastStatus?: CronJobLastStatus;
   /** Stringified error from the most recent failed run, if any. */
   lastError?: string;
+  /** ISO timestamp of the most recent wake-gate skip. */
+  lastSkipAt?: string;
+  /** Reason given by the wake gate on the most recent skip. */
+  lastSkipReason?: string;
   /** ISO timestamp when this state record was last written. */
   updatedAt: string;
 }
@@ -97,6 +103,7 @@ export class HeartbeatStateStore {
    * Record that a job's next fire is scheduled — call this BEFORE doing the
    * work. This is the at-most-once guarantee on crash. Increments runCount,
    * sets lastRunAt to now, lastStatus to "running", and writes nextRunAt.
+   * Preserves skipCount and the prior skip-tracking fields.
    */
   async markRunStart(
     jobId: string,
@@ -111,8 +118,43 @@ export class HeartbeatStateStore {
         nextRunAt: new Date(now.getTime() + opts.intervalMs).toISOString(),
         lastRunAt: nowIso,
         runCount: (existing?.runCount ?? 0) + 1,
+        skipCount: existing?.skipCount ?? 0,
         lastStatus: "running",
         lastError: undefined,
+        lastSkipAt: existing?.lastSkipAt,
+        lastSkipReason: existing?.lastSkipReason,
+        updatedAt: nowIso,
+      };
+    });
+  }
+
+  /**
+   * Record that a job's wake gate denied the tick. Increments skipCount,
+   * sets lastStatus to "skipped", records the reason and timestamp.
+   * Does NOT bump runCount, does NOT advance nextRunAt — the next interval
+   * fires the next attempt. Creates a fresh record if the job has none yet
+   * (rare: a brand-new job whose first tick is gated off).
+   */
+  async markRunSkipped(
+    jobId: string,
+    opts: { intervalMs: number; reason: string; lifecycle?: CronJobLifecycle },
+  ): Promise<CronJobState> {
+    return this.mutate(jobId, (existing) => {
+      const now = new Date();
+      const nowIso = now.toISOString();
+      return {
+        jobId,
+        state: opts.lifecycle ?? existing?.state ?? "active",
+        nextRunAt:
+          existing?.nextRunAt ??
+          new Date(now.getTime() + opts.intervalMs).toISOString(),
+        lastRunAt: existing?.lastRunAt,
+        runCount: existing?.runCount ?? 0,
+        skipCount: (existing?.skipCount ?? 0) + 1,
+        lastStatus: "skipped",
+        lastError: existing?.lastError,
+        lastSkipAt: nowIso,
+        lastSkipReason: opts.reason,
         updatedAt: nowIso,
       };
     });
@@ -244,8 +286,11 @@ function normalize(parsed: unknown): StateFile {
       nextRunAt: j.nextRunAt,
       lastRunAt: typeof j.lastRunAt === "string" ? j.lastRunAt : undefined,
       runCount: typeof j.runCount === "number" ? j.runCount : 0,
+      skipCount: typeof j.skipCount === "number" ? j.skipCount : 0,
       lastStatus: (j.lastStatus as CronJobLastStatus | undefined) ?? undefined,
       lastError: typeof j.lastError === "string" ? j.lastError : undefined,
+      lastSkipAt: typeof j.lastSkipAt === "string" ? j.lastSkipAt : undefined,
+      lastSkipReason: typeof j.lastSkipReason === "string" ? j.lastSkipReason : undefined,
       updatedAt: typeof j.updatedAt === "string" ? j.updatedAt : new Date(0).toISOString(),
     };
   }

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -33,6 +33,36 @@ import type { CronJobState } from "./heartbeat-state.js";
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Optional cheap pre-check that runs before any LLM machinery for a tick.
+ * If `wake: false`, the tick exits without firing the engine — saves money
+ * on quiet ticks. If `wake: true`, the optional `context` string is attached
+ * to the cron_fired event for downstream handlers to inject into the prompt.
+ *
+ * Adapted from Hermes' wakeAgent gate (see external review notes).
+ *
+ * NOT persisted: this is a runtime-only callback; it lives in the closure
+ * of the daemon process. Skip metadata is recorded via
+ * HeartbeatStateStore.markRunSkipped.
+ */
+export interface WakeGateContext {
+  /** Job id being evaluated. */
+  jobId: string;
+  /** Read-only snapshot of the cron job for the gate to inspect. */
+  job: Readonly<Omit<CronJob, "wakeGate">>;
+}
+
+export interface WakeGateResult {
+  /** True to allow the tick to fire the engine; false to skip this tick. */
+  wake: boolean;
+  /** Free-form context attached to cron_fired (only when wake=true). */
+  context?: string;
+  /** Human-readable reason; recorded on the persisted state when wake=false. */
+  reason?: string;
+}
+
+export type WakeGateFn = (ctx: WakeGateContext) => Promise<WakeGateResult> | WakeGateResult;
+
 export interface CronJob {
   /** Unique identifier */
   id: string;
@@ -54,15 +84,28 @@ export interface CronJob {
   runCount: number;
   /** When this job was created */
   createdAt: string;
+  /**
+   * Optional wake gate — cheap pre-check that decides whether this tick
+   * should fire the engine. NOT persisted (functions are not serialisable);
+   * the daemon re-attaches gates at startup.
+   */
+  wakeGate?: WakeGateFn;
 }
 
 export interface HeartbeatEvent {
-  type: "task_matched" | "task_expired" | "cron_fired" | "evaluation_error";
+  type:
+    | "task_matched"
+    | "task_expired"
+    | "cron_fired"
+    | "cron_skipped"
+    | "evaluation_error";
   taskId?: string;
   cronJobId?: string;
   userId?: string;
   result?: string;
   error?: string;
+  /** Optional context emitted alongside cron_fired when the wake gate produced a context string. */
+  wakeContext?: string;
   timestamp: string;
 }
 
@@ -228,6 +271,20 @@ export class HeartbeatService {
     await this.stateStore.markRunFailed(jobId, error);
   }
 
+  /**
+   * Mark the most recent attempt of `jobId` as skipped by the wake gate.
+   * Bumps skipCount, records the reason and timestamp, leaves runCount
+   * unchanged. Usually called internally by the cron timer when the wake
+   * gate denies — exposed publicly so external orchestrators can also
+   * register a skip.
+   */
+  async markJobSkipped(jobId: string, reason: string): Promise<void> {
+    if (!this.stateStore) return;
+    const job = this.cronJobs.get(jobId);
+    const intervalMs = job?.intervalMs ?? this.intervalMs;
+    await this.stateStore.markRunSkipped(jobId, { intervalMs, reason });
+  }
+
   /** Move a persisted job to a different lifecycle (active / paused / completed / error). */
   async setJobLifecycle(
     jobId: string,
@@ -321,6 +378,12 @@ export class HeartbeatService {
      * fresh `cron_<ts>_<rand>` id (single-replica use).
      */
     id?: string;
+    /**
+     * Optional cheap pre-check. Runs before each fire; if it returns
+     * `{wake: false}` the tick is skipped without invoking the engine.
+     * See WakeGateFn.
+     */
+    wakeGate?: WakeGateFn;
   }): CronJob {
     const id = params.id ?? `cron_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
     const job: CronJob = {
@@ -333,6 +396,7 @@ export class HeartbeatService {
       status: "active",
       runCount: 0,
       createdAt: new Date().toISOString(),
+      wakeGate: params.wakeGate,
     };
 
     this.cronJobs.set(id, job);
@@ -455,6 +519,26 @@ export class HeartbeatService {
       }
     } finally {
       this.inFlight = false;
+    }
+  }
+
+  /**
+   * Persist a wake-gate skip. Logged but never throws — gate denial is the
+   * happy path, we shouldn't crash the daemon when persistence is flaky.
+   */
+  private async recordSkip(job: CronJob, reason: string): Promise<void> {
+    if (!this.stateStore) return;
+    try {
+      await this.stateStore.markRunSkipped(job.id, {
+        intervalMs: job.intervalMs,
+        reason,
+        lifecycle: "active",
+      });
+    } catch (err) {
+      console.error(
+        `[heartbeat] markRunSkipped failed for "${job.label}": ` +
+          (err instanceof Error ? err.message : err),
+      );
     }
   }
 
@@ -586,9 +670,9 @@ export class HeartbeatService {
       // Cross-process double-fire protection (when persistence is configured):
       // acquire a per-job lockfile, reload state from disk, and skip if
       // another replica already advanced nextRunAt past now — meaning that
-      // replica won the race for this interval. The lock window covers only
-      // the markRunStart + emit critical section; consumer work runs after
-      // the event fires and outside the lock.
+      // replica won the race for this interval. The lock window covers the
+      // wake-gate evaluation + markRunStart + emit critical section;
+      // consumer work runs after the event fires and outside the lock.
       let releaseLock: (() => Promise<void>) | null = null;
       if (this.stateStore && this.lockPath) {
         const jobLockPath = this.perJobLockPath(job.id);
@@ -639,6 +723,54 @@ export class HeartbeatService {
       }
 
       try {
+        // Wake gate (optional): cheap pre-check that runs BEFORE markRunStart
+        // but INSIDE the per-job lock so two replicas don't both evaluate.
+        //   wake: true  → capture context, proceed to markRunStart + cron_fired
+        //   wake: false → emit cron_skipped, persist skip metadata, return
+        //   throws      → fail-closed (treated as denied) and recorded
+        // (See Hermes wakeAgent gate for the original pattern.)
+        let wakeContext: string | undefined;
+        if (job.wakeGate) {
+          const { wakeGate: _ignored, ...jobView } = job;
+          let result: WakeGateResult;
+          try {
+            result = await Promise.resolve(
+              job.wakeGate({ jobId: job.id, job: jobView }),
+            );
+          } catch (err) {
+            const reason = `wake gate threw: ${err instanceof Error ? err.message : err}`;
+            await this.recordSkip(job, reason);
+            this.emitEvent({
+              type: "cron_skipped",
+              cronJobId: job.id,
+              userId: job.userId,
+              result: reason,
+              error: err instanceof Error ? err.message : String(err),
+              timestamp: new Date().toISOString(),
+            });
+            if (this.verbose) {
+              console.error(`[heartbeat] Cron skipped (gate threw): "${job.label}" — ${reason}`);
+            }
+            return;
+          }
+          if (!result.wake) {
+            const reason = result.reason ?? "wake gate denied";
+            await this.recordSkip(job, reason);
+            this.emitEvent({
+              type: "cron_skipped",
+              cronJobId: job.id,
+              userId: job.userId,
+              result: reason,
+              timestamp: new Date().toISOString(),
+            });
+            if (this.verbose) {
+              console.error(`[heartbeat] Cron skipped: "${job.label}" — ${reason}`);
+            }
+            return;
+          }
+          wakeContext = result.context;
+        }
+
         // Advance-before-execute: write nextRunAt to the persisted state BEFORE
         // emitting the cron_fired event. If the daemon crashes mid-tick, we
         // lose this fire instead of replaying it on restart. At-most-once
@@ -668,6 +800,7 @@ export class HeartbeatService {
           cronJobId: job.id,
           userId: job.userId,
           result: `Cron "${job.label}" fired (run #${job.runCount})`,
+          wakeContext,
           timestamp: new Date().toISOString(),
         });
 

--- a/test/heartbeat-wake-gate.test.mjs
+++ b/test/heartbeat-wake-gate.test.mjs
@@ -1,0 +1,327 @@
+/**
+ * Wake gate — focused tests
+ *
+ * Covers:
+ *   - HeartbeatStateStore.markRunSkipped + skipCount + lastSkipReason
+ *   - HeartbeatService cron flow with a wake gate (allow / deny / throw)
+ *   - cron_skipped event vs cron_fired event
+ *   - wakeContext propagation on cron_fired
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { HeartbeatService } from "../dist/heartbeat.js";
+import { HeartbeatStateStore } from "../dist/heartbeat-state.js";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wake-gate-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// HeartbeatStateStore.markRunSkipped
+// ---------------------------------------------------------------------------
+
+describe("HeartbeatStateStore.markRunSkipped", () => {
+  it("creates a fresh record with skipCount=1 when none exists", async () => {
+    const store = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    const state = await store.markRunSkipped("job-1", {
+      intervalMs: 60_000,
+      reason: "no work to do",
+    });
+    assert.strictEqual(state.runCount, 0);
+    assert.strictEqual(state.skipCount, 1);
+    assert.strictEqual(state.lastStatus, "skipped");
+    assert.strictEqual(state.lastSkipReason, "no work to do");
+    assert.ok(state.lastSkipAt);
+  });
+
+  it("does NOT bump runCount", async () => {
+    const store = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    await store.markRunStart("job-1", { intervalMs: 1000 });
+    await store.markRunStart("job-1", { intervalMs: 1000 });
+    await store.markRunSkipped("job-1", { intervalMs: 1000, reason: "quiet" });
+    const final = store.get("job-1");
+    assert.strictEqual(final.runCount, 2);
+    assert.strictEqual(final.skipCount, 1);
+  });
+
+  it("preserves nextRunAt from a prior run rather than overwriting", async () => {
+    const store = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    const first = await store.markRunStart("job-1", { intervalMs: 60_000 });
+    await store.markRunSkipped("job-1", { intervalMs: 60_000, reason: "x" });
+    const after = store.get("job-1");
+    assert.strictEqual(after.nextRunAt, first.nextRunAt);
+  });
+
+  it("preserves lastError from a prior failure", async () => {
+    const store = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    await store.markRunStart("job-1", { intervalMs: 1000 });
+    await store.markRunFailed("job-1", new Error("oops"));
+    await store.markRunSkipped("job-1", { intervalMs: 1000, reason: "quiet" });
+    const after = store.get("job-1");
+    assert.strictEqual(after.lastStatus, "skipped");
+    assert.strictEqual(after.lastError, "oops");
+  });
+
+  it("starts a fresh run cleanly after skips (lastStatus flips to running)", async () => {
+    const store = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    await store.markRunSkipped("job-1", { intervalMs: 1000, reason: "x" });
+    await store.markRunSkipped("job-1", { intervalMs: 1000, reason: "y" });
+    await store.markRunStart("job-1", { intervalMs: 1000 });
+    const state = store.get("job-1");
+    assert.strictEqual(state.runCount, 1);
+    assert.strictEqual(state.skipCount, 2);
+    assert.strictEqual(state.lastStatus, "running");
+  });
+
+  it("survives reload (skip metadata is persisted)", async () => {
+    const a = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    await a.markRunSkipped("job-1", { intervalMs: 1000, reason: "no input" });
+    const b = new HeartbeatStateStore(path.join(tmpDir, "state.json"));
+    await b.load();
+    const state = b.get("job-1");
+    assert.strictEqual(state.skipCount, 1);
+    assert.strictEqual(state.lastSkipReason, "no input");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HeartbeatService cron with wake gate
+// ---------------------------------------------------------------------------
+
+describe("HeartbeatService cron + wake gate", () => {
+  it("ALLOW gate: emits cron_fired with wakeContext, bumps runCount", async () => {
+    const fires = [];
+    const skips = [];
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.setEventHandler((evt) => {
+      if (evt.type === "cron_fired") fires.push(evt);
+      if (evt.type === "cron_skipped") skips.push(evt);
+    });
+    hb.start();
+    const job = hb.scheduleCron({
+      label: "always-on",
+      prompt: "ignored",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      wakeGate: () => ({ wake: true, context: "fixtures-changed" }),
+    });
+    await wait(80);
+    hb.stop();
+
+    assert.strictEqual(fires.length, 1, "expected one cron_fired event");
+    assert.strictEqual(skips.length, 0, "should not skip when gate allows");
+    assert.strictEqual(fires[0].wakeContext, "fixtures-changed");
+    const persisted = await hb.getPersistedJob(job.id);
+    assert.strictEqual(persisted.runCount, 1);
+    assert.strictEqual(persisted.skipCount, 0);
+    assert.strictEqual(persisted.lastStatus, "running");
+  });
+
+  it("DENY gate: emits cron_skipped, runCount unchanged, skipCount bumps", async () => {
+    const fires = [];
+    const skips = [];
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.setEventHandler((evt) => {
+      if (evt.type === "cron_fired") fires.push(evt);
+      if (evt.type === "cron_skipped") skips.push(evt);
+    });
+    hb.start();
+    const job = hb.scheduleCron({
+      label: "gated-off",
+      prompt: "ignored",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      wakeGate: () => ({ wake: false, reason: "no fresh fixtures" }),
+    });
+    await wait(80);
+    hb.stop();
+
+    assert.strictEqual(fires.length, 0, "no cron_fired when gate denies");
+    assert.strictEqual(skips.length, 1, "expected one cron_skipped");
+    assert.strictEqual(skips[0].result, "no fresh fixtures");
+    const persisted = await hb.getPersistedJob(job.id);
+    assert.strictEqual(persisted.runCount, 0);
+    assert.strictEqual(persisted.skipCount, 1);
+    assert.strictEqual(persisted.lastStatus, "skipped");
+    assert.strictEqual(persisted.lastSkipReason, "no fresh fixtures");
+  });
+
+  it("DENY without explicit reason: records 'wake gate denied'", async () => {
+    const skips = [];
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.setEventHandler((evt) => {
+      if (evt.type === "cron_skipped") skips.push(evt);
+    });
+    hb.start();
+    const job = hb.scheduleCron({
+      label: "no-reason",
+      prompt: "x",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      wakeGate: () => ({ wake: false }),
+    });
+    await wait(80);
+    hb.stop();
+
+    assert.strictEqual(skips.length, 1);
+    const persisted = await hb.getPersistedJob(job.id);
+    assert.match(persisted.lastSkipReason, /denied/i);
+  });
+
+  it("ASYNC gate is awaited", async () => {
+    const fires = [];
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.setEventHandler((evt) => {
+      if (evt.type === "cron_fired") fires.push(evt);
+    });
+    hb.start();
+    hb.scheduleCron({
+      label: "async-gate",
+      prompt: "x",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      wakeGate: async () => {
+        await wait(20);
+        return { wake: true, context: "via-async" };
+      },
+    });
+    await wait(120);
+    hb.stop();
+
+    assert.strictEqual(fires.length, 1);
+    assert.strictEqual(fires[0].wakeContext, "via-async");
+  });
+
+  it("THROWING gate fails closed (treated as denied) and recorded", async () => {
+    const fires = [];
+    const skips = [];
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.setEventHandler((evt) => {
+      if (evt.type === "cron_fired") fires.push(evt);
+      if (evt.type === "cron_skipped") skips.push(evt);
+    });
+    hb.start();
+    const job = hb.scheduleCron({
+      label: "broken-gate",
+      prompt: "x",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      wakeGate: () => {
+        throw new Error("upstream 503");
+      },
+    });
+    await wait(80);
+    hb.stop();
+
+    assert.strictEqual(fires.length, 0, "must not fire when gate throws");
+    assert.strictEqual(skips.length, 1);
+    assert.match(skips[0].error ?? "", /503/);
+    const persisted = await hb.getPersistedJob(job.id);
+    assert.strictEqual(persisted.skipCount, 1);
+    assert.match(persisted.lastSkipReason, /threw/i);
+  });
+
+  it("gate sees a frozen job snapshot WITHOUT the wakeGate function", async () => {
+    let observed = null;
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.start();
+    hb.scheduleCron({
+      label: "introspect",
+      prompt: "p",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      wakeGate: (ctx) => {
+        observed = ctx;
+        return { wake: false, reason: "done" };
+      },
+    });
+    await wait(60);
+    hb.stop();
+
+    assert.ok(observed);
+    assert.strictEqual(observed.job.label, "introspect");
+    assert.strictEqual(observed.job.prompt, "p");
+    assert.strictEqual(observed.job.wakeGate, undefined);
+  });
+
+  it("missing gate behaves as before (always fires)", async () => {
+    const fires = [];
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.setEventHandler((evt) => {
+      if (evt.type === "cron_fired") fires.push(evt);
+    });
+    hb.start();
+    hb.scheduleCron({
+      label: "no-gate",
+      prompt: "x",
+      userId: "tester",
+      intervalMs: 1_000_000,
+      recurring: true,
+      // no wakeGate
+    });
+    await wait(80);
+    hb.stop();
+
+    assert.strictEqual(fires.length, 1);
+    assert.strictEqual(fires[0].wakeContext, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markJobSkipped public API
+// ---------------------------------------------------------------------------
+
+describe("HeartbeatService.markJobSkipped", () => {
+  it("records a skip via the public surface", async () => {
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    hb.configurePersistence({ stateDir: tmpDir });
+    hb.start();
+    const job = hb.scheduleCron({
+      label: "manual-skip-target",
+      prompt: "x",
+      userId: "tester",
+      intervalMs: 5_000,
+      recurring: true,
+      wakeGate: () => ({ wake: true }), // gate allows; we'll skip externally
+    });
+    // wait so the gate fires once and bumps runCount
+    await wait(60);
+    await hb.markJobSkipped(job.id, "ops paused upstream");
+    hb.stop();
+    const persisted = await hb.getPersistedJob(job.id);
+    assert.strictEqual(persisted.lastStatus, "skipped");
+    assert.strictEqual(persisted.lastSkipReason, "ops paused upstream");
+    assert.ok(persisted.skipCount >= 1);
+  });
+
+  it("noops cleanly when persistence is off", async () => {
+    const hb = new HeartbeatService({ intervalMs: 60_000 });
+    await hb.markJobSkipped("nope", "irrelevant");
+    // simply did not throw
+  });
+});


### PR DESCRIPTION
## Summary

Third piece of the autonomous-operator daemon work. **Stacked on top of PR #37** — uses the persistence APIs landed there.

The wake gate is a cheap pre-check that runs before each cron tick fires the engine. If it returns `{wake: false}`, the tick exits without ever constructing the LLM call — saves real money on quiet ticks (e.g., \"no fixtures changed since last poll, no editorial action due\"). If it returns `{wake: true, context: '...'}`, the optional context string rides along on `cron_fired` for downstream handlers to inject into the prompt.

Adapted from [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)'s wakeAgent gate pattern.

## Usage

```ts
hb.scheduleCron({
  label: \"refresh-football-state\",
  prompt: \"...\",
  userId: \"operator\",
  intervalMs: 600_000,
  wakeGate: async ({ jobId, job }) => {
    const last = await getLastIngestAt();
    const stale = Date.now() - last.getTime() > 5 * 60_000;
    return stale
      ? { wake: true, context: \`last fetched \${last.toISOString()} — stale\` }
      : { wake: false, reason: \"fixtures fresh; nothing to do\" };
  },
});
```

When the gate denies, no LLM call is made and the persisted state records the skip:

```
   lastStatus:     skipped
   lastSkipAt:     2026-05-10T22:14:08.421Z
   lastSkipReason: fixtures fresh; nothing to do
   skipCount:      4
   runCount:       (unchanged)
```

## Files

### `src/heartbeat-state.ts` (modified)

```diff
+ lastStatus union now includes 'skipped'
+ skipCount, lastSkipAt, lastSkipReason persisted fields
+ markRunSkipped(jobId, {intervalMs, reason, lifecycle?})
+ normalize() reads new fields; legacy records default skipCount=0
```

### `src/heartbeat.ts` (modified)

```diff
+ WakeGateContext / WakeGateResult / WakeGateFn types exported
+ CronJob.wakeGate? (runtime-only — not persisted)
+ HeartbeatEvent: 'cron_skipped' variant + optional wakeContext on cron_fired
+ scheduleCron({wakeGate?})
+ execute() runs the gate FIRST:
    wake:true   → markRunStart + cron_fired (wakeContext attached)
    wake:false  → markRunSkipped + cron_skipped, return
    throws      → fail-closed (treated as denied), error recorded
+ markJobSkipped(jobId, reason) — public API for external orchestrators
+ recordSkip helper (logs but never throws)
```

The gate receives a frozen `Readonly<Omit<CronJob, 'wakeGate'>>` snapshot so it cannot mutate the job or recurse into itself.

## Tests

```
   heartbeat-wake-gate.test.mjs   15 tests · all green
   ───────────────────────────────────────────────
   pre-existing daemon tests      32 tests (state + heartbeat) · still green
   pre-existing repo suite        145 tests · still green
                                 ────────────
   total                          192 tests
```

`tsc` clean. No new runtime deps.

## Test scenarios covered

- `markRunSkipped` does NOT bump `runCount`
- `markRunSkipped` preserves prior `nextRunAt` and `lastError`
- skip metadata survives reload from disk
- ALLOW gate emits `cron_fired` with `wakeContext`
- DENY gate emits `cron_skipped`, runCount unchanged
- DENY without explicit reason records canonical \"wake gate denied\"
- async gate is awaited
- THROWING gate fails closed (treated as denied) and recorded
- gate sees frozen snapshot WITHOUT the `wakeGate` function
- missing gate behaves as before (always fires)
- public `markJobSkipped` records via the persisted state

## What's next (out of scope)

- (5) tool-call guardrail controller — wraps engine.ts tool execution
- (6) operator daemon entry point — wires everything together

## Test plan

- [x] `npm run build` — tsc clean
- [x] `npm run test:heartbeat-wake-gate`
- [x] `npm run test:heartbeat-state` and `npm run test:heartbeat` — still green
- [x] all pre-existing test scripts still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)