### PR TITLE
feat: add tool-call guardrail (anti-loop circuit breaker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:incident-log": "npm run build && node --test test/incident-log.test.mjs",
     "test:editorial-memory": "npm run build && node --test test/editorial-memory.test.mjs",
     "test:last-tick-brief": "npm run build && node --test test/last-tick-brief.test.mjs",
-    "test:prompts": "npm run build && node --test test/prompts.test.mjs"
+    "test:prompts": "npm run build && node --test test/prompts.test.mjs",
+    "test:guardrails": "npm run build && node --test test/guardrails.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/guardrails.ts
+++ b/src/guardrails.ts
@@ -52,12 +52,6 @@ export interface ToolGuardOptions {
    * repeat detection only runs on tools in this set.
    */
   idempotentTools?: ReadonlySet<string>;
-  /**
-   * Tool names that mutate state. Currently informational — guardrail logic
-   * uses `idempotentTools` for affirmative categorisation. Reserved for
-   * future "no two mutating calls in a row with same args" rules.
-   */
-  mutatingTools?: ReadonlySet<string>;
 }
 
 /** Decision returned by `beforeCall`. */
@@ -169,7 +163,6 @@ const DEFAULTS: Required<ToolGuardOptions> = {
   idempotentRepeatWarn: 3,
   idempotentRepeatBlock: 5,
   idempotentTools: DEFAULT_IDEMPOTENT_TOOLS,
-  mutatingTools: DEFAULT_MUTATING_TOOLS,
 };
 
 // ---------------------------------------------------------------------------
@@ -190,7 +183,6 @@ export class ToolGuardController {
       ...DEFAULTS,
       ...options,
       idempotentTools: options.idempotentTools ?? DEFAULTS.idempotentTools,
-      mutatingTools: options.mutatingTools ?? DEFAULTS.mutatingTools,
     };
   }
 
@@ -334,11 +326,6 @@ export class ToolGuardController {
     return this.opts.idempotentTools.has(toolName);
   }
 
-  /** Whether a tool is categorised as state-mutating under the current options. */
-  isMutating(toolName: string): boolean {
-    return this.opts.mutatingTools.has(toolName);
-  }
-
   // -------------------------------------------------------------------------
   // internals
   // -------------------------------------------------------------------------
@@ -358,10 +345,14 @@ export class ToolGuardController {
 
 /**
  * Stable hex digest of arbitrary JSON-serialisable input. Object keys are
- * sorted recursively so {a:1,b:2} and {b:2,a:1} hash identically.
+ * sorted recursively so {a:1,b:2} and {b:2,a:1} hash identically. `undefined`
+ * inputs (e.g. a no-arg tool call) hash as if `null` was passed — without
+ * this, createHash().update() would throw on the undefined return from
+ * JSON.stringify(undefined).
  */
 export function hashCanonical(value: unknown): string {
-  return createHash("sha256").update(canonicalize(value)).digest("hex");
+  const canonical = canonicalize(value);
+  return createHash("sha256").update(canonical ?? "null").digest("hex");
 }
 
 /** Convenience wrapper for the result-digest pattern. */
@@ -369,7 +360,7 @@ export function digestResult(result: unknown): string {
   return hashCanonical(result);
 }
 
-function canonicalize(value: unknown): string {
+function canonicalize(value: unknown): string | undefined {
   return JSON.stringify(value, function (_key, v) {
     if (v && typeof v === "object" && !Array.isArray(v)) {
       const sorted: Record<string, unknown> = {};

--- a/src/guardrails.ts
+++ b/src/guardrails.ts
@@ -1,0 +1,386 @@
+/**
+ * Tool-call guardrails — anti-loop circuit breaker for autonomous tool use.
+ *
+ * A side-effect-free controller that hashes every tool call as
+ * (tool_name, sha256(canonical_args)) and tracks three counters:
+ *   1. consecutive identical-call failures   (same tool, same args, repeated fail)
+ *   2. per-tool failures                     (any failure of this tool)
+ *   3. idempotent same-result repeats        (read-only tool returning the same
+ *                                             answer N times)
+ *
+ * On warn, callers append the message to the tool result so the LLM sees it
+ * next iteration. On block, callers synthesise a `role=tool` result with
+ * `{error, guardrail:{...}}` instead of running the tool — the model gets a
+ * structured "stop retrying me" signal and changes strategy on its own.
+ *
+ * Adapted from Hermes' ToolCallGuardrailController. Pure data; no engine
+ * dependency. The operator daemon (or engine.ts) wires it inside the tool-
+ * execution wrapper around `tools` handed to `generateText` — this PR
+ * defines the primitive only.
+ *
+ * Lifecycle: one controller per turn / per cron tick. Call `reset()` between
+ * ticks. Counters survive across multiple tool calls within the same turn.
+ */
+
+import { createHash } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Stable identity of a (tool, args) pair. */
+export interface ToolCallSignature {
+  toolName: string;
+  /** sha256 hex of canonical-stringified args. */
+  argsHash: string;
+}
+
+/** Configurable thresholds + tool categorisation. */
+export interface ToolGuardOptions {
+  /** Identical (tool, args) failure count before warning. Default 3. */
+  identicalFailureWarn?: number;
+  /** Identical (tool, args) failure count before blocking. Default 5. */
+  identicalFailureBlock?: number;
+  /** Any-failures of one tool before warning. Default 5. */
+  perToolFailureWarn?: number;
+  /** Idempotent same-result repeats before warning. Default 3. */
+  idempotentRepeatWarn?: number;
+  /** Idempotent same-result repeats before blocking. Default 5. */
+  idempotentRepeatBlock?: number;
+  /**
+   * Tool names safe to call repeatedly with the same args. Same-result
+   * repeat detection only runs on tools in this set.
+   */
+  idempotentTools?: ReadonlySet<string>;
+  /**
+   * Tool names that mutate state. Currently informational — guardrail logic
+   * uses `idempotentTools` for affirmative categorisation. Reserved for
+   * future "no two mutating calls in a row with same args" rules.
+   */
+  mutatingTools?: ReadonlySet<string>;
+}
+
+/** Decision returned by `beforeCall`. */
+export interface BeforeCallDecision {
+  action: "allow" | "warn" | "block";
+  /** Human-readable reason; populated for warn and block. */
+  message?: string;
+  /**
+   * On `block`, callers should return THIS instead of invoking the tool.
+   * Shape mirrors what the LLM expects from a `role=tool` result.
+   */
+  syntheticResult?: { error: string; guardrail: GuardrailDetail };
+  /** The signature this decision was computed for. */
+  signature: ToolCallSignature;
+}
+
+/** Diagnostic counts at decision time. */
+export interface GuardrailDetail {
+  reason: string;
+  toolName: string;
+  consecutiveIdenticalFailures: number;
+  perToolFailures: number;
+  idempotentRepeats: number;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults — categorisation for tv-mcp tools
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only / idempotent MCP tools commonly available on the machina-sports-tv
+ * pod. The set is conservative — anything that *could* mutate is excluded.
+ * Operators can override via `idempotentTools` in options.
+ */
+export const DEFAULT_IDEMPOTENT_TOOLS: ReadonlySet<string> = new Set([
+  // pod-level reads
+  "search_documents",
+  "get_document",
+  "search_workflow",
+  "get_workflow_execution",
+  "search_workflow_executions",
+  "search_agents",
+  "search_agent_executions",
+  "get_agent",
+  "get_agent_by_name",
+  "get_agent_execution",
+  "search_prompts",
+  "get_prompt_by_id",
+  "get_prompt_by_name",
+  "connector_search",
+  "connector_describe",
+  "connector_endpoint",
+  "connector_retrieve_id",
+  "connector_retrieve_args",
+  "mapping_search",
+  "retrieve_mapping_id",
+  "retrieve_mapping_args",
+  "retrieve_workflow_id",
+  "retrieve_workflow_args",
+  "executor_workflow_id",
+  "check_secrets",
+  "health_check",
+  "get_template_directories",
+  "get_git_template_directories",
+  "get_local_template",
+]);
+
+/**
+ * State-mutating tools. Currently informational; reserved for future rules.
+ * Any tool that creates / updates / deletes a document or queues a real-world
+ * side effect belongs here.
+ */
+export const DEFAULT_MUTATING_TOOLS: ReadonlySet<string> = new Set([
+  "create_document",
+  "update_document",
+  "delete_document",
+  "bulk_delete_documents",
+  "create_workflow",
+  "update_workflow_id",
+  "delete_workflow",
+  "execute_workflow",
+  "executor_workflow_name",
+  "schedule_workflow_id",
+  "schedule_workflow_name",
+  "create_agent",
+  "update_agent",
+  "delete_agent",
+  "execute_agent",
+  "create_prompt",
+  "update_prompt",
+  "delete_prompt",
+  "execute_prompt",
+  "create_connector",
+  "connector_update",
+  "delete_connector",
+  "connector_executor",
+  "create_mapping",
+  "update_mapping",
+  "delete_mapping",
+  "create_secrets",
+  "import_templates",
+  "import_templates_from_git",
+]);
+
+const DEFAULTS: Required<ToolGuardOptions> = {
+  identicalFailureWarn: 3,
+  identicalFailureBlock: 5,
+  perToolFailureWarn: 5,
+  idempotentRepeatWarn: 3,
+  idempotentRepeatBlock: 5,
+  idempotentTools: DEFAULT_IDEMPOTENT_TOOLS,
+  mutatingTools: DEFAULT_MUTATING_TOOLS,
+};
+
+// ---------------------------------------------------------------------------
+// ToolGuardController
+// ---------------------------------------------------------------------------
+
+export class ToolGuardController {
+  private opts: Required<ToolGuardOptions>;
+  /** sigKey -> consecutive failures since last success */
+  private consecutiveIdenticalFailures = new Map<string, number>();
+  /** toolName -> total failures this turn */
+  private perToolFailures = new Map<string, number>();
+  /** sigKey -> resultDigest -> count (idempotent tools only) */
+  private perSigResults = new Map<string, Map<string, number>>();
+
+  constructor(options: ToolGuardOptions = {}) {
+    this.opts = {
+      ...DEFAULTS,
+      ...options,
+      idempotentTools: options.idempotentTools ?? DEFAULTS.idempotentTools,
+      mutatingTools: options.mutatingTools ?? DEFAULTS.mutatingTools,
+    };
+  }
+
+  /** Compute the canonical signature for a (tool, args) pair. */
+  signature(toolName: string, args: unknown): ToolCallSignature {
+    return { toolName, argsHash: hashCanonical(args) };
+  }
+
+  /**
+   * Decide whether to allow / warn-and-allow / block this call. Pure read of
+   * internal state — does NOT update counters. Counters update on
+   * `afterCall()` once the tool actually ran (or was synthesised).
+   */
+  beforeCall(toolName: string, args: unknown): BeforeCallDecision {
+    const signature = this.signature(toolName, args);
+    const sigKey = sigKeyOf(signature);
+
+    const consecutiveIdenticalFailuresN =
+      this.consecutiveIdenticalFailures.get(sigKey) ?? 0;
+    const perToolFailures = this.perToolFailures.get(toolName) ?? 0;
+    const idempotentRepeats = this.maxIdempotentRepeat(sigKey);
+
+    const detail: GuardrailDetail = {
+      reason: "",
+      toolName,
+      consecutiveIdenticalFailures: consecutiveIdenticalFailuresN,
+      perToolFailures,
+      idempotentRepeats,
+    };
+
+    // BLOCK: same (tool, args) has failed too many times in a row
+    if (consecutiveIdenticalFailuresN >= this.opts.identicalFailureBlock) {
+      detail.reason = `Same (${toolName}, args) failed ${consecutiveIdenticalFailuresN} times in a row. Stop retrying — change the args, change the tool, or change strategy.`;
+      return {
+        action: "block",
+        message: detail.reason,
+        syntheticResult: { error: detail.reason, guardrail: { ...detail } },
+        signature,
+      };
+    }
+
+    // BLOCK: idempotent tool returning the same result over and over
+    if (idempotentRepeats >= this.opts.idempotentRepeatBlock) {
+      detail.reason = `Idempotent tool '${toolName}' returned the same result ${idempotentRepeats} times. The answer is not changing — stop polling.`;
+      return {
+        action: "block",
+        message: detail.reason,
+        syntheticResult: { error: detail.reason, guardrail: { ...detail } },
+        signature,
+      };
+    }
+
+    // WARN: same (tool, args) failures crossed warn threshold
+    if (consecutiveIdenticalFailuresN >= this.opts.identicalFailureWarn) {
+      detail.reason = `Tool loop warning: same (${toolName}, args) has failed ${consecutiveIdenticalFailuresN} times. Try a different approach.`;
+      return { action: "warn", message: detail.reason, signature };
+    }
+
+    // WARN: per-tool failures crossed warn threshold (regardless of args)
+    if (perToolFailures >= this.opts.perToolFailureWarn) {
+      detail.reason = `Tool loop warning: tool '${toolName}' has failed ${perToolFailures} times this turn. Consider falling back.`;
+      return { action: "warn", message: detail.reason, signature };
+    }
+
+    // WARN: idempotent same-result repeats crossed warn threshold
+    if (idempotentRepeats >= this.opts.idempotentRepeatWarn) {
+      detail.reason = `Tool loop warning: idempotent '${toolName}' returned the same result ${idempotentRepeats} times — the answer is not changing.`;
+      return { action: "warn", message: detail.reason, signature };
+    }
+
+    return { action: "allow", signature };
+  }
+
+  /**
+   * Record the outcome of a tool call. `ok=true` resets the consecutive-
+   * failure counter for this (tool, args) signature. For idempotent tools,
+   * pass `resultDigest` to enable same-result repeat detection.
+   */
+  afterCall(
+    toolName: string,
+    args: unknown,
+    ok: boolean,
+    resultDigest?: string,
+  ): void {
+    const sig = this.signature(toolName, args);
+    const sigKey = sigKeyOf(sig);
+
+    if (!ok) {
+      this.consecutiveIdenticalFailures.set(
+        sigKey,
+        (this.consecutiveIdenticalFailures.get(sigKey) ?? 0) + 1,
+      );
+      this.perToolFailures.set(
+        toolName,
+        (this.perToolFailures.get(toolName) ?? 0) + 1,
+      );
+      return;
+    }
+
+    // success: reset the consecutive-failure streak for this signature.
+    this.consecutiveIdenticalFailures.set(sigKey, 0);
+
+    // for idempotent tools, track the result digest so we can detect
+    // "same answer over and over" loops.
+    if (this.opts.idempotentTools.has(toolName) && resultDigest) {
+      let map = this.perSigResults.get(sigKey);
+      if (!map) {
+        map = new Map();
+        this.perSigResults.set(sigKey, map);
+      }
+      map.set(resultDigest, (map.get(resultDigest) ?? 0) + 1);
+    }
+  }
+
+  /** Reset all counters. Call between turns / cron ticks. */
+  reset(): void {
+    this.consecutiveIdenticalFailures.clear();
+    this.perToolFailures.clear();
+    this.perSigResults.clear();
+  }
+
+  /** Read-only snapshot of internal counters for telemetry / tests. */
+  snapshot(): {
+    consecutiveIdenticalFailures: ReadonlyMap<string, number>;
+    perToolFailures: ReadonlyMap<string, number>;
+    idempotentResultRepeats: ReadonlyMap<string, ReadonlyMap<string, number>>;
+  } {
+    return {
+      consecutiveIdenticalFailures: new Map(this.consecutiveIdenticalFailures),
+      perToolFailures: new Map(this.perToolFailures),
+      idempotentResultRepeats: new Map(
+        Array.from(this.perSigResults.entries()).map(
+          ([k, v]) => [k, new Map(v)] as const,
+        ),
+      ),
+    };
+  }
+
+  /** Whether a tool is treated as idempotent under the current options. */
+  isIdempotent(toolName: string): boolean {
+    return this.opts.idempotentTools.has(toolName);
+  }
+
+  /** Whether a tool is categorised as state-mutating under the current options. */
+  isMutating(toolName: string): boolean {
+    return this.opts.mutatingTools.has(toolName);
+  }
+
+  // -------------------------------------------------------------------------
+  // internals
+  // -------------------------------------------------------------------------
+
+  private maxIdempotentRepeat(sigKey: string): number {
+    const map = this.perSigResults.get(sigKey);
+    if (!map || map.size === 0) return 0;
+    let max = 0;
+    for (const v of map.values()) if (v > max) max = v;
+    return max;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported because callers often need them at the call site
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable hex digest of arbitrary JSON-serialisable input. Object keys are
+ * sorted recursively so {a:1,b:2} and {b:2,a:1} hash identically.
+ */
+export function hashCanonical(value: unknown): string {
+  return createHash("sha256").update(canonicalize(value)).digest("hex");
+}
+
+/** Convenience wrapper for the result-digest pattern. */
+export function digestResult(result: unknown): string {
+  return hashCanonical(result);
+}
+
+function canonicalize(value: unknown): string {
+  return JSON.stringify(value, function (_key, v) {
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      const sorted: Record<string, unknown> = {};
+      const obj = v as Record<string, unknown>;
+      for (const k of Object.keys(obj).sort()) sorted[k] = obj[k];
+      return sorted;
+    }
+    return v;
+  });
+}
+
+function sigKeyOf(sig: ToolCallSignature): string {
+  return `${sig.toolName}:${sig.argsHash}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,6 +333,21 @@ export {
   FileIncidentLedger,
 } from "./incident-log.js";
 
+// Tool-call Guardrails
+export {
+  ToolGuardController,
+  DEFAULT_IDEMPOTENT_TOOLS,
+  DEFAULT_MUTATING_TOOLS,
+  hashCanonical,
+  digestResult,
+} from "./guardrails.js";
+export type {
+  ToolCallSignature,
+  ToolGuardOptions,
+  BeforeCallDecision,
+  GuardrailDetail,
+} from "./guardrails.js";
+
 // ---------------------------------------------------------------------------
 // Markdown terminal renderer
 // ---------------------------------------------------------------------------

--- a/test/guardrails.test.mjs
+++ b/test/guardrails.test.mjs
@@ -1,0 +1,356 @@
+/**
+ * Tool-Call Guardrails — test suite
+ *
+ * Tests for the anti-loop circuit breaker controller. Pure data; no engine
+ * dependency, so no fixtures or temp dirs required.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  ToolGuardController,
+  DEFAULT_IDEMPOTENT_TOOLS,
+  DEFAULT_MUTATING_TOOLS,
+  hashCanonical,
+  digestResult,
+} from "../dist/guardrails.js";
+
+import * as publicEntry from "../dist/index.js";
+
+// ---------------------------------------------------------------------------
+// hashCanonical / signature stability
+// ---------------------------------------------------------------------------
+
+describe("hashCanonical", () => {
+  it("produces a stable sha256 hex digest", () => {
+    const h = hashCanonical({ a: 1, b: 2 });
+    assert.match(h, /^[0-9a-f]{64}$/);
+  });
+
+  it("is stable across object key order", () => {
+    const a = hashCanonical({ a: 1, b: 2, c: { x: 1, y: 2 } });
+    const b = hashCanonical({ c: { y: 2, x: 1 }, b: 2, a: 1 });
+    assert.strictEqual(a, b);
+  });
+
+  it("preserves array order (arrays are NOT canonicalised)", () => {
+    const a = hashCanonical([1, 2, 3]);
+    const b = hashCanonical([3, 2, 1]);
+    assert.notStrictEqual(a, b);
+  });
+
+  it("differs for different values", () => {
+    assert.notStrictEqual(hashCanonical({ a: 1 }), hashCanonical({ a: 2 }));
+  });
+});
+
+describe("ToolGuardController.signature", () => {
+  it("returns the same signature for equivalent args", () => {
+    const g = new ToolGuardController();
+    const a = g.signature("search_documents", { name: "x", limit: 1 });
+    const b = g.signature("search_documents", { limit: 1, name: "x" });
+    assert.strictEqual(a.toolName, b.toolName);
+    assert.strictEqual(a.argsHash, b.argsHash);
+  });
+
+  it("returns different signatures for different tool names", () => {
+    const g = new ToolGuardController();
+    const a = g.signature("search_documents", { name: "x" });
+    const b = g.signature("get_document", { name: "x" });
+    assert.notStrictEqual(a.argsHash + a.toolName, b.argsHash + b.toolName);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// beforeCall — allow path
+// ---------------------------------------------------------------------------
+
+describe("ToolGuardController.beforeCall", () => {
+  it("allows a fresh call", () => {
+    const g = new ToolGuardController();
+    const d = g.beforeCall("search_documents", { name: "x" });
+    assert.strictEqual(d.action, "allow");
+    assert.ok(d.signature);
+    assert.strictEqual(d.signature.toolName, "search_documents");
+  });
+
+  it("does not mutate counters on beforeCall", () => {
+    const g = new ToolGuardController();
+    g.beforeCall("search_documents", { name: "x" });
+    g.beforeCall("search_documents", { name: "x" });
+    g.beforeCall("search_documents", { name: "x" });
+    const snap = g.snapshot();
+    assert.strictEqual(snap.consecutiveIdenticalFailures.size, 0);
+    assert.strictEqual(snap.perToolFailures.size, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Identical (tool, args) failure tracking
+// ---------------------------------------------------------------------------
+
+describe("identical (tool, args) failure tracking", () => {
+  it("warns at identicalFailureWarn (default 3)", () => {
+    const g = new ToolGuardController();
+    const args = { workflow: "ingest" };
+
+    for (let i = 0; i < 2; i++) {
+      g.afterCall("execute_workflow", args, false);
+    }
+    // 2 prior failures — still allow on the 3rd attempt
+    let d = g.beforeCall("execute_workflow", args);
+    assert.strictEqual(d.action, "allow");
+
+    g.afterCall("execute_workflow", args, false); // 3rd failure
+    d = g.beforeCall("execute_workflow", args);
+    assert.strictEqual(d.action, "warn");
+    assert.match(d.message, /3 times/);
+  });
+
+  it("blocks at identicalFailureBlock (default 5) with syntheticResult", () => {
+    const g = new ToolGuardController();
+    const args = { workflow: "ingest" };
+    for (let i = 0; i < 5; i++) g.afterCall("execute_workflow", args, false);
+
+    const d = g.beforeCall("execute_workflow", args);
+    assert.strictEqual(d.action, "block");
+    assert.ok(d.syntheticResult);
+    assert.strictEqual(typeof d.syntheticResult.error, "string");
+    assert.strictEqual(
+      d.syntheticResult.guardrail.toolName,
+      "execute_workflow",
+    );
+    assert.strictEqual(
+      d.syntheticResult.guardrail.consecutiveIdenticalFailures,
+      5,
+    );
+  });
+
+  it("resets the consecutive-failure streak on success", () => {
+    const g = new ToolGuardController();
+    const args = { workflow: "ingest" };
+    for (let i = 0; i < 4; i++) g.afterCall("execute_workflow", args, false);
+    g.afterCall("execute_workflow", args, true); // success resets
+
+    const d = g.beforeCall("execute_workflow", args);
+    assert.strictEqual(d.action, "allow");
+
+    const snap = g.snapshot();
+    const sigKey = Array.from(snap.consecutiveIdenticalFailures.keys())[0];
+    assert.strictEqual(snap.consecutiveIdenticalFailures.get(sigKey), 0);
+  });
+
+  it("tracks failures per-signature, not per-tool", () => {
+    const g = new ToolGuardController();
+    // 3 failures on one set of args, 1 on another — only the first warns
+    for (let i = 0; i < 3; i++) {
+      g.afterCall("execute_workflow", { workflow: "a" }, false);
+    }
+    g.afterCall("execute_workflow", { workflow: "b" }, false);
+
+    const dA = g.beforeCall("execute_workflow", { workflow: "a" });
+    const dB = g.beforeCall("execute_workflow", { workflow: "b" });
+    assert.strictEqual(dA.action, "warn");
+    assert.strictEqual(dB.action, "allow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-tool failure tracking (any-args)
+// ---------------------------------------------------------------------------
+
+describe("per-tool failure tracking", () => {
+  it("warns at perToolFailureWarn (default 5) regardless of args", () => {
+    const g = new ToolGuardController();
+    // 5 failures across 5 different arg shapes — none cross the per-sig
+    // warn threshold, but the per-tool counter does.
+    for (let i = 0; i < 5; i++) {
+      g.afterCall("execute_workflow", { i }, false);
+    }
+    const d = g.beforeCall("execute_workflow", { i: 99 });
+    assert.strictEqual(d.action, "warn");
+    assert.match(d.message, /5 times this turn/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotent same-result repeats
+// ---------------------------------------------------------------------------
+
+describe("idempotent same-result repeats", () => {
+  it("warns at idempotentRepeatWarn (default 3) when the same digest comes back", () => {
+    const g = new ToolGuardController();
+    const args = { name: "tv-stat-snapshot" };
+    const digest = digestResult({ documents: [], total: 0 });
+
+    for (let i = 0; i < 3; i++) {
+      g.afterCall("search_documents", args, true, digest);
+    }
+    const d = g.beforeCall("search_documents", args);
+    assert.strictEqual(d.action, "warn");
+    assert.match(d.message, /3 times/);
+  });
+
+  it("blocks at idempotentRepeatBlock (default 5) with syntheticResult", () => {
+    const g = new ToolGuardController();
+    const args = { name: "tv-stat-snapshot" };
+    const digest = digestResult({ documents: [], total: 0 });
+
+    for (let i = 0; i < 5; i++) {
+      g.afterCall("search_documents", args, true, digest);
+    }
+    const d = g.beforeCall("search_documents", args);
+    assert.strictEqual(d.action, "block");
+    assert.ok(d.syntheticResult);
+    assert.strictEqual(d.syntheticResult.guardrail.idempotentRepeats, 5);
+  });
+
+  it("does NOT count repeats for mutating tools", () => {
+    const g = new ToolGuardController();
+    const args = { workflow: "publish-approved" };
+    const digest = digestResult({ ok: true });
+
+    for (let i = 0; i < 5; i++) {
+      g.afterCall("execute_workflow", args, true, digest);
+    }
+    const d = g.beforeCall("execute_workflow", args);
+    assert.strictEqual(d.action, "allow");
+  });
+
+  it("does NOT trigger when results differ", () => {
+    const g = new ToolGuardController();
+    const args = { name: "tv-news-feed" };
+    for (let i = 0; i < 5; i++) {
+      g.afterCall(
+        "search_documents",
+        args,
+        true,
+        digestResult({ tick: i }), // unique each time
+      );
+    }
+    const d = g.beforeCall("search_documents", args);
+    assert.strictEqual(d.action, "allow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom thresholds & options
+// ---------------------------------------------------------------------------
+
+describe("custom options", () => {
+  it("respects custom identicalFailureWarn / Block thresholds", () => {
+    const g = new ToolGuardController({
+      identicalFailureWarn: 1,
+      identicalFailureBlock: 2,
+    });
+    g.afterCall("foo", { x: 1 }, false);
+    let d = g.beforeCall("foo", { x: 1 });
+    assert.strictEqual(d.action, "warn");
+
+    g.afterCall("foo", { x: 1 }, false);
+    d = g.beforeCall("foo", { x: 1 });
+    assert.strictEqual(d.action, "block");
+  });
+
+  it("treats a tool as idempotent when added via custom set", () => {
+    const custom = new Set(["my_read_tool"]);
+    const g = new ToolGuardController({ idempotentTools: custom });
+    assert.ok(g.isIdempotent("my_read_tool"));
+    assert.ok(!g.isIdempotent("search_documents")); // overridden
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reset / snapshot
+// ---------------------------------------------------------------------------
+
+describe("reset / snapshot", () => {
+  it("reset() clears all internal counters", () => {
+    const g = new ToolGuardController();
+    for (let i = 0; i < 5; i++) g.afterCall("execute_workflow", { i }, false);
+    g.afterCall("search_documents", { name: "x" }, true, "digest-1");
+
+    g.reset();
+
+    const snap = g.snapshot();
+    assert.strictEqual(snap.consecutiveIdenticalFailures.size, 0);
+    assert.strictEqual(snap.perToolFailures.size, 0);
+    assert.strictEqual(snap.idempotentResultRepeats.size, 0);
+  });
+
+  it("snapshot() returns counts without mutating state", () => {
+    const g = new ToolGuardController();
+    g.afterCall("execute_workflow", { x: 1 }, false);
+    g.afterCall("execute_workflow", { x: 1 }, false);
+
+    const a = g.snapshot();
+    const b = g.snapshot();
+    assert.strictEqual(a.perToolFailures.get("execute_workflow"), 2);
+    assert.strictEqual(b.perToolFailures.get("execute_workflow"), 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default tool sets
+// ---------------------------------------------------------------------------
+
+describe("default tool sets", () => {
+  it("DEFAULT_IDEMPOTENT_TOOLS includes the common tv-mcp reads", () => {
+    for (const t of [
+      "search_documents",
+      "get_document",
+      "search_workflow",
+      "get_workflow_execution",
+      "health_check",
+    ]) {
+      assert.ok(
+        DEFAULT_IDEMPOTENT_TOOLS.has(t),
+        `expected ${t} in DEFAULT_IDEMPOTENT_TOOLS`,
+      );
+    }
+  });
+
+  it("DEFAULT_MUTATING_TOOLS includes the common tv-mcp mutations", () => {
+    for (const t of [
+      "execute_workflow",
+      "create_document",
+      "update_document",
+      "delete_document",
+      "create_agent",
+      "update_agent",
+    ]) {
+      assert.ok(
+        DEFAULT_MUTATING_TOOLS.has(t),
+        `expected ${t} in DEFAULT_MUTATING_TOOLS`,
+      );
+    }
+  });
+
+  it("idempotent and mutating sets are disjoint", () => {
+    for (const t of DEFAULT_IDEMPOTENT_TOOLS) {
+      assert.ok(
+        !DEFAULT_MUTATING_TOOLS.has(t),
+        `${t} appears in both default sets`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public entry re-exports
+// ---------------------------------------------------------------------------
+
+describe("public entry re-exports", () => {
+  it("re-exports ToolGuardController and default sets from index.js", () => {
+    assert.strictEqual(
+      typeof publicEntry.ToolGuardController,
+      "function",
+      "ToolGuardController should be re-exported",
+    );
+    assert.ok(publicEntry.DEFAULT_IDEMPOTENT_TOOLS instanceof Set);
+    assert.ok(publicEntry.DEFAULT_MUTATING_TOOLS instanceof Set);
+    assert.strictEqual(typeof publicEntry.hashCanonical, "function");
+    assert.strictEqual(typeof publicEntry.digestResult, "function");
+  });
+});

--- a/test/guardrails.test.mjs
+++ b/test/guardrails.test.mjs
@@ -43,6 +43,16 @@ describe("hashCanonical", () => {
   it("differs for different values", () => {
     assert.notStrictEqual(hashCanonical({ a: 1 }), hashCanonical({ a: 2 }));
   });
+
+  it("does not throw on undefined input (no-arg tool calls)", () => {
+    // Without the fix, JSON.stringify(undefined) returns undefined and
+    // createHash().update() throws. Guard hashes undefined as null.
+    const h = hashCanonical(undefined);
+    assert.match(h, /^[0-9a-f]{64}$/);
+    // Sanity: undefined and null hash to the same value (we treat them
+    // as equivalent for digest purposes)
+    assert.strictEqual(hashCanonical(undefined), hashCanonical(null));
+  });
 });
 
 describe("ToolGuardController.signature", () => {


### PR DESCRIPTION
## Summary
- Adds `ToolGuardController` — a side-effect-free anti-loop circuit breaker for autonomous tool use
- Hashes `(toolName, sha256(canonicalArgs))` and tracks three counters per turn:
  1. consecutive identical-call failures (warn 3, block 5)
  2. per-tool failures (warn 5)
  3. idempotent same-result repeats (warn 3, block 5)
- On block, returns a synthetic `role=tool` result so the LLM gets a structured "stop retrying" signal
- Ships `DEFAULT_IDEMPOTENT_TOOLS` / `DEFAULT_MUTATING_TOOLS` categorising the tv-mcp tools

## Why
The autonomous operator can get stuck in tool-call loops — same `execute_workflow` failing 30 times in a row, or `search_documents` polling for a value that is never going to change. Same pattern Hermes hit. This primitive caps the blast radius without depending on the engine.

## Scope
This PR ships the **primitive only**. Engine wiring (so `engine.ts` consults the controller around `generateText`'s tool execution) lands as part of the operator daemon entry PR — that's the file this is built for.

Stack-independent: branched off `main`, not stacked on the heartbeat PRs.

## Test plan
- [x] 25 new tests in `test/guardrails.test.mjs` — signature stability, allow/warn/block transitions, idempotent same-result detection, custom thresholds, reset, snapshot, default sets
- [x] Full suite still green: 170/170 (was 145, +25 new)
- [x] `npm run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)