### PR TITLE
feat: add operator daemon (autonomous tick loop integration)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:guardrails": "npm run build && node --test test/guardrails.test.mjs",
     "test:heartbeat-state": "npm run build && node --test test/heartbeat-state.test.mjs",
     "test:heartbeat": "npm run build && node --test test/heartbeat.test.mjs",
-    "test:heartbeat-wake-gate": "npm run build && node --test test/heartbeat-wake-gate.test.mjs"
+    "test:heartbeat-wake-gate": "npm run build && node --test test/heartbeat-wake-gate.test.mjs",
+    "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -252,6 +252,22 @@ export class HeartbeatService {
   }
 
   /**
+   * Mark a job as starting a run. Bumps runCount, advances nextRunAt, sets
+   * lastStatus="running". The cron timer calls this implicitly via the
+   * advance-before-execute path; manual / `tickOnce` callers should invoke
+   * it before `markJobSucceeded` so the success record actually lands
+   * (markRunSuccess updates an existing record only).
+   * No-op when persistence is off.
+   */
+  async markJobStart(jobId: string, opts: { intervalMs: number }): Promise<void> {
+    if (!this.stateStore) return;
+    await this.stateStore.markRunStart(jobId, {
+      intervalMs: opts.intervalMs,
+      lifecycle: "active",
+    });
+  }
+
+  /**
    * Mark the most recent run of `jobId` as succeeded. Downstream cron handlers
    * call this after the work finishes. No-op when persistence is off.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,6 +348,15 @@ export type {
   GuardrailDetail,
 } from "./guardrails.js";
 
+// Operator Daemon (autonomous tick loop)
+export { createOperatorDaemon } from "./operator-daemon.js";
+export type {
+  OperatorDaemon,
+  OperatorDaemonConfig,
+  TickEvent,
+  TickStatus,
+} from "./operator-daemon.js";
+
 // ---------------------------------------------------------------------------
 // Markdown terminal renderer
 // ---------------------------------------------------------------------------

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -1,0 +1,448 @@
+/**
+ * Operator Daemon — autonomous tick loop for SportsClaw.
+ *
+ * Wires the four primitive surfaces into a single tick driver:
+ *
+ *   HeartbeatService       schedules + persists + locks + wake-gates ticks
+ *   EditorialMemory        frozen-snapshot lessons surfaced into the prompt
+ *   LastTickBrief          per-tick handoff (last brief in, this brief out)
+ *   ToolGuardController    anti-loop circuit breaker around tool execution
+ *
+ * The adapter calls the Vercel AI SDK's `generateText` directly. It does NOT
+ * extend or reshape `engine.ts` — chat-mode and operator-mode have genuinely
+ * different shapes (no stdin, no user turn, [SILENT] sentinel, time-driven)
+ * and unifying them would fight assumptions baked into the chat REPL. Future
+ * cleanup can extract a shared `core/llm-pass` module if real shared logic
+ * emerges.
+ *
+ * Lifecycle of a single tick:
+ *   1. Heartbeat fires the cron timer.
+ *   2. The optional wake gate runs INSIDE heartbeat — if denied, cron_skipped
+ *      fires and the tick is recorded but the LLM is never invoked.
+ *   3. Heartbeat marks run-start (advance-before-execute), then emits
+ *      cron_fired with optional wake context.
+ *   4. The daemon's onEvent handler picks up cron_fired for THIS jobId and:
+ *        a. Loads the editorial-memory snapshot (frozen for the tick).
+ *        b. Loads up to N recent briefs across all known jobs.
+ *        c. Composes a system prompt via buildSystemPrompt.
+ *        d. Resets the tool guardrail and wraps each tool's execute with it.
+ *        e. Calls generateText with the prompt + wrapped tools.
+ *        f. Parses output for [SILENT]; writes a brief either way.
+ *        g. Marks run success or failure on the heartbeat persistence.
+ *
+ * One daemon = one cron job in this PR. Multi-job is a future extension.
+ */
+
+import path from "node:path";
+import {
+  generateText,
+  type LanguageModel,
+  type ToolSet,
+  type Tool,
+} from "ai";
+
+import {
+  HeartbeatService,
+  type CronJob,
+  type HeartbeatEvent,
+  type WakeGateFn,
+} from "./heartbeat.js";
+import { EditorialMemory } from "./editorial-memory.js";
+import { LastTickBrief, newTickId } from "./last-tick-brief.js";
+import { buildSystemPrompt } from "./prompts.js";
+import {
+  ToolGuardController,
+  digestResult,
+  type ToolGuardOptions,
+} from "./guardrails.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TickStatus = "silent" | "published" | "failed" | "skipped";
+
+export interface TickEvent {
+  type:
+    | "tick_started"
+    | "tick_silent"
+    | "tick_published"
+    | "tick_failed"
+    | "tick_skipped";
+  jobId: string;
+  tickId: string;
+  /** Final assistant text, if any. Omitted when silent or failed. */
+  text?: string;
+  /** Reason string for skipped, error message for failed. */
+  reason?: string;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+  /** Counts captured from the per-tick guardrail. */
+  toolCalls?: number;
+  guardrailWarnings?: number;
+  guardrailBlocks?: number;
+}
+
+export interface OperatorDaemonConfig {
+  /** Stable cron job id used by heartbeat persistence + brief filenames. */
+  jobId: string;
+  /** Human label (heartbeat logs). Defaults to jobId. */
+  jobLabel?: string;
+  /** Tick interval in ms. */
+  intervalMs: number;
+  /** User scope (heartbeat persistence keys by this). Default "operator". */
+  userId?: string;
+
+  /** AI SDK language model used for the tick LLM call. */
+  model: LanguageModel;
+  /** Persona / role paragraph — top of every system prompt. */
+  role: string;
+  /** Per-tick user prompt template. `{tickId}` and `{timestamp}` are substituted. */
+  tickPrompt?: string;
+  /** Tools handed to the model. Each tool's `execute` is wrapped by the guardrail. */
+  tools?: ToolSet;
+  /** Max output tokens for the tick. Default 2048. */
+  maxOutputTokens?: number;
+  /** Append additional fragments to the system prompt (project-specific guides, etc.). */
+  extraFragments?: string[];
+
+  /** Filesystem root for daemon surfaces. Subdirs created lazily. */
+  rootDir: string;
+  /** Editorial memory file path. Default `<rootDir>/editorial-memory.md`. */
+  memoryFilePath?: string;
+  /** Brief root dir. Default `<rootDir>/briefs`. */
+  briefDir?: string;
+  /** State + lock dir for heartbeat persistence. Default `<rootDir>`. */
+  stateDir?: string;
+
+  /** Optional wake gate. Forwarded to heartbeat unchanged. */
+  wakeGate?: WakeGateFn;
+  /** Tool guardrail thresholds + tool categorisation. */
+  guardOptions?: ToolGuardOptions;
+  /**
+   * How many recent briefs (per job) to surface to the model. Default 1.
+   */
+  recentBriefLimit?: number;
+  /**
+   * Job ids to pull recent briefs from. Defaults to `[jobId]`. Useful when
+   * multiple daemons share editorial context.
+   */
+  recentBriefJobIds?: string[];
+
+  /** Telemetry hook — called for every tick lifecycle event. */
+  onTickEvent?: (event: TickEvent) => void;
+  /** Heartbeat event hook — surfaces cron_fired / cron_skipped / etc. */
+  onHeartbeatEvent?: (event: HeartbeatEvent) => void;
+
+  /** Inject a HeartbeatService (tests). Default: a fresh instance. */
+  heartbeat?: HeartbeatService;
+  /** Inject a generateText impl (tests). Default: ai SDK's. */
+  generateTextImpl?: typeof generateText;
+}
+
+export interface OperatorDaemon {
+  /** Underlying heartbeat — exposed for inspection / advanced wiring. */
+  readonly heartbeat: HeartbeatService;
+  /** The scheduled cron job (after start()). */
+  readonly cronJob: CronJob | null;
+  /** Start scheduling. Idempotent. */
+  start(): void;
+  /** Stop scheduling and clear timers. */
+  stop(): void;
+  /**
+   * Run a single tick body synchronously, bypassing heartbeat scheduling.
+   * Intended for tests and `sportsclaw operate --once` style commands.
+   * Heartbeat persistence is still touched (markRunStart / Success / Failed)
+   * if persistence is configured.
+   */
+  tickOnce(): Promise<TickEvent>;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TICK_PROMPT = [
+  "Tick {tickId} at {timestamp}.",
+  "",
+  "Decide the next on-air action for this job. Inspect the editorial memory",
+  "and previous tick brief above; call tools to fetch live data; produce a",
+  "short broadcast/telemetry summary OR return [SILENT] if nothing new is",
+  "worth surfacing.",
+].join("\n");
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+const DEFAULT_RECENT_BRIEF_LIMIT = 1;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createOperatorDaemon(
+  cfg: OperatorDaemonConfig,
+): OperatorDaemon {
+  if (!cfg.jobId) throw new Error("OperatorDaemon: jobId is required.");
+  if (!cfg.intervalMs || cfg.intervalMs <= 0) {
+    throw new Error("OperatorDaemon: intervalMs must be > 0.");
+  }
+  if (!cfg.rootDir) throw new Error("OperatorDaemon: rootDir is required.");
+
+  const userId = cfg.userId ?? "operator";
+  const memoryFilePath =
+    cfg.memoryFilePath ?? path.join(cfg.rootDir, "editorial-memory.md");
+  const briefDir = cfg.briefDir ?? path.join(cfg.rootDir, "briefs");
+  const stateDir = cfg.stateDir ?? cfg.rootDir;
+  const recentBriefLimit = cfg.recentBriefLimit ?? DEFAULT_RECENT_BRIEF_LIMIT;
+  const recentBriefJobIds = cfg.recentBriefJobIds ?? [cfg.jobId];
+  const tickPromptTemplate = cfg.tickPrompt ?? DEFAULT_TICK_PROMPT;
+  const generateImpl = cfg.generateTextImpl ?? generateText;
+
+  const heartbeat = cfg.heartbeat ?? new HeartbeatService();
+  if (!heartbeat.hasPersistence) {
+    heartbeat.configurePersistence({ stateDir });
+  }
+
+  const memory = new EditorialMemory(memoryFilePath);
+  const briefStore = new LastTickBrief(briefDir);
+
+  let cronJob: CronJob | null = null;
+  let started = false;
+
+  // ---- core tick body ---------------------------------------------------
+
+  async function runTick(tickId: string): Promise<TickEvent> {
+    const timestamp = new Date().toISOString();
+    cfg.onTickEvent?.({
+      type: "tick_started",
+      jobId: cfg.jobId,
+      tickId,
+      timestamp,
+    });
+
+    // 1. Frozen memory snapshot for this tick.
+    await memory.load();
+    const memorySnapshot = memory.snapshot();
+
+    // 2. Recent brief context across the configured job set.
+    const recentTickBrief = await briefStore.contextFrom(recentBriefJobIds, {
+      perJobLimit: recentBriefLimit,
+    });
+
+    // 3. System prompt composition.
+    const system = buildSystemPrompt({
+      role: cfg.role,
+      isCron: true,
+      toolDiscipline: true,
+      silentSentinel: true,
+      editorialMemorySnapshot: memorySnapshot,
+      recentTickBrief,
+      extras: cfg.extraFragments,
+    });
+
+    // 4. Wrap tools with the guardrail.
+    const guard = new ToolGuardController(cfg.guardOptions);
+    const counts = { calls: 0, warnings: 0, blocks: 0 };
+    const wrappedTools = wrapTools(cfg.tools, guard, counts);
+
+    const tickPrompt = tickPromptTemplate
+      .replace("{tickId}", tickId)
+      .replace("{timestamp}", timestamp);
+
+    // 5. LLM pass.
+    let text = "";
+    let failureReason: string | undefined;
+    try {
+      const result = await generateImpl({
+        model: cfg.model,
+        system,
+        prompt: tickPrompt,
+        ...(wrappedTools ? { tools: wrappedTools } : {}),
+        maxOutputTokens: cfg.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+      });
+      text = (result.text ?? "").trim();
+    } catch (err) {
+      failureReason = err instanceof Error ? err.message : String(err);
+    }
+
+    // 6. Persist a brief either way (failures get a body too — handoff).
+    const briefBody = failureReason
+      ? `**tick failed**: ${failureReason}`
+      : text || "[SILENT]";
+    try {
+      await briefStore.write({
+        tickId,
+        jobId: cfg.jobId,
+        body: briefBody,
+      });
+    } catch (err) {
+      // brief-write failure is logged but does not promote a successful
+      // tick to failed — the LLM result is the source of truth.
+      console.error(
+        `[operator-daemon] brief write failed for tick ${tickId}: ${
+          err instanceof Error ? err.message : err
+        }`,
+      );
+    }
+
+    // 7. Heartbeat status + telemetry.
+    if (failureReason) {
+      await heartbeat
+        .markJobFailed(cfg.jobId, failureReason)
+        .catch(() => {});
+      const event: TickEvent = {
+        type: "tick_failed",
+        jobId: cfg.jobId,
+        tickId,
+        reason: failureReason,
+        timestamp,
+        toolCalls: counts.calls,
+        guardrailWarnings: counts.warnings,
+        guardrailBlocks: counts.blocks,
+      };
+      cfg.onTickEvent?.(event);
+      return event;
+    }
+
+    await heartbeat.markJobSucceeded(cfg.jobId).catch(() => {});
+
+    const silent = LastTickBrief.isSilent(text);
+    const event: TickEvent = {
+      type: silent ? "tick_silent" : "tick_published",
+      jobId: cfg.jobId,
+      tickId,
+      text: silent ? undefined : text,
+      timestamp,
+      toolCalls: counts.calls,
+      guardrailWarnings: counts.warnings,
+      guardrailBlocks: counts.blocks,
+    };
+    cfg.onTickEvent?.(event);
+    return event;
+  }
+
+  // ---- heartbeat event routing -----------------------------------------
+
+  const onEvent = (event: HeartbeatEvent): void => {
+    cfg.onHeartbeatEvent?.(event);
+    if (event.cronJobId !== cronJob?.id) return;
+
+    if (event.type === "cron_skipped") {
+      const tickId = newTickId();
+      const skip: TickEvent = {
+        type: "tick_skipped",
+        jobId: cfg.jobId,
+        tickId,
+        reason: event.result ?? "wake gate denied",
+        timestamp: event.timestamp,
+      };
+      cfg.onTickEvent?.(skip);
+      return;
+    }
+
+    if (event.type === "cron_fired") {
+      const tickId = newTickId();
+      runTick(tickId).catch((err) => {
+        console.error(
+          `[operator-daemon] tick crashed for ${cfg.jobId}: ${
+            err instanceof Error ? err.message : err
+          }`,
+        );
+      });
+    }
+  };
+
+  heartbeat.setEventHandler(onEvent);
+
+  // ---- public surface --------------------------------------------------
+
+  return {
+    get heartbeat() {
+      return heartbeat;
+    },
+    get cronJob() {
+      return cronJob;
+    },
+    start(): void {
+      if (started) return;
+      cronJob = heartbeat.scheduleCron({
+        label: cfg.jobLabel ?? cfg.jobId,
+        prompt: cfg.role, // not used by the cron timer; kept for traceability
+        userId,
+        intervalMs: cfg.intervalMs,
+        recurring: true,
+        wakeGate: cfg.wakeGate,
+      });
+      // Re-key the persisted job under the configured jobId so subsequent
+      // markJobSucceeded / Failed calls land on the same record. The heartbeat
+      // generates its own id; we accept that and use it for routing.
+      cfg.jobId = cronJob.id; // bind config jobId to the actual cron id
+      heartbeat.start();
+      started = true;
+    },
+    stop(): void {
+      heartbeat.stop();
+      started = false;
+    },
+    async tickOnce(): Promise<TickEvent> {
+      return runTick(newTickId());
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TickCounts {
+  calls: number;
+  warnings: number;
+  blocks: number;
+}
+
+/**
+ * Wrap each tool's `execute` so the guardrail decides whether to allow,
+ * warn, or block. Returns undefined (so generateText omits the tools field)
+ * when no tools were provided.
+ */
+function wrapTools(
+  tools: ToolSet | undefined,
+  guard: ToolGuardController,
+  counts: TickCounts,
+): ToolSet | undefined {
+  if (!tools) return undefined;
+  const wrapped: ToolSet = {};
+  for (const [name, def] of Object.entries(tools)) {
+    wrapped[name] = wrapOneTool(name, def, guard, counts);
+  }
+  return wrapped;
+}
+
+function wrapOneTool(
+  name: string,
+  def: Tool,
+  guard: ToolGuardController,
+  counts: TickCounts,
+): Tool {
+  const original = (def as { execute?: Tool["execute"] }).execute;
+  if (!original) return def; // declarative-only tools (no runtime execute) — pass through
+
+  const wrappedExecute: NonNullable<Tool["execute"]> = async (args, ctx) => {
+    const decision = guard.beforeCall(name, args);
+    if (decision.action === "block") {
+      counts.blocks++;
+      return decision.syntheticResult as unknown;
+    }
+    if (decision.action === "warn") counts.warnings++;
+    counts.calls++;
+    try {
+      const result = await original(args, ctx);
+      guard.afterCall(name, args, true, digestResult(result));
+      return result;
+    } catch (err) {
+      guard.afterCall(name, args, false);
+      throw err;
+    }
+  };
+
+  return { ...def, execute: wrappedExecute } as Tool;
+}

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -368,6 +368,11 @@ export function createOperatorDaemon(
     },
     start(): void {
       if (started) return;
+      // Order matters: heartbeat.start() must run BEFORE scheduleCron,
+      // because scheduleCron only starts the per-cron timer when the
+      // heartbeat is already running. Reversing the order leaves the cron
+      // job registered but never firing.
+      heartbeat.start();
       // Pin the cron id to the operator-supplied jobId so the brief
       // directory, persisted record, and per-job lockfile all use the same
       // key — and so two daemon replicas can coordinate via the per-job
@@ -381,7 +386,6 @@ export function createOperatorDaemon(
         recurring: true,
         wakeGate: cfg.wakeGate,
       });
-      heartbeat.start();
       started = true;
     },
     stop(): void {
@@ -447,14 +451,25 @@ function wrapOneTool(
     }
     if (decision.action === "warn") counts.warnings++;
     counts.calls++;
+    let result: unknown;
     try {
-      const result = await original(args, ctx);
-      guard.afterCall(name, args, true, digestResult(result));
-      return result;
+      result = await original(args, ctx);
     } catch (err) {
       guard.afterCall(name, args, false);
       throw err;
     }
+    // Compute the digest defensively: a successful tool returning a
+    // non-serialisable result (circular ref, BigInt, etc.) would otherwise
+    // throw inside digestResult, get caught by the outer try, and be
+    // miscounted as a failure. Pass undefined to skip same-result tracking.
+    let digest: string | undefined;
+    try {
+      digest = digestResult(result);
+    } catch {
+      digest = undefined;
+    }
+    guard.afterCall(name, args, true, digest);
+    return result;
   };
 
   return { ...def, execute: wrappedExecute } as Tool;

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -187,13 +187,19 @@ export function createOperatorDaemon(
   }
   if (!cfg.rootDir) throw new Error("OperatorDaemon: rootDir is required.");
 
+  // Capture the operator-supplied jobId as a stable local. Used as the cron
+  // id (via scheduleCron({id})), the brief jobId, and the persistence key —
+  // all three must agree across the daemon's lifetime, so we never read
+  // `cfg.jobId` after this point.
+  const jobId = cfg.jobId;
+  const intervalMs = cfg.intervalMs;
   const userId = cfg.userId ?? "operator";
   const memoryFilePath =
     cfg.memoryFilePath ?? path.join(cfg.rootDir, "editorial-memory.md");
   const briefDir = cfg.briefDir ?? path.join(cfg.rootDir, "briefs");
   const stateDir = cfg.stateDir ?? cfg.rootDir;
   const recentBriefLimit = cfg.recentBriefLimit ?? DEFAULT_RECENT_BRIEF_LIMIT;
-  const recentBriefJobIds = cfg.recentBriefJobIds ?? [cfg.jobId];
+  const recentBriefJobIds = cfg.recentBriefJobIds ?? [jobId];
   const tickPromptTemplate = cfg.tickPrompt ?? DEFAULT_TICK_PROMPT;
   const generateImpl = cfg.generateTextImpl ?? generateText;
 
@@ -214,7 +220,7 @@ export function createOperatorDaemon(
     const timestamp = new Date().toISOString();
     cfg.onTickEvent?.({
       type: "tick_started",
-      jobId: cfg.jobId,
+      jobId,
       tickId,
       timestamp,
     });
@@ -271,7 +277,7 @@ export function createOperatorDaemon(
     try {
       await briefStore.write({
         tickId,
-        jobId: cfg.jobId,
+        jobId,
         body: briefBody,
       });
     } catch (err) {
@@ -286,12 +292,10 @@ export function createOperatorDaemon(
 
     // 7. Heartbeat status + telemetry.
     if (failureReason) {
-      await heartbeat
-        .markJobFailed(cfg.jobId, failureReason)
-        .catch(() => {});
+      await heartbeat.markJobFailed(jobId, failureReason).catch(() => {});
       const event: TickEvent = {
         type: "tick_failed",
-        jobId: cfg.jobId,
+        jobId,
         tickId,
         reason: failureReason,
         timestamp,
@@ -303,12 +307,12 @@ export function createOperatorDaemon(
       return event;
     }
 
-    await heartbeat.markJobSucceeded(cfg.jobId).catch(() => {});
+    await heartbeat.markJobSucceeded(jobId).catch(() => {});
 
     const silent = LastTickBrief.isSilent(text);
     const event: TickEvent = {
       type: silent ? "tick_silent" : "tick_published",
-      jobId: cfg.jobId,
+      jobId,
       tickId,
       text: silent ? undefined : text,
       timestamp,
@@ -324,13 +328,13 @@ export function createOperatorDaemon(
 
   const onEvent = (event: HeartbeatEvent): void => {
     cfg.onHeartbeatEvent?.(event);
-    if (event.cronJobId !== cronJob?.id) return;
+    if (event.cronJobId !== jobId) return;
 
     if (event.type === "cron_skipped") {
       const tickId = newTickId();
       const skip: TickEvent = {
         type: "tick_skipped",
-        jobId: cfg.jobId,
+        jobId,
         tickId,
         reason: event.result ?? "wake gate denied",
         timestamp: event.timestamp,
@@ -343,7 +347,7 @@ export function createOperatorDaemon(
       const tickId = newTickId();
       runTick(tickId).catch((err) => {
         console.error(
-          `[operator-daemon] tick crashed for ${cfg.jobId}: ${
+          `[operator-daemon] tick crashed for ${jobId}: ${
             err instanceof Error ? err.message : err
           }`,
         );
@@ -364,18 +368,19 @@ export function createOperatorDaemon(
     },
     start(): void {
       if (started) return;
+      // Pin the cron id to the operator-supplied jobId so the brief
+      // directory, persisted record, and per-job lockfile all use the same
+      // key — and so two daemon replicas can coordinate via the per-job
+      // lock added in #37.
       cronJob = heartbeat.scheduleCron({
-        label: cfg.jobLabel ?? cfg.jobId,
+        id: jobId,
+        label: cfg.jobLabel ?? jobId,
         prompt: cfg.role, // not used by the cron timer; kept for traceability
         userId,
-        intervalMs: cfg.intervalMs,
+        intervalMs,
         recurring: true,
         wakeGate: cfg.wakeGate,
       });
-      // Re-key the persisted job under the configured jobId so subsequent
-      // markJobSucceeded / Failed calls land on the same record. The heartbeat
-      // generates its own id; we accept that and use it for routing.
-      cfg.jobId = cronJob.id; // bind config jobId to the actual cron id
       heartbeat.start();
       started = true;
     },
@@ -384,6 +389,14 @@ export function createOperatorDaemon(
       started = false;
     },
     async tickOnce(): Promise<TickEvent> {
+      // Manual / test seam: the cron timer normally calls markRunStart
+      // inside execute(); when we bypass the timer we must prime the
+      // persisted record ourselves, otherwise markJobSucceeded / Failed
+      // would silently no-op (markRunSuccess only updates an existing
+      // record). No-op when persistence is off.
+      if (heartbeat.hasPersistence) {
+        await heartbeat.markJobStart(jobId, { intervalMs }).catch(() => {});
+      }
       return runTick(newTickId());
     },
   };

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -1,0 +1,365 @@
+/**
+ * Operator Daemon — test suite
+ *
+ * Tests the integration adapter that wires HeartbeatService + EditorialMemory
+ * + LastTickBrief + ToolGuardController + an AI-SDK generateText pass.
+ *
+ * Strategy: inject a mock generateText impl + a fresh HeartbeatService per
+ * test, so no network and no real model. Use tickOnce() to drive the body
+ * directly — start()/stop() with timers is exercised separately.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  createOperatorDaemon,
+} from "../dist/operator-daemon.js";
+import { HeartbeatService } from "../dist/heartbeat.js";
+import { LastTickBrief } from "../dist/last-tick-brief.js";
+
+import * as publicEntry from "../dist/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "operator-daemon-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Build a generateText stub that returns a fixed text and records inputs. */
+function makeGen(text) {
+  const calls = [];
+  const impl = async (args) => {
+    calls.push(args);
+    return { text };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+/** Build a fake AI-SDK Tool with a controllable execute. */
+function makeTool(execute) {
+  return {
+    description: "test tool",
+    inputSchema: { jsonSchema: { type: "object" } },
+    execute,
+  };
+}
+
+function freshHeartbeat() {
+  return new HeartbeatService();
+}
+
+function baseConfig(overrides = {}) {
+  return {
+    jobId: "tv-operator-test",
+    intervalMs: 60_000,
+    rootDir: tmpDir,
+    role: "You are SportsClaw, a 24/7 broadcast editor.",
+    model: { name: "mock-model" }, // never actually used by the stub
+    heartbeat: freshHeartbeat(),
+    generateTextImpl: makeGen("Tonight: Argentina vs Brazil opens."),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// tickOnce — published path
+// ---------------------------------------------------------------------------
+
+describe("tickOnce — published path", () => {
+  it("returns a tick_published event with the model text", async () => {
+    const daemon = createOperatorDaemon(baseConfig());
+    const event = await daemon.tickOnce();
+
+    assert.strictEqual(event.type, "tick_published");
+    assert.strictEqual(event.text, "Tonight: Argentina vs Brazil opens.");
+    assert.strictEqual(event.jobId, "tv-operator-test");
+    assert.match(event.tickId, /^tick_/);
+  });
+
+  it("writes the brief to disk under <briefDir>/<jobId>/<tickId>.md", async () => {
+    const daemon = createOperatorDaemon(baseConfig());
+    const event = await daemon.tickOnce();
+
+    const briefPath = path.join(
+      tmpDir,
+      "briefs",
+      "tv-operator-test",
+      `${event.tickId}.md`,
+    );
+    assert.ok(fs.existsSync(briefPath), `expected brief at ${briefPath}`);
+    const text = fs.readFileSync(briefPath, "utf8");
+    assert.match(text, /Tonight: Argentina vs Brazil opens\./);
+  });
+
+  it("composes the system prompt with cron + tool-discipline + sentinel + memory", async () => {
+    const gen = makeGen("hello world");
+    fs.writeFileSync(
+      path.join(tmpDir, "editorial-memory.md"),
+      "lesson: prefer fallback over hallucination",
+      "utf8",
+    );
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen }),
+    );
+    await daemon.tickOnce();
+
+    assert.strictEqual(gen.calls.length, 1);
+    const sys = gen.calls[0].system;
+    assert.match(sys, /Autonomous mode/);
+    assert.match(sys, /Tool use discipline/);
+    assert.match(sys, /\[SILENT\] sentinel/);
+    assert.match(sys, /prefer fallback over hallucination/);
+  });
+
+  it("substitutes {tickId} and {timestamp} in the tick prompt", async () => {
+    const gen = makeGen("ok");
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        tickPrompt: "Run {tickId} at {timestamp}.",
+      }),
+    );
+    const event = await daemon.tickOnce();
+    const userPrompt = gen.calls[0].prompt;
+    assert.match(userPrompt, new RegExp(`Run ${event.tickId} at `));
+    assert.match(userPrompt, /at \d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tickOnce — silent path
+// ---------------------------------------------------------------------------
+
+describe("tickOnce — silent path", () => {
+  it("recognises [SILENT] as a tick_silent event with no text", async () => {
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: makeGen("[SILENT]") }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_silent");
+    assert.strictEqual(event.text, undefined);
+  });
+
+  it("writes a silent brief that downstream loadRecent reports as silent", async () => {
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: makeGen("[SILENT]") }),
+    );
+    await daemon.tickOnce();
+    const briefs = await new LastTickBrief(
+      path.join(tmpDir, "briefs"),
+    ).loadRecent("tv-operator-test", 1);
+    assert.strictEqual(briefs.length, 1);
+    assert.strictEqual(briefs[0].silent, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tickOnce — failed path
+// ---------------------------------------------------------------------------
+
+describe("tickOnce — failed path", () => {
+  it("returns tick_failed when generateText throws", async () => {
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: async () => {
+          throw new Error("upstream timeout");
+        },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_failed");
+    assert.match(event.reason, /upstream timeout/);
+  });
+
+  it("still writes a brief that records the failure", async () => {
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: async () => {
+          throw new Error("upstream timeout");
+        },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    const briefPath = path.join(
+      tmpDir,
+      "briefs",
+      "tv-operator-test",
+      `${event.tickId}.md`,
+    );
+    const text = fs.readFileSync(briefPath, "utf8");
+    assert.match(text, /tick failed/);
+    assert.match(text, /upstream timeout/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool guardrail wrapping
+// ---------------------------------------------------------------------------
+
+describe("tool guardrail wrapping", () => {
+  it("wraps each tool's execute and counts tool calls", async () => {
+    const calls = [];
+    const tools = {
+      search_documents: makeTool(async (args) => {
+        calls.push(args);
+        return { documents: [] };
+      }),
+    };
+
+    const events = [];
+    // The mock generateText now invokes the tool from inside the stub.
+    const generateTextImpl = async ({ tools: passedTools }) => {
+      // Drive the wrapped execute directly to mimic an AI-SDK pass.
+      await passedTools.search_documents.execute(
+        { name: "tv-news" },
+        { toolCallId: "1", messages: [] },
+      );
+      await passedTools.search_documents.execute(
+        { name: "tv-news" },
+        { toolCallId: "2", messages: [] },
+      );
+      return { text: "two reads done" };
+    };
+
+    const daemon = createOperatorDaemon(
+      baseConfig({ tools, generateTextImpl }),
+    );
+    const event = await daemon.tickOnce();
+
+    assert.strictEqual(calls.length, 2, "underlying tool invoked twice");
+    assert.strictEqual(event.toolCalls, 2);
+    assert.strictEqual(event.guardrailBlocks, 0);
+  });
+
+  it("blocks repeated identical failures and reports it on the event", async () => {
+    const tools = {
+      execute_workflow: makeTool(async () => {
+        throw new Error("workflow not found");
+      }),
+    };
+
+    const generateTextImpl = async ({ tools: passedTools }) => {
+      // Drive the same failing call 6 times — guardrail blocks 5+.
+      for (let i = 0; i < 6; i++) {
+        try {
+          await passedTools.execute_workflow.execute(
+            { workflow: "ingest" },
+            { toolCallId: String(i), messages: [] },
+          );
+        } catch {
+          // expected — first 5 throw, 6th returns synthetic block result
+        }
+      }
+      return { text: "tried ingest" };
+    };
+
+    const daemon = createOperatorDaemon(
+      baseConfig({ tools, generateTextImpl }),
+    );
+    const event = await daemon.tickOnce();
+    assert.ok(
+      event.guardrailBlocks >= 1,
+      `expected at least one block, got ${event.guardrailBlocks}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heartbeat persistence integration
+// ---------------------------------------------------------------------------
+
+describe("heartbeat persistence integration", () => {
+  it("configurePersistence is auto-applied with rootDir as stateDir", async () => {
+    const daemon = createOperatorDaemon(baseConfig());
+    assert.strictEqual(daemon.heartbeat.hasPersistence, true);
+  });
+
+  it("does not double-configure persistence if heartbeat already has it", async () => {
+    const hb = freshHeartbeat();
+    hb.configurePersistence({ stateDir: tmpDir });
+    const daemon = createOperatorDaemon(baseConfig({ heartbeat: hb }));
+    assert.strictEqual(daemon.heartbeat.hasPersistence, true);
+    // tickOnce runs without throwing about double-config.
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telemetry hook
+// ---------------------------------------------------------------------------
+
+describe("onTickEvent telemetry hook", () => {
+  it("fires tick_started followed by tick_published", async () => {
+    const events = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({ onTickEvent: (e) => events.push(e.type) }),
+    );
+    await daemon.tickOnce();
+    assert.deepStrictEqual(events, ["tick_started", "tick_published"]);
+  });
+
+  it("fires tick_started followed by tick_failed on error", async () => {
+    const events = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        onTickEvent: (e) => events.push(e.type),
+        generateTextImpl: async () => {
+          throw new Error("nope");
+        },
+      }),
+    );
+    await daemon.tickOnce();
+    assert.deepStrictEqual(events, ["tick_started", "tick_failed"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("config validation", () => {
+  it("throws when jobId is missing", () => {
+    assert.throws(
+      () => createOperatorDaemon({ ...baseConfig(), jobId: "" }),
+      /jobId is required/,
+    );
+  });
+
+  it("throws when intervalMs is non-positive", () => {
+    assert.throws(
+      () => createOperatorDaemon({ ...baseConfig(), intervalMs: 0 }),
+      /intervalMs must be > 0/,
+    );
+  });
+
+  it("throws when rootDir is missing", () => {
+    assert.throws(
+      () => createOperatorDaemon({ ...baseConfig(), rootDir: "" }),
+      /rootDir is required/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public entry re-exports
+// ---------------------------------------------------------------------------
+
+describe("public entry re-exports", () => {
+  it("re-exports createOperatorDaemon from index.js", () => {
+    assert.strictEqual(typeof publicEntry.createOperatorDaemon, "function");
+  });
+});

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -296,6 +296,58 @@ describe("heartbeat persistence integration", () => {
     const event = await daemon.tickOnce();
     assert.strictEqual(event.type, "tick_published");
   });
+
+  it("tickOnce primes markRunStart so markJobSucceeded actually persists", async () => {
+    const daemon = createOperatorDaemon(baseConfig());
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_published");
+    // Before this fix, the persisted record was a silent no-op because no
+    // markRunStart had run first. Now tickOnce primes markJobStart and
+    // markJobSucceeded lands on the same record.
+    const persisted = await daemon.heartbeat.getPersistedJob("tv-operator-test");
+    assert.ok(persisted, "tickOnce must create a persisted record");
+    assert.strictEqual(persisted.runCount, 1);
+    assert.strictEqual(persisted.lastStatus, "succeeded");
+  });
+
+  it("tickOnce on a failing tick persists lastStatus=failed with the error", async () => {
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: async () => {
+          throw new Error("upstream gone");
+        },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_failed");
+    const persisted = await daemon.heartbeat.getPersistedJob("tv-operator-test");
+    assert.ok(persisted);
+    assert.strictEqual(persisted.lastStatus, "failed");
+    assert.match(persisted.lastError, /upstream gone/);
+  });
+
+  it("does not mutate cfg.jobId after start() — briefs stay under the operator-supplied id", async () => {
+    // Use a fresh heartbeat that we DON'T pre-start, then drive a tick via
+    // tickOnce — and verify the brief landed at the operator-supplied jobId
+    // (not under an auto-generated cron_xxx_yyy id, which was the bug).
+    const cfgIn = baseConfig({ jobId: "stable-operator-id" });
+    const daemon = createOperatorDaemon(cfgIn);
+    daemon.start();
+    // start() previously did `cfg.jobId = cronJob.id` — assert it didn't:
+    assert.strictEqual(cfgIn.jobId, "stable-operator-id");
+    // cronJob exposed via the daemon must use the same id
+    assert.strictEqual(daemon.cronJob.id, "stable-operator-id");
+    daemon.stop();
+    // Drive a tick after start() to confirm brief routing is stable
+    const event = await daemon.tickOnce();
+    const briefPath = path.join(
+      tmpDir,
+      "briefs",
+      "stable-operator-id",
+      `${event.tickId}.md`,
+    );
+    assert.ok(fs.existsSync(briefPath), `expected brief at ${briefPath}`);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -37,6 +37,8 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
 /** Build a generateText stub that returns a fixed text and records inputs. */
 function makeGen(text) {
   const calls = [];
@@ -244,6 +246,42 @@ describe("tool guardrail wrapping", () => {
     assert.strictEqual(event.guardrailBlocks, 0);
   });
 
+  it("does not miscount a non-serialisable success as a failure", async () => {
+    // A tool returning a circular-ref result would crash JSON.stringify
+    // inside digestResult; without the try/catch around digestResult the
+    // outer catch would mark this as a failure. With the fix the success
+    // is recorded and no digest is tracked.
+    const tools = {
+      search_documents: makeTool(async () => {
+        const a = { hello: "world" };
+        // create a circular reference (un-stringifiable)
+        a.self = a;
+        return a;
+      }),
+    };
+    const generateTextImpl = async ({ tools: passedTools }) => {
+      // Invoke the wrapped tool 4 times. Each succeeds. Without the fix,
+      // each would be (mis)counted as a failure and the 4th would trip
+      // the warn threshold via per-tool failure tracking.
+      for (let i = 0; i < 4; i++) {
+        await passedTools.search_documents.execute(
+          { i },
+          { toolCallId: String(i), messages: [] },
+        );
+      }
+      return { text: "ok" };
+    };
+    const daemon = createOperatorDaemon(
+      baseConfig({ tools, generateTextImpl }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_published");
+    assert.strictEqual(event.toolCalls, 4);
+    // No warnings, no blocks — these are successful calls.
+    assert.strictEqual(event.guardrailWarnings, 0);
+    assert.strictEqual(event.guardrailBlocks, 0);
+  });
+
   it("blocks repeated identical failures and reports it on the event", async () => {
     const tools = {
       execute_workflow: makeTool(async () => {
@@ -347,6 +385,78 @@ describe("heartbeat persistence integration", () => {
       `${event.tickId}.md`,
     );
     assert.ok(fs.existsSync(briefPath), `expected brief at ${briefPath}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timer-driven path — drives runTick via the heartbeat scheduler instead of
+// tickOnce(), so the cron timer's wake-gate + markRunStart + cron_fired
+// emission are all exercised end-to-end.
+// ---------------------------------------------------------------------------
+
+describe("timer-driven tick path", () => {
+  it("start() → cron timer fires → runTick writes brief under operator-supplied jobId", async () => {
+    const tickEvents = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        jobId: "stable-operator-id",
+        intervalMs: 60_000, // long; rely on the immediate first-fire
+        onTickEvent: (e) => tickEvents.push(e),
+        generateTextImpl: makeGen("first tick body"),
+      }),
+    );
+    daemon.start();
+    // Wait for the heartbeat's immediate first-fire to flow through
+    // cron_fired → onEvent → runTick → brief write.
+    await wait(150);
+    daemon.stop();
+
+    // tick_started + tick_published landed via the event handler
+    const types = tickEvents.map((e) => e.type);
+    assert.ok(types.includes("tick_started"), `missing tick_started, got ${types.join(",")}`);
+    assert.ok(types.includes("tick_published"), `missing tick_published, got ${types.join(",")}`);
+
+    // Brief is on disk under the operator-supplied jobId
+    const briefRoot = path.join(tmpDir, "briefs", "stable-operator-id");
+    assert.ok(fs.existsSync(briefRoot), `expected brief dir at ${briefRoot}`);
+    const briefs = fs.readdirSync(briefRoot).filter((f) => f.endsWith(".md"));
+    assert.strictEqual(briefs.length, 1);
+    const text = fs.readFileSync(path.join(briefRoot, briefs[0]), "utf8");
+    assert.match(text, /first tick body/);
+
+    // Heartbeat persistence reflects the timer-driven fire (markRunStart
+    // ran inside execute(), then markJobSucceeded ran from runTick).
+    const persisted = await daemon.heartbeat.getPersistedJob("stable-operator-id");
+    assert.ok(persisted, "timer-driven tick must persist heartbeat state");
+    assert.strictEqual(persisted.runCount, 1);
+    assert.strictEqual(persisted.lastStatus, "succeeded");
+  });
+
+  it("wake-gate denial → cron_skipped → tick_skipped, no brief written", async () => {
+    const tickEvents = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        jobId: "gated-job",
+        intervalMs: 60_000,
+        onTickEvent: (e) => tickEvents.push(e.type),
+        wakeGate: () => ({ wake: false, reason: "fixtures fresh" }),
+      }),
+    );
+    daemon.start();
+    await wait(150);
+    daemon.stop();
+
+    assert.ok(
+      tickEvents.includes("tick_skipped"),
+      `expected tick_skipped, got ${tickEvents.join(",")}`,
+    );
+    assert.ok(
+      !tickEvents.includes("tick_started"),
+      "tick_started should not fire when the wake gate denies",
+    );
+    // No brief should have been written
+    const briefRoot = path.join(tmpDir, "briefs", "gated-job");
+    assert.ok(!fs.existsSync(briefRoot), "no brief should be written on a skipped tick");
   });
 });
 


### PR DESCRIPTION
## Summary
Phase-1 daemon: the integration PR that wires together the four primitives shipped in #36–#39.

`createOperatorDaemon(cfg)` returns a small adapter that:
- Schedules + persists + locks + wake-gates ticks via `HeartbeatService`
- Loads a frozen `EditorialMemory` snapshot per tick (cache-friendly prompt prefix)
- Pulls recent `LastTickBrief` files into the system prompt as handoff context
- Composes the system prompt via `buildSystemPrompt` (cron + tool-discipline + [SILENT] fragments)
- Wraps every tool's `execute` with `ToolGuardController` (anti-loop circuit breaker)
- Calls Vercel AI SDK's `generateText` directly — does **not** touch `engine.ts`
- Parses `[SILENT]` sentinel; writes a brief either way; marks heartbeat success/fail

## Why option 3 (thin + small adapter) over reshaping engine.ts
The cron tick is a different shape from chat: no stdin, no user turn, time-driven, must be silent most ticks, must produce a structured brief. Bolting that onto the 3917-line interactive REPL would fight assumptions baked into chat mode. The adapter is purpose-built for autonomous ticks (~330 LOC) and `engine.ts` keeps working unchanged. If real shared logic emerges later, extract a `core/llm-pass` module then.

## Per-tick lifecycle
1. Heartbeat fires the cron timer
2. Optional wake gate denies → `cron_skipped` → `tick_skipped`, no LLM call
3. Heartbeat advance-before-execute, then `cron_fired`
4. Daemon: load memory snapshot → recent briefs → build prompt → reset guardrail → wrap tools → `generateText` → parse `[SILENT]` → write brief → mark success/fail

## Scope notes
- One daemon = one cron job. Multi-job is a future extension; YAGNI now.
- This PR carries merges of #36, #37, #38, #39. Mergeable independently if those merge first; otherwise this resolves the trivial package.json conflicts already.
- `tickOnce()` is the testing/manual seam — bypasses the heartbeat scheduler so we can unit-test the body without timers.

## Test plan
- [x] 18 new tests in `test/operator-daemon.test.mjs` — published / silent / failed paths, prompt composition (cron + tool-discipline + sentinel + memory), tick prompt substitution, tool guardrail wrapping (counts + block on repeated failures), heartbeat persistence integration, telemetry hooks, config validation
- [x] Full suite green: 292/292 (was 274 on the four-primitive base)
- [x] `npm run build` clean
- [x] No engine.ts changes
- [ ] CI green
- [ ] Manual: wire one daemon against a real model + tools (follow-up)

## Depends on
- #36 (memory split + prompt fragments)
- #37 (tick lock + advance-before-execute)
- #38 (wake gate)
- #39 (tool-call guardrail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)