### PR TITLE
refactor: domain-neutral prompt fragments + opt-in broadcast directive

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -6,19 +6,26 @@
  * Hermes' `PLATFORM_HINTS` + tool-use discipline pattern (see external
  * review notes).
  *
- * The cron-mode autonomy fragment and tool-discipline fragment together
- * stop a Gemini-class model from rambling instead of dispatching tools —
- * this is the small-LOC fix with the largest behavioural win for the
- * autonomous operator daemon.
+ * The cron-autonomy fragment and tool-discipline fragment together stop a
+ * Gemini-class model from rambling instead of dispatching tools — this is
+ * the small-LOC fix with the largest behavioural win for any autonomous
+ * worker, not just the broadcast operator.
  *
  * The `[SILENT]` sentinel fragment teaches the model to vote "no useful
- * broadcast this tick" instead of forcing us to ship empty narration.
+ * action this tick" instead of forcing us to ship empty work.
+ *
+ * Domain coupling: CRON_AUTONOMY, TOOL_DISCIPLINE, and SILENT_SENTINEL are
+ * deliberately written in domain-neutral language so betting / scouting /
+ * fan-engagement / other autonomous workers can reuse them unchanged.
+ * Broadcast-specific framing lives in BROADCAST_DIRECTIVE_FRAGMENT — pass
+ * it via `extras` (or via the daemon's `extraFragments`) when the worker
+ * IS a broadcast operator.
  *
  * No I/O. Pure string composition.
  */
 
 // ---------------------------------------------------------------------------
-// Fragments
+// Fragments — domain-neutral
 // ---------------------------------------------------------------------------
 
 export const CRON_AUTONOMY_FRAGMENT = `
@@ -29,10 +36,10 @@ You are running on a scheduler, not in a chat. There is no human present.
 - Do not ask clarifying questions. There is no one to answer.
 - Do not request approvals. The cron contract is your approval to act.
 - Execute the task fully and autonomously. If the task is ambiguous,
-  pick the safer path — lean on fallback content, return [SILENT], or
-  reduce the scope rather than escalate.
-- Your final response is broadcast/telemetry, not a chat reply. Treat
-  every word as on-air content.
+  pick the safer path — lean on a fallback, return [SILENT], or reduce
+  the scope rather than escalate.
+- Your final response is the work product, not a chat reply. Treat
+  every word as the final output for this tick.
 `.trim();
 
 export const TOOL_DISCIPLINE_FRAGMENT = `
@@ -43,26 +50,49 @@ export const TOOL_DISCIPLINE_FRAGMENT = `
 - Do not ask permission to call a tool. The user is not here to grant it.
 - If a tool fails: classify the error. Retry only when the error is
   transient. Otherwise fall through to a safer path or return [SILENT].
-- The final assistant text must be ONLY the broadcast/telemetry summary
-  suitable for the on-air reasoning trail. No prefatory "Here is what I
-  did", no trailing "Let me know if you want changes". Just the summary.
+- The final assistant text must be ONLY the output summary for this
+  tick. No prefatory "Here is what I did", no trailing "Let me know if
+  you want changes". Just the summary.
 `.trim();
 
 export const SILENT_SENTINEL_FRAGMENT = `
 # The [SILENT] sentinel
 
-If a tick has nothing meaningful to broadcast — no new data, no editorial
-change, no fan signal worth surfacing — return EXACTLY \`[SILENT]\` as
-your final response. The runtime suppresses delivery; nothing pollutes
-the trail; no tokens are wasted on empty narration.
+If a tick has nothing worth surfacing — no new data, no state change, no
+signal worth acting on — return EXACTLY \`[SILENT]\` as your final
+response. The runtime suppresses delivery; nothing pollutes the trail;
+no tokens are wasted on empty output.
 
 Use [SILENT] when:
 - Nothing has changed since the previous brief on this job.
 - An upstream dependency is unavailable and you have no useful fallback.
-- The wake-gate fired but inspection shows no editorial action is due.
+- The wake-gate fired but inspection shows no action is due.
 
-Do not use [SILENT] to avoid hard work. If the cron contract says "plan
-the next 60 minutes," plan it.
+Do not use [SILENT] to avoid hard work. If the cron contract specifies a
+task, complete it.
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Fragments — domain-specific (opt-in via extras)
+// ---------------------------------------------------------------------------
+
+/**
+ * Broadcast-specific framing for the SportsClaw TV operator. Pass via
+ * `extras` (or `OperatorDaemonConfig.extraFragments`) when the daemon's
+ * role IS a broadcast editor. Non-broadcast domains (betting / scouting /
+ * fan-engagement) supply their own directive fragments instead.
+ */
+export const BROADCAST_DIRECTIVE_FRAGMENT = `
+# Broadcast directive
+
+Your output for this tick is on-air content for a 24/7 sports channel.
+
+- Treat every word as broadcast/telemetry — viewers will read or hear it.
+- [SILENT] here maps to "no editorial action is due this tick" — use it
+  when there is no new data, no editorial change, and no fan signal
+  worth surfacing.
+- Hard rules: no dead air, no invented live facts, fallback before
+  hallucination.
 `.trim();
 
 export const EDITORIAL_MEMORY_FRAGMENT_HEADER = `

--- a/test/prompts.test.mjs
+++ b/test/prompts.test.mjs
@@ -10,6 +10,7 @@ import {
   CRON_AUTONOMY_FRAGMENT,
   TOOL_DISCIPLINE_FRAGMENT,
   SILENT_SENTINEL_FRAGMENT,
+  BROADCAST_DIRECTIVE_FRAGMENT,
   EDITORIAL_MEMORY_FRAGMENT_HEADER,
   TICK_BRIEF_FRAGMENT_HEADER,
   SILENT_SENTINEL_TOKEN,
@@ -36,6 +37,44 @@ describe("fragments", () => {
 
   it("SILENT_SENTINEL_TOKEN matches the canonical sentinel from last-tick-brief", () => {
     assert.strictEqual(SILENT_SENTINEL_TOKEN, SILENT_SENTINEL);
+  });
+
+  it("BROADCAST_DIRECTIVE_FRAGMENT is exported and mentions on-air", () => {
+    assert.match(BROADCAST_DIRECTIVE_FRAGMENT, /on-air/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Domain neutrality — the autonomy / discipline / sentinel fragments must
+// NOT carry broadcast-specific wording so non-broadcast workers (betting,
+// scouting, fan-engagement) can reuse them unchanged.
+// ---------------------------------------------------------------------------
+
+describe("domain neutrality", () => {
+  const broadcastTerms = [
+    /broadcast/i,
+    /\bon-air\b/i,
+    /telemetry/i,
+    /editorial/i,
+    /\bfan signal\b/i,
+  ];
+
+  for (const term of broadcastTerms) {
+    it(`CRON_AUTONOMY_FRAGMENT does not contain ${term}`, () => {
+      assert.doesNotMatch(CRON_AUTONOMY_FRAGMENT, term);
+    });
+    it(`TOOL_DISCIPLINE_FRAGMENT does not contain ${term}`, () => {
+      assert.doesNotMatch(TOOL_DISCIPLINE_FRAGMENT, term);
+    });
+    it(`SILENT_SENTINEL_FRAGMENT does not contain ${term}`, () => {
+      assert.doesNotMatch(SILENT_SENTINEL_FRAGMENT, term);
+    });
+  }
+
+  it("BROADCAST_DIRECTIVE_FRAGMENT IS allowed to mention broadcast/on-air", () => {
+    // Sanity check: the directive fragment is where broadcast wording lives.
+    assert.match(BROADCAST_DIRECTIVE_FRAGMENT, /broadcast/i);
+    assert.match(BROADCAST_DIRECTIVE_FRAGMENT, /on-air/i);
   });
 });
 
@@ -110,5 +149,21 @@ describe("buildSystemPrompt", () => {
   it("trims the role to avoid stray leading/trailing whitespace", () => {
     const out = buildSystemPrompt({ role: "   ROLE   ", isCron: true });
     assert.ok(out.startsWith("ROLE"));
+  });
+
+  it("broadcast workers opt in by passing BROADCAST_DIRECTIVE_FRAGMENT via extras", () => {
+    const out = buildSystemPrompt({
+      role: "ROLE",
+      isCron: true,
+      toolDiscipline: true,
+      silentSentinel: true,
+      extras: [BROADCAST_DIRECTIVE_FRAGMENT],
+    });
+    // Domain-neutral fragments are present
+    assert.ok(out.includes("Autonomous mode"));
+    assert.ok(out.includes("Tool use discipline"));
+    // Domain-specific framing is present too — opted in via extras
+    assert.ok(out.includes("Broadcast directive"));
+    assert.match(out, /on-air/i);
   });
 });


### PR DESCRIPTION
## Summary

The autonomy + tool-discipline + [SILENT] mechanics are universal to any autonomous worker. The original fragments carried broadcast wording (\"broadcast/telemetry\", \"on-air content\", \"editorial change\", \"fan signal\") that couples them to SportsClaw TV. Other domains we're building — betting agents, scouting agents, fan-engagement bots — would all need to copy and edit ~80% of the same wording.

This refactor:
- Strips broadcast wording from \`CRON_AUTONOMY_FRAGMENT\`, \`TOOL_DISCIPLINE_FRAGMENT\`, and \`SILENT_SENTINEL_FRAGMENT\`. They now talk about \"the work product\", \"output summary for this tick\", \"no signal worth acting on\" — language that fits any autonomous worker.
- Adds \`BROADCAST_DIRECTIVE_FRAGMENT\` for SportsClaw TV consumers to opt into via the existing \`extras\` plumbing (or \`OperatorDaemonConfig.extraFragments\`). Zero new mechanism.

The daemon's \`role\` parameter continues to anchor domain voice. Fragments are mechanism, role is voice.

## Tests

- Existing fragment tests pass against the neutral wording
- New domain-neutrality tests: \`CRON_AUTONOMY\` / \`TOOL_DISCIPLINE\` / \`SILENT_SENTINEL\` do NOT contain broadcast / on-air / telemetry / editorial / fan-signal terms
- New broadcast tests: \`BROADCAST_DIRECTIVE_FRAGMENT\` DOES contain those terms and reaches the system prompt when passed via \`extras\`
- 30 prompts tests (was 12, +18 new)
- Full suite: 297 pass

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run test:prompts\`
- [x] full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)