### PR TITLE
feat: engine reliability + observability cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "test:ci-smoke": "npm run build && node test/ci-smoke.mjs",
     "test:ci-integration": "npm run build && node test/ci-integration.mjs",
     "test:pod-memory-append-race": "npm run build && node --test test/pod-memory-append-race.test.mjs",
-    "test:halt-guard": "npm run build && node --test test/halt-guard.test.mjs"
+    "test:halt-guard": "npm run build && node --test test/halt-guard.test.mjs",
+    "test:tool-call-part-guard": "npm run build && node --test test/tool-call-part-guard.test.mjs"
   },
   "keywords": [
     "sports",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "test:operate": "npm run build && node --test test/operate.test.mjs",
     "test:daemon-operator": "npm run build && node --test test/daemon-operator.test.mjs",
     "test:ci-smoke": "npm run build && node test/ci-smoke.mjs",
-    "test:ci-integration": "npm run build && node test/ci-integration.mjs"
+    "test:ci-integration": "npm run build && node test/ci-integration.mjs",
+    "test:pod-memory-append-race": "npm run build && node --test test/pod-memory-append-race.test.mjs"
   },
   "keywords": [
     "sports",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "test:daemon-operator": "npm run build && node --test test/daemon-operator.test.mjs",
     "test:ci-smoke": "npm run build && node test/ci-smoke.mjs",
     "test:ci-integration": "npm run build && node test/ci-integration.mjs",
-    "test:pod-memory-append-race": "npm run build && node --test test/pod-memory-append-race.test.mjs"
+    "test:pod-memory-append-race": "npm run build && node --test test/pod-memory-append-race.test.mjs",
+    "test:halt-guard": "npm run build && node --test test/halt-guard.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3014,9 +3014,9 @@ export class sportsclawEngine {
         memory.readStrategy(),
       ]);
 
-      if (this.config.verbose && memoryBlock) {
+      if (memoryBlock) {
         console.error(
-          `[sportsclaw] memory loaded for user ${options.userId} (${memoryBlock.length} chars)`
+          `[sportsclaw] memory_loaded user=${options.userId} chars=${memoryBlock.length}`
         );
       }
     }
@@ -3073,11 +3073,9 @@ export class sportsclawEngine {
       const recentTail = this.messages.slice(-keepCount);
       const dropped = this.messages.length - (pinnedHead.length + recentTail.length);
       this.messages = [...pinnedHead, ...recentTail];
-      if (this.config.verbose) {
-        console.error(
-          `[sportsclaw] context pruned: dropped ${dropped} old messages, keeping ${this.messages.length} (1 pinned + ${recentTail.length} recent)`
-        );
-      }
+      console.error(
+        `[sportsclaw] context_pruned dropped=${dropped} kept=${this.messages.length} pinned=1 recent=${recentTail.length}`
+      );
     }
 
     let stepCount = 0;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -331,6 +331,32 @@ export function isHalt(e: unknown): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-provider message-part shape guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of a tool-call message part as emitted by the Vercel AI SDK across
+ * providers. We only depend on `type` and `toolName`; other fields (id, args)
+ * vary by provider and are not consulted here.
+ */
+export type ToolCallPart = {
+  type: "tool-call";
+  toolName: string;
+};
+
+/**
+ * Runtime guard for tool-call parts. The previous version cast `msg.content`
+ * to a structural array shape and accessed fields without validation, which
+ * silently produced no matches if a provider returned an unexpected envelope.
+ * This guard narrows safely and skips unrecognized shapes.
+ */
+export function isToolCallPart(part: unknown): part is ToolCallPart {
+  if (!part || typeof part !== "object") return false;
+  const p = part as Record<string, unknown>;
+  return p.type === "tool-call" && typeof p.toolName === "string";
+}
+
+// ---------------------------------------------------------------------------
 // Engine class
 // ---------------------------------------------------------------------------
 
@@ -3143,8 +3169,8 @@ export class sportsclawEngine {
       const historyToolNames = new Set<string>();
       for (const msg of this.messages) {
         if (msg.role === "assistant" && Array.isArray(msg.content)) {
-          for (const part of msg.content as Array<{ type?: string; toolName?: string }>) {
-            if (part.type === "tool-call" && part.toolName && part.toolName in tools) {
+          for (const part of msg.content) {
+            if (isToolCallPart(part) && part.toolName in tools) {
               historyToolNames.add(part.toolName);
             }
           }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -317,6 +317,20 @@ export class SessionStore {
 export const sessionStore = new SessionStore();
 
 // ---------------------------------------------------------------------------
+// Halt sentinel guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if `e` is a sentinel that halts the engine loop and must
+ * propagate to the listener (which has dedicated handling for it). Catch
+ * blocks inside engine.run() and its helpers should re-throw on these so
+ * they don't get converted into a normal error response.
+ */
+export function isHalt(e: unknown): boolean {
+  return e instanceof AskUserQuestionHalt || e instanceof ApprovalPendingHalt;
+}
+
+// ---------------------------------------------------------------------------
 // Engine class
 // ---------------------------------------------------------------------------
 
@@ -1496,6 +1510,7 @@ export class sportsclawEngine {
             created_at: task.createdAt,
           });
         } catch (err) {
+          if (isHalt(err)) throw err;
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }
       },
@@ -1612,6 +1627,7 @@ export class sportsclawEngine {
               "when ready. Tell the user you're working on it.",
           });
         } catch (err) {
+          if (isHalt(err)) throw err;
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }
       },
@@ -1824,6 +1840,7 @@ export class sportsclawEngine {
             return `Consolidated ${count} daily log file(s) into CONSOLIDATED.md. ` +
               "Old logs have been deleted. Memory is now leaner.";
           } catch (err) {
+            if (isHalt(err)) throw err;
             return `Consolidation failed: ${err instanceof Error ? err.message : String(err)}`;
           }
         },
@@ -1869,6 +1886,7 @@ export class sportsclawEngine {
           this._generatedImages.push(image);
           return `Image generated successfully with prompt: "${args.prompt}"`;
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Failed to generate image: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -1934,6 +1952,7 @@ export class sportsclawEngine {
           this._generatedVideos.push(video);
           return `Video generated successfully with prompt: "${args.prompt}"`;
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Failed to generate video: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2062,6 +2081,7 @@ export class sportsclawEngine {
           });
           return "```\n" + result + "\n```";
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Chart rendering failed: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2146,6 +2166,7 @@ export class sportsclawEngine {
             message: `Bracket "${session.name}" created with ${session.totalMatchups} matchups. Start picking!`,
           });
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Error creating bracket: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2215,6 +2236,7 @@ export class sportsclawEngine {
           }
           return JSON.stringify(result);
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Error making pick: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2302,6 +2324,7 @@ export class sportsclawEngine {
 
           return parts.join("\n\n");
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Error viewing bracket: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2371,6 +2394,7 @@ export class sportsclawEngine {
             }),
           );
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Error checking bracket status: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2436,6 +2460,7 @@ export class sportsclawEngine {
 
           return `Error: unknown mode "${args.mode}". Use "reset_picks" or "delete".`;
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Error resetting bracket: ${error instanceof Error ? error.message : String(error)}`;
         }
       },
@@ -2617,6 +2642,7 @@ export class sportsclawEngine {
 
           return JSON.stringify(response);
         } catch (error) {
+          if (isHalt(error)) throw error;
           return `Error running simulation: ${error instanceof Error ? error.message : String(error)}`;
         }
       },

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -65,6 +65,7 @@ import {
 import { AskUserQuestionHalt } from "./ask.js";
 import {
   isActionPreApproved,
+  ApprovalPendingHalt,
 } from "./approval.js";
 import { isGuideIntent, generateGuideResponse } from "./guide.js";
 import { createTask, listTasks, completeTask } from "./taskbus.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ const PKG_VERSION: string = require("../package.json").version;
 // Re-exports for library usage
 // ---------------------------------------------------------------------------
 
-export { sportsclawEngine } from "./engine.js";
+export { sportsclawEngine, isHalt } from "./engine.js";
 export {
   TOOL_SPECS,
   ToolRegistry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,8 @@ const PKG_VERSION: string = require("../package.json").version;
 // Re-exports for library usage
 // ---------------------------------------------------------------------------
 
-export { sportsclawEngine, isHalt } from "./engine.js";
+export { sportsclawEngine, isHalt, isToolCallPart } from "./engine.js";
+export type { ToolCallPart } from "./engine.js";
 export {
   TOOL_SPECS,
   ToolRegistry,

--- a/src/listeners/discord.ts
+++ b/src/listeners/discord.ts
@@ -42,6 +42,7 @@ import {
   getAllowedUsers,
   ButtonContextStore,
   buildListenerEngineConfig,
+  formatListenerError,
 } from "./shared.js";
 
 const PREFIX = process.env.DISCORD_PREFIX || "!sportsclaw";
@@ -189,7 +190,7 @@ export async function startDiscordListener(): Promise<void> {
         }
       } catch (sendErr) {
         console.error(
-          `[sportsclaw] Failed to send to channel: ${sendErr instanceof Error ? sendErr.message : sendErr}`
+          `[sportsclaw] Failed to send to channel: ${formatListenerError(sendErr)}`
         );
       }
     }
@@ -371,7 +372,7 @@ export async function startDiscordListener(): Promise<void> {
     } catch (err) {
       // Polls require the SEND_POLLS permission — degrade silently
       if (process.env.SPORTSCLAW_VERBOSE) {
-        console.error(`[sportsclaw] Poll creation failed: ${err instanceof Error ? err.message : err}`);
+        console.error(`[sportsclaw] Poll creation failed: ${formatListenerError(err)}`);
       }
     }
   }
@@ -448,7 +449,7 @@ export async function startDiscordListener(): Promise<void> {
           });
         }
       } catch (error: unknown) {
-        const errMsg = error instanceof Error ? error.message : String(error);
+        const errMsg = formatListenerError(error);
         console.error(`[sportsclaw] AskUserQuestion resume error: ${errMsg}`);
         await interaction.editReply(
           "Sorry, I encountered an error processing your selection."
@@ -508,7 +509,7 @@ export async function startDiscordListener(): Promise<void> {
           });
         }
       } catch (error: unknown) {
-        const errMsg = error instanceof Error ? error.message : String(error);
+        const errMsg = formatListenerError(error);
         console.error(`[sportsclaw] Quick action error: ${errMsg}`);
         await interaction.editReply("Sorry, I encountered an error processing that request.");
       }
@@ -555,7 +556,7 @@ export async function startDiscordListener(): Promise<void> {
         });
       }
     } catch (error: unknown) {
-      const errMsg = error instanceof Error ? error.message : String(error);
+      const errMsg = formatListenerError(error);
       console.error(`[sportsclaw] Button handler error: ${errMsg}`);
       await interaction.editReply(
         "Sorry, I encountered an error processing that request."
@@ -592,7 +593,7 @@ export async function startDiscordListener(): Promise<void> {
       } catch (err) {
         // Non-fatal — prefix commands still work
         console.error(
-          `[sportsclaw] Slash command registration failed: ${err instanceof Error ? err.message : err}`
+          `[sportsclaw] Slash command registration failed: ${formatListenerError(err)}`
         );
       }
     }
@@ -678,7 +679,7 @@ export async function startDiscordListener(): Promise<void> {
           await sendGeneratedImages(pollEngine, message);
           await sendGeneratedVideos(pollEngine, message);
         } catch (error: unknown) {
-          const errMsg = error instanceof Error ? error.message : String(error);
+          const errMsg = formatListenerError(error);
           console.error(`[sportsclaw] Discord error: ${errMsg}`);
           await safeSend(message, "Sorry, I encountered an error processing your request.");
         } finally {
@@ -737,7 +738,7 @@ export async function startDiscordListener(): Promise<void> {
         return;
       }
 
-      const errMsg = error instanceof Error ? error.message : String(error);
+      const errMsg = formatListenerError(error);
       console.error(`[sportsclaw] Discord error: ${errMsg}`);
       await safeSend(
         message,
@@ -778,7 +779,7 @@ export async function startDiscordListener(): Promise<void> {
   try {
     await client.login(process.env.DISCORD_BOT_TOKEN);
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatListenerError(err);
     if (msg.includes("disallowed intents")) {
       console.error("[sportsclaw] Error: Discord rejected the connection due to disallowed intents.");
       console.error("");

--- a/src/listeners/shared.ts
+++ b/src/listeners/shared.ts
@@ -38,6 +38,28 @@ export function parsePositiveInt(value: string | undefined, fallback: number): n
 }
 
 // ---------------------------------------------------------------------------
+// Error formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical "anything → string" coercion for listener catch blocks.
+ *
+ * Both listeners caught errors with subtly different inline patterns —
+ *   • `e instanceof Error ? e.message : String(e)`  (canonical, most sites)
+ *   • `e instanceof Error ? e.message : e`           (drops the String wrap)
+ *   • `e.message` / `e.stack ?? e.message`           (assumes typed Error)
+ *
+ * The middle form returns the original (possibly non-string) value when
+ * `e` isn't an Error, which then gets template-literal-stringified
+ * unpredictably depending on the provider.
+ *
+ * Use this helper instead. Always returns a string.
+ */
+export function formatListenerError(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// ---------------------------------------------------------------------------
 // Button context store — bounded LRU keyed by random short ID.
 // ---------------------------------------------------------------------------
 

--- a/src/listeners/telegram.ts
+++ b/src/listeners/telegram.ts
@@ -39,6 +39,7 @@ import {
   getAllowedUsers,
   ButtonContextStore,
   buildListenerEngineConfig,
+  formatListenerError,
 } from "./shared.js";
 
 const COMMAND_PREFIX = "/claw";
@@ -479,7 +480,7 @@ export async function startTelegramListener(): Promise<void> {
       lastSuccessfulPoll = Date.now();
     } catch (error: unknown) {
       // Network errors during polling — retry after a short delay
-      const errMsg = error instanceof Error ? error.message : String(error);
+      const errMsg = formatListenerError(error);
       console.error(`[sportsclaw] Polling error: ${errMsg}`);
       await new Promise((r) => setTimeout(r, 5000));
     }
@@ -572,7 +573,7 @@ async function sendGeneratedImages(
       method: "POST",
       body: formData,
     }).catch((err) => {
-      console.error(`[sportsclaw] Failed to send generated image: ${err instanceof Error ? err.message : err}`);
+      console.error(`[sportsclaw] Failed to send generated image: ${formatListenerError(err)}`);
     });
     // Persist locally
     saveImageToDisk(img.data, img.mimeType).catch(() => {});
@@ -765,7 +766,7 @@ async function processMessage(
       return;
     }
 
-    const errMsg = error instanceof Error ? error.message : String(error);
+    const errMsg = formatListenerError(error);
     console.error(`[sportsclaw] Telegram error: ${errMsg}`);
     await sendMessage(apiBase, msg.chat.id, "Sorry, I encountered an error processing your request.", {
       replyToMessageId: msg.message_id,
@@ -869,7 +870,7 @@ async function processCallbackQuery(
         });
       }
     } catch (resumeErr: unknown) {
-      const errMsg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+      const errMsg = formatListenerError(resumeErr);
       console.error(`[sportsclaw] AskUserQuestion resume error: ${errMsg}`);
       await sendMessage(apiBase, cqMessage.chat.id, "Sorry, I encountered an error processing your selection.", {
         replyToMessageId: cqMessage.message_id,
@@ -963,7 +964,7 @@ async function processCallbackQuery(
         });
       }
     } catch (error: unknown) {
-      const errMsg = error instanceof Error ? error.message : String(error);
+      const errMsg = formatListenerError(error);
       console.error(`[sportsclaw] Quick action error: ${errMsg}`);
       await sendMessage(apiBase, cqMessage.chat.id, "Sorry, I encountered an error processing that request.");
     } finally {
@@ -1038,7 +1039,7 @@ async function processCallbackQuery(
       });
     }
   } catch (error: unknown) {
-    const errMsg = error instanceof Error ? error.message : String(error);
+    const errMsg = formatListenerError(error);
     console.error(`[sportsclaw] Callback query error: ${errMsg}`);
     await sendMessage(
       apiBase,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -227,6 +227,12 @@ export class PodMemoryStorage implements MemoryStorage {
   // races and each branch creates its own duplicate memory doc.
   private cache = new Map<string, Promise<MemoryEntry>>();
 
+  // Per-userId serialization chain for read-modify-write operations (append).
+  // Without this, two concurrent append() calls on the same userId both read
+  // the pre-mutation doc and the second flush overwrites the first — losing
+  // an entry. Chaining serializes the RMW segment so both writes land.
+  private appendChain = new Map<string, Promise<void>>();
+
   constructor(private mcpManager: McpManager, private serverName: string) {}
 
   /**
@@ -402,8 +408,26 @@ export class PodMemoryStorage implements MemoryStorage {
   }
 
   async append(userId: string, file: string, content: string): Promise<void> {
-    const existing = await this.read(userId, file);
-    await this.write(userId, file, existing ? `${existing}\n${content}` : content);
+    // Serialize concurrent appends per userId. read+write share a cached doc
+    // that mutates synchronously, but the read→mutate→flush sequence isn't
+    // atomic, so two concurrent appends would both read pre-mutation state
+    // and the second write would overwrite the first. Queue them instead.
+    const previous = this.appendChain.get(userId) ?? Promise.resolve();
+    const next = previous
+      .catch(() => {}) // existing append swallowed errors; preserve that
+      .then(async () => {
+        const existing = await this.read(userId, file);
+        await this.write(userId, file, existing ? `${existing}\n${content}` : content);
+      });
+    this.appendChain.set(userId, next);
+    try {
+      await next;
+    } finally {
+      // Drop the entry once we're the tail of the chain so the map doesn't grow.
+      if (this.appendChain.get(userId) === next) {
+        this.appendChain.delete(userId);
+      }
+    }
   }
 
   async list(userId: string, _pattern: string): Promise<string[]> {

--- a/test/halt-guard.test.mjs
+++ b/test/halt-guard.test.mjs
@@ -1,0 +1,45 @@
+/**
+ * isHalt — type guard for engine-halting sentinel errors.
+ *
+ * Tool-wrapper catch blocks in engine.ts must re-throw halts so the
+ * listener can render the appropriate UI (clarifying question / approval
+ * prompt). Without the guard they would be converted into normal error
+ * strings and the halt mechanism breaks silently.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isHalt, AskUserQuestionHalt } from "../dist/index.js";
+import { ApprovalPendingHalt } from "../dist/approval.js";
+
+describe("isHalt", () => {
+  it("returns true for AskUserQuestionHalt", () => {
+    // Constructor accesses .prompt for the super() message; rest of the
+    // request fields don't matter for the guard.
+    const e = new AskUserQuestionHalt({ prompt: "?" });
+    assert.equal(isHalt(e), true);
+  });
+
+  it("returns true for ApprovalPendingHalt", () => {
+    // Constructor accesses .action and .description for super(); rest unused.
+    const e = new ApprovalPendingHalt({ action: "trade", description: "place order" });
+    assert.equal(isHalt(e), true);
+  });
+
+  it("returns false for a plain Error", () => {
+    assert.equal(isHalt(new Error("boom")), false);
+  });
+
+  it("returns false for a TypeError subclass", () => {
+    assert.equal(isHalt(new TypeError("bad type")), false);
+  });
+
+  it("returns false for non-Error values", () => {
+    assert.equal(isHalt("string"), false);
+    assert.equal(isHalt(42), false);
+    assert.equal(isHalt(null), false);
+    assert.equal(isHalt(undefined), false);
+    assert.equal(isHalt({ message: "looks like an error" }), false);
+  });
+});

--- a/test/pod-memory-append-race.test.mjs
+++ b/test/pod-memory-append-race.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * PodMemoryStorage.append — concurrent-write race regression test.
+ *
+ * Without per-userId serialization, two concurrent appends on the same
+ * (userId, file) read pre-mutation state and the second flush overwrites
+ * the first, silently losing one entry. This test fires two appends in
+ * parallel and asserts both contents land in the persisted doc.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { PodMemoryStorage } from "../dist/memory.js";
+
+/**
+ * Minimal McpManager stub. Maintains a single in-memory doc keyed by
+ * `name` (e.g. "memory-<userId>") and applies search/create/update calls
+ * the way Machina pods would, with an artificial async delay so the race
+ * window in the SUT is wide enough to be deterministic.
+ */
+function makeMcpStub({ writeDelayMs = 5 } = {}) {
+  const store = new Map(); // name -> { _id, value }
+  let nextId = 1;
+  const calls = [];
+
+  const callToolDirect = async (_serverName, toolName, args) => {
+    calls.push({ toolName, args });
+
+    if (toolName === "search_documents") {
+      const name = args.filters?.name;
+      const hit = store.get(name);
+      const data = hit ? [{ _id: hit._id, value: hit.value, updated: Date.now() }] : [];
+      return {
+        isError: false,
+        content: JSON.stringify({ data: { data, status: "ok", total_documents: data.length } }),
+      };
+    }
+
+    if (toolName === "create_document") {
+      const id = `doc-${nextId++}`;
+      const value = args.content?.value ?? {};
+      // Simulate network latency around the write so concurrent flushes can race.
+      await new Promise((r) => setTimeout(r, writeDelayMs));
+      store.set(args.name, { _id: id, value });
+      return {
+        isError: false,
+        content: JSON.stringify({ data: { data: { _id: id } } }),
+      };
+    }
+
+    if (toolName === "update_document") {
+      const id = args.item_id;
+      const value = args.content?.value ?? {};
+      await new Promise((r) => setTimeout(r, writeDelayMs));
+      // Find and replace by _id
+      for (const [name, doc] of store.entries()) {
+        if (doc._id === id) {
+          store.set(name, { _id: id, value });
+          break;
+        }
+      }
+      return { isError: false, content: JSON.stringify({ data: { data: { _id: id } } }) };
+    }
+
+    if (toolName === "delete_document") {
+      // Used only by migration; not exercised here.
+      return { isError: false, content: "{}" };
+    }
+
+    return { isError: false, content: "{}" };
+  };
+
+  return {
+    mcpManager: { callToolDirect },
+    store,
+    calls,
+  };
+}
+
+describe("PodMemoryStorage.append — concurrent-write safety", () => {
+  it("preserves both entries when two appends run in parallel for the same user", async () => {
+    const { mcpManager, store } = makeMcpStub({ writeDelayMs: 8 });
+    const storage = new PodMemoryStorage(mcpManager, "machina-test");
+    const userId = "race-test-user";
+
+    // Fire two appends in parallel. Without the per-userId chain, they would
+    // both read the empty doc and the second flush would overwrite the first.
+    await Promise.all([
+      storage.append(userId, "REFLECTIONS.md", "first"),
+      storage.append(userId, "REFLECTIONS.md", "second"),
+    ]);
+
+    const finalDoc = store.get(`memory-${userId}`);
+    assert.ok(finalDoc, "expected memory doc to exist after appends");
+
+    const reflections = finalDoc.value.reflections ?? "";
+    assert.match(
+      reflections,
+      /first/,
+      `expected 'first' to be present in final reflections; got: ${JSON.stringify(reflections)}`
+    );
+    assert.match(
+      reflections,
+      /second/,
+      `expected 'second' to be present in final reflections; got: ${JSON.stringify(reflections)}`
+    );
+  });
+
+  it("preserves order within a single chain (each append sees the previous one's content)", async () => {
+    const { mcpManager, store } = makeMcpStub({ writeDelayMs: 4 });
+    const storage = new PodMemoryStorage(mcpManager, "machina-test");
+    const userId = "ordered-test-user";
+
+    // Sequential awaits — each must see the prior content.
+    await storage.append(userId, "REFLECTIONS.md", "a");
+    await storage.append(userId, "REFLECTIONS.md", "b");
+    await storage.append(userId, "REFLECTIONS.md", "c");
+
+    const finalDoc = store.get(`memory-${userId}`);
+    const reflections = finalDoc?.value?.reflections ?? "";
+    assert.equal(
+      reflections,
+      "a\nb\nc",
+      `expected 'a\\nb\\nc'; got: ${JSON.stringify(reflections)}`
+    );
+  });
+});

--- a/test/tool-call-part-guard.test.mjs
+++ b/test/tool-call-part-guard.test.mjs
@@ -1,0 +1,56 @@
+/**
+ * isToolCallPart — runtime guard for cross-provider tool-call message parts.
+ *
+ * Replaces a structural cast (`msg.content as Array<{type?, toolName?}>`)
+ * that silently produced no matches when a provider returned an unexpected
+ * shape. The guard only accepts parts where `type === "tool-call"` and
+ * `toolName` is a string.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isToolCallPart } from "../dist/index.js";
+
+describe("isToolCallPart", () => {
+  it("accepts a well-formed tool-call part", () => {
+    assert.equal(isToolCallPart({ type: "tool-call", toolName: "get_score" }), true);
+  });
+
+  it("accepts extra fields without rejecting", () => {
+    // Real Vercel AI SDK parts carry id/args/etc.; the guard only checks the
+    // fields we depend on, so additional properties are fine.
+    assert.equal(
+      isToolCallPart({
+        type: "tool-call",
+        toolName: "get_score",
+        toolCallId: "tc-1",
+        args: { sport: "nba" },
+      }),
+      true
+    );
+  });
+
+  it("rejects a part with the wrong type", () => {
+    assert.equal(isToolCallPart({ type: "text", toolName: "get_score" }), false);
+    assert.equal(isToolCallPart({ type: "tool-result", toolName: "get_score" }), false);
+  });
+
+  it("rejects a part missing toolName", () => {
+    assert.equal(isToolCallPart({ type: "tool-call" }), false);
+  });
+
+  it("rejects a part where toolName is not a string", () => {
+    assert.equal(isToolCallPart({ type: "tool-call", toolName: 42 }), false);
+    assert.equal(isToolCallPart({ type: "tool-call", toolName: null }), false);
+    assert.equal(isToolCallPart({ type: "tool-call", toolName: { name: "x" } }), false);
+  });
+
+  it("rejects non-objects", () => {
+    assert.equal(isToolCallPart(null), false);
+    assert.equal(isToolCallPart(undefined), false);
+    assert.equal(isToolCallPart("tool-call"), false);
+    assert.equal(isToolCallPart(123), false);
+    assert.equal(isToolCallPart(true), false);
+  });
+});


### PR DESCRIPTION
## What

Five small, related improvements to the engine and listener layer, bundled because each one is hard to evaluate in isolation without the others. Two are real bug fixes (silent data loss, silently-swallowed UI halts), two are type/consistency cleanups, and one is a production-debugging primitive that makes the rest evaluable in real deployments.

```
31120aa  feat: emit memory_loaded and context_pruned logs unconditionally
a140742  fix:  serialize PodMemoryStorage.append per userId to prevent data loss
087d2f0  fix:  re-throw halt sentinels from tool-wrapper catch blocks
fb4f14c  chore: tighten cross-provider tool-call message-part typing
636a7fa  chore: extract formatListenerError helper, normalize listener catch blocks
```

Each commit message has the full detail; this description summarizes the why per item.

## Why

| # | Problem | Impact |
|---|---|---|
| 1 | `memory_loaded` and `context_pruned` diagnostic logs in `engine.run()` were gated behind `if (this.config.verbose)`, so production daemon deployments never emitted them. When users report "the bot forgot me," there's no historical trace to confirm whether memory actually loaded. | Post-hoc memory debugging was impossible — verbose-on-demand can't reconstruct a past failure. |
| 2 | `PodMemoryStorage.append()` was a non-atomic read-modify-write on a shared cached doc. Two concurrent `append()` calls on the same `(userId, file)` both read pre-mutation state, and the second flush silently overwrote the first — losing one entry. | Daily-log entries and any append-only memory writes were exposed to silent data loss under any concurrency. |
| 3 | 12 tool-wrapper `catch` blocks in `engine.run()` caught `AskUserQuestionHalt` and `ApprovalPendingHalt` as generic errors and converted them to strings like `"Error: [AskUserQuestion] ..."`. Listeners never saw the halt and the user never got the clarifying-question or approval UI. | Silently broken UX for any tool path that needed to halt for user input. |
| 4 | The `activeTools` merge for follow-up turns walked assistant message content with a structural cast (`as Array<{type?, toolName?}>`). Providers that returned an unexpected envelope shape silently produced no matches; the merge would skip valid history and the LLM call could fail with "tool not in activeTools" errors that look unrelated. | Cross-provider fragility, hard-to-diagnose tool-not-found failures. |
| 5 | Discord and Telegram listeners caught errors with three subtly different inline patterns. One variant (`e instanceof Error ? e.message : e`, missing the `String()` wrap) returned the original non-string value when `e` wasn't an `Error`, which template-literal-coerced unpredictably depending on the source. | Cosmetic but exactly the kind of drift that produces "buttons-don't-show-up"-class bugs when the listeners are touched together. |
