### PR TITLE
ci: add PR-gating CI workflow with build, tests, smoke, and Gemini in…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel in-progress runs for the same PR/branch when new commits land,
+# so a rapid push sequence doesn't queue up many duplicate runs.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-typecheck:
+    name: Build (tsc strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  test:
+    name: Tests + smoke (no API key)
+    runs-on: ubuntu-latest
+    needs: build-and-typecheck
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Run all node:test files
+        run: node --test test/*.test.mjs
+      - name: CI smoke (engine boot + memory_loaded log)
+        run: node test/ci-smoke.mjs
+
+  integration:
+    name: Integration (Gemini end-to-end)
+    runs-on: ubuntu-latest
+    needs: build-and-typecheck
+    # Skip on PRs from forks — GitHub doesn't pass repo secrets to fork-triggered
+    # workflows, so the integration step would always fail on those. Build + test
+    # still run on fork PRs via the other two jobs.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: CI integration (Gemini end-to-end)
+        env:
+          # The repo secret is named GEMINI_API_KEY (user-friendly), but the
+          # engine internally reads GOOGLE_GENERATIVE_AI_API_KEY (src/engine.ts).
+          # Set both from the same secret so either code path resolves.
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: node test/ci-integration.mjs

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs",
     "test:operator-config": "npm run build && node --test test/operator-config.test.mjs",
     "test:operate": "npm run build && node --test test/operate.test.mjs",
-    "test:daemon-operator": "npm run build && node --test test/daemon-operator.test.mjs"
+    "test:daemon-operator": "npm run build && node --test test/daemon-operator.test.mjs",
+    "test:ci-smoke": "npm run build && node test/ci-smoke.mjs",
+    "test:ci-integration": "npm run build && node test/ci-integration.mjs"
   },
   "keywords": [
     "sports",

--- a/test/ci-integration.mjs
+++ b/test/ci-integration.mjs
@@ -1,0 +1,101 @@
+/**
+ * CI integration — end-to-end Gemini smoke. Requires GEMINI_API_KEY (or
+ * GOOGLE_GENERATIVE_AI_API_KEY) in env. Stages a stub user, runs engine.run()
+ * with a tiny prompt, asserts non-empty response AND that the memory_loaded
+ * log fired (proves the observability change still works against a real
+ * provider).
+ *
+ * Exits 0 on success, 1 on failure.
+ */
+
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { sportsclawEngine } from "../dist/index.js";
+
+const apiKey =
+  process.env.GOOGLE_GENERATIVE_AI_API_KEY || process.env.GEMINI_API_KEY;
+if (!apiKey) {
+  console.error(
+    "CI integration FAILED: GOOGLE_GENERATIVE_AI_API_KEY (or GEMINI_API_KEY) is not set."
+  );
+  console.error(
+    "Set the secret in repo settings → Secrets and variables → Actions."
+  );
+  process.exit(1);
+}
+
+// Engine reads GOOGLE_GENERATIVE_AI_API_KEY at src/engine.ts:3817 / :3896.
+// If only GEMINI_API_KEY was provided, propagate it so the engine resolves.
+process.env.GOOGLE_GENERATIVE_AI_API_KEY = apiKey;
+
+const USER_ID = "ci-int-user";
+const memDir = join(homedir(), ".sportsclaw", "memory", USER_ID);
+
+mkdirSync(memDir, { recursive: true });
+writeFileSync(
+  join(memDir, "SOUL.md"),
+  "# SOUL\nBorn: 2026-05-10\nExchanges: 1\n\nCI integration test user.\n"
+);
+
+const captured = [];
+const origError = console.error;
+console.error = (...args) => {
+  captured.push(args.map(String).join(" "));
+};
+
+let response;
+let runError;
+try {
+  const engine = new sportsclawEngine({
+    provider: "google",
+    model: "gemini-3-flash-preview",
+    // verbose:true so the memory_loaded log fires regardless of PR #40's
+    // merge status (pre-#40 the log is gated behind verbose). Once #40
+    // lands a follow-up can pin verbose:false specifically.
+    verbose: true,
+  });
+  response = await engine.run("Reply with the single word: pong", {
+    userId: USER_ID,
+  });
+} catch (e) {
+  runError = e;
+} finally {
+  console.error = origError;
+  rmSync(memDir, { recursive: true, force: true });
+}
+
+if (runError) {
+  console.error("CI integration FAILED: engine.run threw:");
+  console.error(runError instanceof Error ? runError.stack : String(runError));
+  console.error("Captured stderr lines:");
+  for (const line of captured) console.error(`  ${line}`);
+  process.exit(1);
+}
+
+if (!response || typeof response !== "string" || response.trim().length === 0) {
+  console.error("CI integration FAILED: engine.run returned empty / non-string.");
+  console.error(`response: ${JSON.stringify(response)}`);
+  process.exit(1);
+}
+
+// Same both-formats acceptance as ci-smoke (lands independently of PR #40).
+const memoryLogged = captured.some(
+  (line) =>
+    line.includes(`memory_loaded user=${USER_ID}`) ||
+    line.includes(`memory loaded for user ${USER_ID}`)
+);
+if (!memoryLogged) {
+  console.error(
+    "CI integration FAILED: memory_loaded log not seen on stderr."
+  );
+  console.error("Captured stderr lines:");
+  for (const line of captured) console.error(`  ${line}`);
+  process.exit(1);
+}
+
+console.log("CI integration PASSED.");
+console.log(`  response (first 80 chars): ${response.slice(0, 80)}`);
+console.log(`  memory_loaded log: confirmed`);
+process.exit(0);

--- a/test/ci-smoke.mjs
+++ b/test/ci-smoke.mjs
@@ -1,0 +1,64 @@
+/**
+ * CI smoke — proves the engine boots, memory loads, and the
+ * `[sportsclaw] memory_loaded user=…` log fires on stderr WITHOUT any API
+ * key configured. Intentionally expects engine.run() to throw on missing
+ * key — the log fires before that throw.
+ *
+ * Exits 0 on success, 1 on failure with captured stderr context.
+ */
+
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { sportsclawEngine } from "../dist/index.js";
+
+const USER_ID = "ci-smoke-user";
+const memDir = join(homedir(), ".sportsclaw", "memory", USER_ID);
+
+// Stage stub memory so buildMemoryBlock returns non-empty and the log fires.
+mkdirSync(memDir, { recursive: true });
+writeFileSync(
+  join(memDir, "SOUL.md"),
+  "# SOUL\nBorn: 2026-05-10\nExchanges: 1\n\nCI smoke test user.\n"
+);
+
+const captured = [];
+const origError = console.error;
+console.error = (...args) => {
+  captured.push(args.map(String).join(" "));
+};
+
+try {
+  // verbose:true so the memory_loaded log fires on every branch state (pre- or
+  // post-PR-#40). PR #40 drops the verbose gate; until it lands, verbose:true
+  // is the only way the log emits. Once #40 merges, this smoke continues to
+  // pass — and a follow-up can pin verbose:false to assert the new behavior
+  // specifically.
+  const engine = new sportsclawEngine({ verbose: true });
+  try {
+    await engine.run("hi", { userId: USER_ID });
+  } catch {
+    // Expected — engine.run() throws on missing API key after the memory log fires.
+  }
+} finally {
+  console.error = origError;
+  rmSync(memDir, { recursive: true, force: true });
+}
+
+// Accept both the new key=value format (post-PR-#40) and the old free-text
+// format (pre-merge), so this CI lands independently of PR #40's status.
+const found = captured.find(
+  (line) =>
+    line.includes(`memory_loaded user=${USER_ID}`) ||
+    line.includes(`memory loaded for user ${USER_ID}`)
+);
+if (!found) {
+  console.error("CI smoke FAILED: memory_loaded log not seen on stderr.");
+  console.error("Captured stderr lines:");
+  for (const line of captured) console.error(`  ${line}`);
+  process.exit(1);
+}
+
+console.log(`CI smoke PASSED: ${found}`);
+process.exit(0);


### PR DESCRIPTION
Adds the first pull_request-triggered workflow in the repo. Three jobs run on every PR to main and on push to main:

  build-and-typecheck — npm run build (tsc strict)
  test                — node --test test/*.test.mjs + ci-smoke
  integration         — Gemini end-to-end via GEMINI_API_KEY secret

The integration job skips on PRs from forks since GitHub doesn't pass repo secrets to those, so build+test still gate fork contributions while the in-org / push-to-main path gets the real provider check.

Helper scripts in test/ci-smoke.mjs and test/ci-integration.mjs are also exposed as npm run test:ci-smoke / test:ci-integration so the same checks run locally.

Auto-discovery via test/*.test.mjs glob means future test files are picked up without workflow changes.
