### PR TITLE
feat: sportsclaw operate — autonomous daemon driver

### DIFF
--- a/examples/operator-jobs/markets-monitor.example.json
+++ b/examples/operator-jobs/markets-monitor.example.json
@@ -1,0 +1,8 @@
+{
+  "jobId": "markets-monitor",
+  "label": "Markets monitor — Kalshi / Polymarket edge watcher",
+  "intervalMs": 600000,
+  "personaText": "You are an autonomous markets analyst. Every tick, inspect the major event contracts on Kalshi and Polymarket for sports we cover. Surface a short structured report ONLY when you detect a meaningful edge or a notable line move; otherwise return [SILENT].",
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic"
+}

--- a/examples/operator-jobs/tv-operator.example.json
+++ b/examples/operator-jobs/tv-operator.example.json
@@ -1,0 +1,10 @@
+{
+  "jobId": "tv-operator",
+  "label": "Machina Sports TV — operator",
+  "intervalMs": 300000,
+  "personaText": "You are the editorial operator for Machina Sports TV — a 24/7 World Cup companion channel on YouTube Live. Every tick, you decide whether to publish a broadcast block or stay silent. Hard rules: no dead air, no invented live facts, fallback before hallucination.",
+  "extraFragments": ["broadcast-directive"],
+  "model": "gemini-2.5-flash",
+  "provider": "google",
+  "tailServer": "http://localhost:8090"
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "test:heartbeat-state": "npm run build && node --test test/heartbeat-state.test.mjs",
     "test:heartbeat": "npm run build && node --test test/heartbeat.test.mjs",
     "test:heartbeat-wake-gate": "npm run build && node --test test/heartbeat-wake-gate.test.mjs",
-    "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs"
+    "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs",
+    "test:operator-config": "npm run build && node --test test/operator-config.test.mjs",
+    "test:operate": "npm run build && node --test test/operate.test.mjs",
+    "test:daemon-operator": "npm run build && node --test test/daemon-operator.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16,7 +16,17 @@
  */
 
 import { execSync, execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  openSync,
+  readSync,
+  closeSync,
+} from "node:fs";
 import { homedir, platform as osPlatform } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,11 +35,51 @@ import { fileURLToPath } from "node:url";
 // Public types and validation
 // ---------------------------------------------------------------------------
 
-export type DaemonPlatform = "discord" | "telegram" | "watch";
-const VALID_PLATFORMS: DaemonPlatform[] = ["discord", "telegram", "watch"];
+export type DaemonPlatform = "discord" | "telegram" | "watch" | "operator";
+/** Platforms that take no second positional argument. */
+const SIMPLE_PLATFORMS: DaemonPlatform[] = ["discord", "telegram", "watch"];
+const VALID_PLATFORMS: DaemonPlatform[] = ["discord", "telegram", "watch", "operator"];
 
 export function isValidPlatform(value: string): value is DaemonPlatform {
   return VALID_PLATFORMS.includes(value as DaemonPlatform);
+}
+
+/**
+ * Platforms whose service / log / pid identity is keyed by a jobId in
+ * addition to the platform itself. Operator daemons are the only such
+ * platform in v1.
+ */
+export function platformRequiresJobId(platform: DaemonPlatform): boolean {
+  return platform === "operator";
+}
+
+const JOB_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function assertJobId(platform: DaemonPlatform, jobId: string | undefined): string {
+  if (!platformRequiresJobId(platform)) {
+    throw new Error(
+      `[daemon] platform "${platform}" does not take a jobId argument`,
+    );
+  }
+  if (!jobId || !JOB_ID_PATTERN.test(jobId)) {
+    throw new Error(
+      `[daemon] platform "${platform}" requires a jobId matching ${JOB_ID_PATTERN.source}`,
+    );
+  }
+  return jobId;
+}
+
+function assertNoJobId(platform: DaemonPlatform, jobId: string | undefined): void {
+  if (jobId !== undefined && !platformRequiresJobId(platform)) {
+    throw new Error(
+      `[daemon] platform "${platform}" does not accept a jobId (got "${jobId}")`,
+    );
+  }
+}
+
+/** Cross-driver service-key composition. Used in error messages + status output. */
+function serviceKey(platform: DaemonPlatform, jobId?: string): string {
+  return jobId ? `${platform}/${jobId}` : platform;
 }
 
 // ---------------------------------------------------------------------------
@@ -50,16 +100,26 @@ function logsDir(): string {
   return dir;
 }
 
-function logPaths(platform: DaemonPlatform): { out: string; err: string } {
+export function logPaths(
+  platform: DaemonPlatform,
+  jobId?: string,
+): { out: string; err: string } {
+  const suffix = jobId ? `${platform}-${jobId}` : platform;
   return {
-    out: join(logsDir(), `${platform}-out.log`),
-    err: join(logsDir(), `${platform}-err.log`),
+    out: join(logsDir(), `${suffix}-out.log`),
+    err: join(logsDir(), `${suffix}-err.log`),
   };
 }
 
-function scriptArgsFor(platform: DaemonPlatform): string[] {
+export function scriptArgsFor(
+  platform: DaemonPlatform,
+  jobId?: string,
+): string[] {
   if (platform === "watch") {
     return ["watch", `--config=${join(homedir(), ".sportsclaw", "watchers.json")}`];
+  }
+  if (platform === "operator") {
+    return ["operate", "--job", assertJobId(platform, jobId)];
   }
   return ["listen", platform];
 }
@@ -90,11 +150,11 @@ function tailFile(path: string, lines: number): string {
 
 interface Driver {
   name: string;
-  start(platform: DaemonPlatform): void;
-  stop(platform: DaemonPlatform): void;
+  start(platform: DaemonPlatform, jobId?: string): void;
+  stop(platform: DaemonPlatform, jobId?: string): void;
   status(): void;
-  logs(platform: DaemonPlatform, lines: number): void;
-  restart(platform: DaemonPlatform): void;
+  logs(platform: DaemonPlatform, lines: number, jobId?: string): void;
+  restart(platform: DaemonPlatform, jobId?: string): void;
 }
 
 function driver(): Driver {
@@ -129,6 +189,8 @@ interface Pm2Process {
 
 function migratePm2IfPresent(platform: DaemonPlatform): void {
   if (process.env.SPORTSCLAW_KEEP_PM2 === "1") return;
+  // operator daemons never had pm2 supervision (this PR introduces the platform).
+  if (platform === "operator") return;
 
   // Only proceed if pm2 is actually on PATH.
   const which = spawnSync(osPlatform() === "win32" ? "where.exe" : "which", ["pm2"], {
@@ -171,29 +233,41 @@ function migratePm2IfPresent(platform: DaemonPlatform): void {
 // Public API — same surface as before, dispatched per-OS
 // ---------------------------------------------------------------------------
 
-export function daemonStart(platform: DaemonPlatform): void {
+export function daemonStart(platform: DaemonPlatform, jobId?: string): void {
+  if (platformRequiresJobId(platform)) assertJobId(platform, jobId);
+  else assertNoJobId(platform, jobId);
   migratePm2IfPresent(platform);
-  driver().start(platform);
+  driver().start(platform, jobId);
 }
 
-export function daemonStop(platform: DaemonPlatform): void {
+export function daemonStop(platform: DaemonPlatform, jobId?: string): void {
+  if (platformRequiresJobId(platform)) assertJobId(platform, jobId);
+  else assertNoJobId(platform, jobId);
   // Migration is silent when no pm2 entry exists, so this only fires when
   // the user has a leftover pm2 daemon — exactly when stopping it is helpful.
   migratePm2IfPresent(platform);
-  driver().stop(platform);
+  driver().stop(platform, jobId);
 }
 
 export function daemonStatus(): void {
   driver().status();
 }
 
-export function daemonLogs(platform: DaemonPlatform, lines = 50): void {
-  driver().logs(platform, lines);
+export function daemonLogs(
+  platform: DaemonPlatform,
+  lines = 50,
+  jobId?: string,
+): void {
+  if (platformRequiresJobId(platform)) assertJobId(platform, jobId);
+  else assertNoJobId(platform, jobId);
+  driver().logs(platform, lines, jobId);
 }
 
-export function daemonRestart(platform: DaemonPlatform): void {
+export function daemonRestart(platform: DaemonPlatform, jobId?: string): void {
+  if (platformRequiresJobId(platform)) assertJobId(platform, jobId);
+  else assertNoJobId(platform, jobId);
   migratePm2IfPresent(platform);
-  driver().restart(platform);
+  driver().restart(platform, jobId);
 }
 
 // ---------------------------------------------------------------------------
@@ -202,17 +276,48 @@ export function daemonRestart(platform: DaemonPlatform): void {
 
 const LAUNCHD_LABEL_PREFIX = "gg.sportsclaw.";
 
-function launchdLabel(p: DaemonPlatform): string {
+function launchdLabel(p: DaemonPlatform, jobId?: string): string {
+  if (p === "operator") {
+    return `${LAUNCHD_LABEL_PREFIX}operator.${assertJobId(p, jobId)}`;
+  }
   return `${LAUNCHD_LABEL_PREFIX}${p}`;
 }
 
-function launchdPlistPath(p: DaemonPlatform): string {
-  return join(homedir(), "Library", "LaunchAgents", `${launchdLabel(p)}.plist`);
+function launchdPlistPath(p: DaemonPlatform, jobId?: string): string {
+  return join(
+    homedir(),
+    "Library",
+    "LaunchAgents",
+    `${launchdLabel(p, jobId)}.plist`,
+  );
 }
 
-function launchdRenderPlist(p: DaemonPlatform): string {
-  const { out, err } = logPaths(p);
-  const args = [nodeBin(), entryPoint(), ...scriptArgsFor(p)];
+/**
+ * Enumerate every installed sportsclaw plist, returning the parsed
+ * (platform, jobId?) tuple. Used by `status` to surface every operator
+ * job alongside the simple platforms.
+ */
+function launchdInstalledServices(): Array<{ platform: DaemonPlatform; jobId?: string }> {
+  const dir = join(homedir(), "Library", "LaunchAgents");
+  if (!existsSync(dir)) return [];
+  const out: Array<{ platform: DaemonPlatform; jobId?: string }> = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.startsWith(LAUNCHD_LABEL_PREFIX) || !file.endsWith(".plist")) continue;
+    const label = file.slice(0, -".plist".length);
+    const rest = label.slice(LAUNCHD_LABEL_PREFIX.length);
+    if (rest.startsWith("operator.")) {
+      const jobId = rest.slice("operator.".length);
+      if (JOB_ID_PATTERN.test(jobId)) out.push({ platform: "operator", jobId });
+    } else if (SIMPLE_PLATFORMS.includes(rest as DaemonPlatform)) {
+      out.push({ platform: rest as DaemonPlatform });
+    }
+  }
+  return out;
+}
+
+function launchdRenderPlist(p: DaemonPlatform, jobId?: string): string {
+  const { out, err } = logPaths(p, jobId);
+  const args = [nodeBin(), entryPoint(), ...scriptArgsFor(p, jobId)];
   const xmlArgs = args
     .map((a) => `        <string>${escapeXml(a)}</string>`)
     .join("\n");
@@ -221,7 +326,7 @@ function launchdRenderPlist(p: DaemonPlatform): string {
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>${launchdLabel(p)}</string>
+    <string>${launchdLabel(p, jobId)}</string>
 
     <key>ProgramArguments</key>
     <array>
@@ -284,66 +389,75 @@ function launchctlList(label: string): { running: boolean; pid?: number } {
   return { running: true };
 }
 
+/** Compose the supervisor display tag for "<platform>[ <jobId>]". */
+function tag(p: DaemonPlatform, jobId?: string): string {
+  return jobId ? `${p} ${jobId}` : p;
+}
+
+/** Compose the `stop`-style CLI suffix: `<platform> [<jobId>]`. */
+function cliSuffix(p: DaemonPlatform, jobId?: string): string {
+  return jobId ? `${p} ${jobId}` : p;
+}
+
 const launchdDriver: Driver = {
   name: "launchd",
-  start(p) {
-    const plistPath = launchdPlistPath(p);
+  start(p, jobId) {
+    const plistPath = launchdPlistPath(p, jobId);
     const dir = join(homedir(), "Library", "LaunchAgents");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
-    const existing = launchctlList(launchdLabel(p));
+    const existing = launchctlList(launchdLabel(p, jobId));
     if (existing.running && existing.pid) {
-      console.error(`${p} daemon is already running (PID ${existing.pid}).`);
-      console.error(`Stop it first with: sportsclaw stop ${p}`);
+      console.error(`${tag(p, jobId)} daemon is already running (PID ${existing.pid}).`);
+      console.error(`Stop it first with: sportsclaw stop ${cliSuffix(p, jobId)}`);
       process.exit(1);
     }
 
-    writeFileSync(plistPath, launchdRenderPlist(p), "utf-8");
+    writeFileSync(plistPath, launchdRenderPlist(p, jobId), "utf-8");
     // load is the legacy command but works across all macOS versions we target.
     spawnSync("launchctl", ["load", plistPath], { stdio: "inherit" });
 
-    console.log(`${p} daemon started via launchd.`);
+    console.log(`${tag(p, jobId)} daemon started via launchd.`);
     console.log(`  Status: sportsclaw status`);
-    console.log(`  Logs:   sportsclaw logs ${p}`);
-    console.log(`  Stop:   sportsclaw stop ${p}`);
+    console.log(`  Logs:   sportsclaw logs ${cliSuffix(p, jobId)}`);
+    console.log(`  Stop:   sportsclaw stop ${cliSuffix(p, jobId)}`);
   },
-  stop(p) {
-    const plistPath = launchdPlistPath(p);
+  stop(p, jobId) {
+    const plistPath = launchdPlistPath(p, jobId);
     if (!existsSync(plistPath)) {
-      console.error(`${p} daemon is not installed.`);
+      console.error(`${tag(p, jobId)} daemon is not installed.`);
       process.exit(1);
     }
     spawnSync("launchctl", ["unload", plistPath], { stdio: "inherit" });
-    console.log(`${p} daemon stopped.`);
+    console.log(`${tag(p, jobId)} daemon stopped.`);
   },
   status() {
-    let any = false;
+    const services = launchdInstalledServices();
     console.log("Daemon Status:");
     console.log("");
-    for (const p of VALID_PLATFORMS) {
-      const plistPath = launchdPlistPath(p);
-      if (!existsSync(plistPath)) continue;
-      any = true;
-      const info = launchctlList(launchdLabel(p));
-      const online = info.running && info.pid;
-      const icon = online ? "\x1b[32m●\x1b[0m" : "\x1b[2m○\x1b[0m";
-      const label = online ? `online (PID ${info.pid})` : "stopped";
-      console.log(`  ${icon} ${p.padEnd(12)} ${label}`);
-    }
-    if (!any) {
+    if (services.length === 0) {
       console.log("No daemons installed.");
       console.log("");
       console.log("Start one with: sportsclaw start <discord|telegram|watch>");
+      console.log("            or: sportsclaw start operator <jobId>");
       return;
+    }
+    for (const { platform, jobId } of services) {
+      const info = launchctlList(launchdLabel(platform, jobId));
+      const online = info.running && info.pid;
+      const icon = online ? "\x1b[32m●\x1b[0m" : "\x1b[2m○\x1b[0m";
+      const status = online ? `online (PID ${info.pid})` : "stopped";
+      const left = jobId ? `${platform} [${jobId}]` : platform;
+      console.log(`  ${icon} ${left.padEnd(36)} ${status}`);
     }
     console.log("");
     console.log(`Logs: ${logsDir()}`);
   },
-  logs(p, lines) {
-    const { out, err } = logPaths(p);
+  logs(p, lines, jobId) {
+    const { out, err } = logPaths(p, jobId);
     if (!existsSync(out) && !existsSync(err)) {
-      console.error(`No logs found for ${p}. Is the daemon running?`);
-      console.error(`Start it with: sportsclaw start ${p}`);
+      console.error(`No logs found for ${tag(p, jobId)}. Is the daemon running?`);
+      console.error(`Start it with: sportsclaw start ${cliSuffix(p, jobId)}`);
       process.exit(1);
     }
     if (existsSync(out)) {
@@ -355,22 +469,20 @@ const launchdDriver: Driver = {
       console.log(tailFile(err, lines));
     }
   },
-  restart(p) {
-    const plistPath = launchdPlistPath(p);
+  restart(p, jobId) {
+    const plistPath = launchdPlistPath(p, jobId);
     if (!existsSync(plistPath)) {
-      console.log(`${p} daemon is not currently installed. Starting fresh...`);
-      this.start(p);
+      console.log(`${tag(p, jobId)} daemon is not currently installed. Starting fresh...`);
+      this.start(p, jobId);
       return;
     }
     // kickstart -k restarts cleanly, surviving even a hung process.
-    // process.getuid() is always defined on macOS (POSIX); the optional-call
-    // syntax exists only because Node types it as conditional for Windows.
     const uid = typeof process.getuid === "function" ? process.getuid() : null;
     const r =
       uid !== null
         ? spawnSync(
             "launchctl",
-            ["kickstart", "-k", `gui/${uid}/${launchdLabel(p)}`],
+            ["kickstart", "-k", `gui/${uid}/${launchdLabel(p, jobId)}`],
             { stdio: "inherit" }
           )
         : { status: 1 };
@@ -379,7 +491,7 @@ const launchdDriver: Driver = {
       spawnSync("launchctl", ["unload", plistPath], { stdio: "inherit" });
       spawnSync("launchctl", ["load", plistPath], { stdio: "inherit" });
     }
-    console.log(`Restarted ${p} daemon.`);
+    console.log(`Restarted ${tag(p, jobId)} daemon.`);
   },
 };
 
@@ -387,20 +499,42 @@ const launchdDriver: Driver = {
 // Linux — systemd user units
 // ---------------------------------------------------------------------------
 
-function systemdUnitName(p: DaemonPlatform): string {
+function systemdUnitName(p: DaemonPlatform, jobId?: string): string {
+  if (p === "operator") {
+    return `sportsclaw-operator-${assertJobId(p, jobId)}.service`;
+  }
   return `sportsclaw-${p}.service`;
 }
 
-function systemdUnitPath(p: DaemonPlatform): string {
-  return join(homedir(), ".config", "systemd", "user", systemdUnitName(p));
+function systemdUnitPath(p: DaemonPlatform, jobId?: string): string {
+  return join(homedir(), ".config", "systemd", "user", systemdUnitName(p, jobId));
 }
 
-function systemdRenderUnit(p: DaemonPlatform): string {
-  const { out, err } = logPaths(p);
-  const args = [nodeBin(), entryPoint(), ...scriptArgsFor(p)];
+/** Enumerate installed systemd user units belonging to sportsclaw. */
+function systemdInstalledServices(): Array<{ platform: DaemonPlatform; jobId?: string }> {
+  const dir = join(homedir(), ".config", "systemd", "user");
+  if (!existsSync(dir)) return [];
+  const out: Array<{ platform: DaemonPlatform; jobId?: string }> = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.startsWith("sportsclaw-") || !file.endsWith(".service")) continue;
+    const rest = file.slice("sportsclaw-".length, -".service".length);
+    if (rest.startsWith("operator-")) {
+      const jobId = rest.slice("operator-".length);
+      if (JOB_ID_PATTERN.test(jobId)) out.push({ platform: "operator", jobId });
+    } else if (SIMPLE_PLATFORMS.includes(rest as DaemonPlatform)) {
+      out.push({ platform: rest as DaemonPlatform });
+    }
+  }
+  return out;
+}
+
+function systemdRenderUnit(p: DaemonPlatform, jobId?: string): string {
+  const { out, err } = logPaths(p, jobId);
+  const args = [nodeBin(), entryPoint(), ...scriptArgsFor(p, jobId)];
   const execStart = args.map(quoteIfNeeded).join(" ");
+  const description = jobId ? `sportsclaw ${p} ${jobId}` : `sportsclaw ${p} listener`;
   return `[Unit]
-Description=sportsclaw ${p} listener
+Description=${description}
 After=network-online.target
 Wants=network-online.target
 
@@ -435,73 +569,72 @@ function systemctlUser(args: string[]): { ok: boolean; stdout: string; stderr: s
 
 const systemdDriver: Driver = {
   name: "systemd",
-  start(p) {
-    const unitPath = systemdUnitPath(p);
+  start(p, jobId) {
+    const unitName = systemdUnitName(p, jobId);
+    const unitPath = systemdUnitPath(p, jobId);
     const dir = join(homedir(), ".config", "systemd", "user");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
-    // Already running?
-    const active = systemctlUser(["is-active", systemdUnitName(p)]);
+    const active = systemctlUser(["is-active", unitName]);
     if (active.stdout === "active") {
-      console.error(`${p} daemon is already running.`);
-      console.error(`Stop it first with: sportsclaw stop ${p}`);
+      console.error(`${tag(p, jobId)} daemon is already running.`);
+      console.error(`Stop it first with: sportsclaw stop ${cliSuffix(p, jobId)}`);
       process.exit(1);
     }
 
-    writeFileSync(unitPath, systemdRenderUnit(p), "utf-8");
+    writeFileSync(unitPath, systemdRenderUnit(p, jobId), "utf-8");
     const reload = systemctlUser(["daemon-reload"]);
     if (!reload.ok) {
       console.error(`systemctl --user daemon-reload failed: ${reload.stderr}`);
       process.exit(1);
     }
-    const enable = systemctlUser(["enable", "--now", systemdUnitName(p)]);
+    const enable = systemctlUser(["enable", "--now", unitName]);
     if (!enable.ok) {
-      console.error(`systemctl --user enable --now ${systemdUnitName(p)} failed:`);
+      console.error(`systemctl --user enable --now ${unitName} failed:`);
       console.error(enable.stderr);
       process.exit(1);
     }
 
-    console.log(`${p} daemon started via systemd (--user).`);
+    console.log(`${tag(p, jobId)} daemon started via systemd (--user).`);
     console.log(`  Status: sportsclaw status`);
-    console.log(`  Logs:   sportsclaw logs ${p}`);
-    console.log(`  Stop:   sportsclaw stop ${p}`);
+    console.log(`  Logs:   sportsclaw logs ${cliSuffix(p, jobId)}`);
+    console.log(`  Stop:   sportsclaw stop ${cliSuffix(p, jobId)}`);
     console.log(`  Note: enable lingering with \`loginctl enable-linger\` if you want this to`);
     console.log(`        survive logout. Otherwise it stops when you log out.`);
   },
-  stop(p) {
-    const unitPath = systemdUnitPath(p);
+  stop(p, jobId) {
+    const unitPath = systemdUnitPath(p, jobId);
     if (!existsSync(unitPath)) {
-      console.error(`${p} daemon is not installed.`);
+      console.error(`${tag(p, jobId)} daemon is not installed.`);
       process.exit(1);
     }
-    systemctlUser(["disable", "--now", systemdUnitName(p)]);
-    console.log(`${p} daemon stopped.`);
+    systemctlUser(["disable", "--now", systemdUnitName(p, jobId)]);
+    console.log(`${tag(p, jobId)} daemon stopped.`);
   },
   status() {
-    let any = false;
+    const services = systemdInstalledServices();
     console.log("Daemon Status:");
     console.log("");
-    for (const p of VALID_PLATFORMS) {
-      const unitPath = systemdUnitPath(p);
-      if (!existsSync(unitPath)) continue;
-      any = true;
-      const active = systemctlUser(["is-active", systemdUnitName(p)]);
-      const online = active.stdout === "active";
-      const icon = online ? "\x1b[32m●\x1b[0m" : "\x1b[2m○\x1b[0m";
-      const label = online ? "online" : active.stdout || "inactive";
-      console.log(`  ${icon} ${p.padEnd(12)} ${label}`);
-    }
-    if (!any) {
+    if (services.length === 0) {
       console.log("No daemons installed.");
       console.log("");
       console.log("Start one with: sportsclaw start <discord|telegram|watch>");
+      console.log("            or: sportsclaw start operator <jobId>");
       return;
+    }
+    for (const { platform, jobId } of services) {
+      const active = systemctlUser(["is-active", systemdUnitName(platform, jobId)]);
+      const online = active.stdout === "active";
+      const icon = online ? "\x1b[32m●\x1b[0m" : "\x1b[2m○\x1b[0m";
+      const status = online ? "online" : active.stdout || "inactive";
+      const left = jobId ? `${platform} [${jobId}]` : platform;
+      console.log(`  ${icon} ${left.padEnd(36)} ${status}`);
     }
     console.log("");
     console.log(`Logs: ${logsDir()}`);
   },
-  logs(p, lines) {
-    const { out, err } = logPaths(p);
+  logs(p, lines, jobId) {
+    const { out, err } = logPaths(p, jobId);
     if (existsSync(out) || existsSync(err)) {
       if (existsSync(out)) {
         console.log(`=== ${out} ===`);
@@ -519,23 +652,23 @@ const systemdDriver: Driver = {
       "--no-pager",
       "-n",
       String(lines),
-      systemdUnitName(p),
+      systemdUnitName(p, jobId),
     ]);
     console.log(r.stdout || r.stderr);
   },
-  restart(p) {
-    const unitPath = systemdUnitPath(p);
+  restart(p, jobId) {
+    const unitPath = systemdUnitPath(p, jobId);
     if (!existsSync(unitPath)) {
-      console.log(`${p} daemon is not currently installed. Starting fresh...`);
-      this.start(p);
+      console.log(`${tag(p, jobId)} daemon is not currently installed. Starting fresh...`);
+      this.start(p, jobId);
       return;
     }
-    const r = systemctlUser(["restart", systemdUnitName(p)]);
+    const r = systemctlUser(["restart", systemdUnitName(p, jobId)]);
     if (!r.ok) {
       console.error(`systemctl --user restart failed: ${r.stderr}`);
       process.exit(1);
     }
-    console.log(`Restarted ${p} daemon.`);
+    console.log(`Restarted ${tag(p, jobId)} daemon.`);
   },
 };
 
@@ -543,23 +676,48 @@ const systemdDriver: Driver = {
 // Windows — Task Scheduler + .cmd respawn wrapper
 // ---------------------------------------------------------------------------
 
-function windowsTaskName(p: DaemonPlatform): string {
+function windowsTaskName(p: DaemonPlatform, jobId?: string): string {
+  if (p === "operator") return `sportsclaw-operator-${assertJobId(p, jobId)}`;
   return `sportsclaw-${p}`;
 }
 
-function windowsWrapperPath(p: DaemonPlatform): string {
-  return join(homedir(), ".sportsclaw", "scripts", `sportsclaw-${p}.cmd`);
+function windowsWrapperPath(p: DaemonPlatform, jobId?: string): string {
+  return join(
+    homedir(),
+    ".sportsclaw",
+    "scripts",
+    `${windowsTaskName(p, jobId)}.cmd`,
+  );
+}
+
+/** Enumerate installed sportsclaw task names. */
+function windowsInstalledServices(): Array<{ platform: DaemonPlatform; jobId?: string }> {
+  const dir = join(homedir(), ".sportsclaw", "scripts");
+  if (!existsSync(dir)) return [];
+  const out: Array<{ platform: DaemonPlatform; jobId?: string }> = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.startsWith("sportsclaw-") || !file.endsWith(".cmd")) continue;
+    const rest = file.slice("sportsclaw-".length, -".cmd".length);
+    if (rest.startsWith("operator-")) {
+      const jobId = rest.slice("operator-".length);
+      if (JOB_ID_PATTERN.test(jobId)) out.push({ platform: "operator", jobId });
+    } else if (SIMPLE_PLATFORMS.includes(rest as DaemonPlatform)) {
+      out.push({ platform: rest as DaemonPlatform });
+    }
+  }
+  return out;
 }
 
 /**
  * Render a Windows .cmd that respawns the listener forever with a 10s back-off.
  * Logs append to the same files used on macOS/Linux.
  */
-function windowsRenderWrapper(p: DaemonPlatform): string {
-  const { out, err } = logPaths(p);
-  const args = [`"${nodeBin()}"`, `"${entryPoint()}"`, ...scriptArgsFor(p)].join(" ");
+function windowsRenderWrapper(p: DaemonPlatform, jobId?: string): string {
+  const { out, err } = logPaths(p, jobId);
+  const args = [`"${nodeBin()}"`, `"${entryPoint()}"`, ...scriptArgsFor(p, jobId)].join(" ");
+  const label = jobId ? `${p} ${jobId}` : p;
   return `@echo off
-REM sportsclaw ${p} listener — respawn loop
+REM sportsclaw ${label} — respawn loop
 :loop
 ${args} 1>>"${out}" 2>>"${err}"
 timeout /t 10 /nobreak >nul
@@ -589,21 +747,19 @@ function windowsTaskRunning(name: string): boolean {
 
 const windowsDriver: Driver = {
   name: "schtasks",
-  start(p) {
-    const taskName = windowsTaskName(p);
+  start(p, jobId) {
+    const taskName = windowsTaskName(p, jobId);
     if (windowsTaskRunning(taskName)) {
-      console.error(`${p} daemon is already running.`);
-      console.error(`Stop it first with: sportsclaw stop ${p}`);
+      console.error(`${tag(p, jobId)} daemon is already running.`);
+      console.error(`Stop it first with: sportsclaw stop ${cliSuffix(p, jobId)}`);
       process.exit(1);
     }
 
-    // Write/refresh the wrapper script
-    const wrapperPath = windowsWrapperPath(p);
+    const wrapperPath = windowsWrapperPath(p, jobId);
     const wrapperDir = join(homedir(), ".sportsclaw", "scripts");
     if (!existsSync(wrapperDir)) mkdirSync(wrapperDir, { recursive: true });
-    writeFileSync(wrapperPath, windowsRenderWrapper(p), "utf-8");
+    writeFileSync(wrapperPath, windowsRenderWrapper(p, jobId), "utf-8");
 
-    // Create-or-replace the scheduled task — runs at logon, kills on logoff.
     const create = schtasks([
       "/Create",
       "/F",
@@ -620,50 +776,50 @@ const windowsDriver: Driver = {
       console.error(`schtasks /Create failed: ${create.stderr || create.stdout}`);
       process.exit(1);
     }
-    // Run it now (without waiting for next logon).
     schtasks(["/Run", "/TN", taskName]);
 
-    console.log(`${p} daemon started via Task Scheduler.`);
+    console.log(`${tag(p, jobId)} daemon started via Task Scheduler.`);
     console.log(`  Status: sportsclaw status`);
-    console.log(`  Logs:   sportsclaw logs ${p}`);
-    console.log(`  Stop:   sportsclaw stop ${p}`);
+    console.log(`  Logs:   sportsclaw logs ${cliSuffix(p, jobId)}`);
+    console.log(`  Stop:   sportsclaw stop ${cliSuffix(p, jobId)}`);
   },
-  stop(p) {
-    const taskName = windowsTaskName(p);
+  stop(p, jobId) {
+    const taskName = windowsTaskName(p, jobId);
     if (!windowsTaskExists(taskName)) {
-      console.error(`${p} daemon is not installed.`);
+      console.error(`${tag(p, jobId)} daemon is not installed.`);
       process.exit(1);
     }
     schtasks(["/End", "/TN", taskName]);
     schtasks(["/Delete", "/TN", taskName, "/F"]);
-    console.log(`${p} daemon stopped.`);
+    console.log(`${tag(p, jobId)} daemon stopped.`);
   },
   status() {
-    let any = false;
+    const services = windowsInstalledServices();
     console.log("Daemon Status:");
     console.log("");
-    for (const p of VALID_PLATFORMS) {
-      const taskName = windowsTaskName(p);
-      if (!windowsTaskExists(taskName)) continue;
-      any = true;
-      const online = windowsTaskRunning(taskName);
-      const icon = online ? "\x1b[32m●\x1b[0m" : "\x1b[2m○\x1b[0m";
-      console.log(`  ${icon} ${p.padEnd(12)} ${online ? "online" : "stopped"}`);
-    }
-    if (!any) {
+    if (services.length === 0) {
       console.log("No daemons installed.");
       console.log("");
       console.log("Start one with: sportsclaw start <discord|telegram|watch>");
+      console.log("            or: sportsclaw start operator <jobId>");
       return;
+    }
+    for (const { platform, jobId } of services) {
+      const taskName = windowsTaskName(platform, jobId);
+      if (!windowsTaskExists(taskName)) continue;
+      const online = windowsTaskRunning(taskName);
+      const icon = online ? "\x1b[32m●\x1b[0m" : "\x1b[2m○\x1b[0m";
+      const left = jobId ? `${platform} [${jobId}]` : platform;
+      console.log(`  ${icon} ${left.padEnd(36)} ${online ? "online" : "stopped"}`);
     }
     console.log("");
     console.log(`Logs: ${logsDir()}`);
   },
-  logs(p, lines) {
-    const { out, err } = logPaths(p);
+  logs(p, lines, jobId) {
+    const { out, err } = logPaths(p, jobId);
     if (!existsSync(out) && !existsSync(err)) {
-      console.error(`No logs found for ${p}. Is the daemon running?`);
-      console.error(`Start it with: sportsclaw start ${p}`);
+      console.error(`No logs found for ${tag(p, jobId)}. Is the daemon running?`);
+      console.error(`Start it with: sportsclaw start ${cliSuffix(p, jobId)}`);
       process.exit(1);
     }
     if (existsSync(out)) {
@@ -675,16 +831,16 @@ const windowsDriver: Driver = {
       console.log(tailFile(err, lines));
     }
   },
-  restart(p) {
-    const taskName = windowsTaskName(p);
+  restart(p, jobId) {
+    const taskName = windowsTaskName(p, jobId);
     if (!windowsTaskExists(taskName)) {
-      console.log(`${p} daemon is not currently installed. Starting fresh...`);
-      this.start(p);
+      console.log(`${tag(p, jobId)} daemon is not currently installed. Starting fresh...`);
+      this.start(p, jobId);
       return;
     }
     schtasks(["/End", "/TN", taskName]);
     schtasks(["/Run", "/TN", taskName]);
-    console.log(`Restarted ${p} daemon.`);
+    console.log(`Restarted ${tag(p, jobId)} daemon.`);
   },
 };
 
@@ -695,3 +851,4 @@ const windowsDriver: Driver = {
 void execSync;
 void execFileSync;
 void readFileSync;
+void serviceKey;

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,10 @@ import {
   daemonRestart,
   daemonLogs,
   isValidPlatform,
+  platformRequiresJobId,
+  type DaemonPlatform,
 } from "./daemon.js";
+import { cmdOperate } from "./operate.js";
 import { runSetup } from "./setup.js";
 import {
   loadMcpConfigs,
@@ -1915,13 +1918,54 @@ async function cmdQuery(args: string[]): Promise<void> {
 // CLI: `sportsclaw start <platform>` — start a daemon
 // ---------------------------------------------------------------------------
 
-function cmdStart(args: string[]): void {
+/**
+ * Parse the first two positionals as (platform, jobId?) for the
+ * supervisor subcommands. Returns null + prints a usage hint on bad input.
+ *
+ * Shape:
+ *   <platform>                — simple platforms (discord/telegram/watch)
+ *   operator <jobId>          — operator daemons require a jobId
+ *
+ * Returns: { platform, jobId? } on success; null on failure (caller exits).
+ */
+function parseDaemonTarget(
+  verb: string,
+  args: string[],
+): { platform: DaemonPlatform; jobId?: string } | null {
   const platform = args[0]?.toLowerCase();
   if (!platform || !isValidPlatform(platform)) {
-    console.error("Usage: sportsclaw start <discord|telegram|watch>");
-    process.exit(1);
+    console.error(
+      `Usage: sportsclaw ${verb} <discord|telegram|watch|operator <jobId>>`,
+    );
+    return null;
   }
-  daemonStart(platform);
+  if (platformRequiresJobId(platform)) {
+    const jobId = args[1];
+    if (!jobId) {
+      console.error(`Usage: sportsclaw ${verb} operator <jobId>`);
+      return null;
+    }
+    if (args.length > 2 && verb !== "logs") {
+      console.error(
+        `Usage: sportsclaw ${verb} operator <jobId> — unexpected arg "${args[2]}"`,
+      );
+      return null;
+    }
+    return { platform, jobId };
+  }
+  if (args.length > 1 && verb !== "logs") {
+    console.error(
+      `Usage: sportsclaw ${verb} ${platform} — does not take additional args (got "${args[1]}")`,
+    );
+    return null;
+  }
+  return { platform };
+}
+
+function cmdStart(args: string[]): void {
+  const target = parseDaemonTarget("start", args);
+  if (!target) process.exit(1);
+  daemonStart(target.platform, target.jobId);
 }
 
 // ---------------------------------------------------------------------------
@@ -1929,16 +1973,13 @@ function cmdStart(args: string[]): void {
 // ---------------------------------------------------------------------------
 
 function cmdStop(args: string[]): void {
-  const platform = args[0]?.toLowerCase();
-  if (!platform || !isValidPlatform(platform)) {
-    console.error("Usage: sportsclaw stop <discord|telegram|watch>");
-    process.exit(1);
-  }
-  daemonStop(platform);
+  const target = parseDaemonTarget("stop", args);
+  if (!target) process.exit(1);
+  daemonStop(target.platform, target.jobId);
 }
 
 // ---------------------------------------------------------------------------
-// CLI: `sportsclaw status` — show daemon status
+// CLI: `sportsclaw status` — show daemon status (all platforms)
 // ---------------------------------------------------------------------------
 
 function cmdStatus(): void {
@@ -1950,26 +1991,44 @@ function cmdStatus(): void {
 // ---------------------------------------------------------------------------
 
 function cmdRestart(args: string[]): void {
-  const platform = args[0]?.toLowerCase();
-  if (!platform || !["discord", "telegram", "watch"].includes(platform)) {
-    console.error("Usage: sportsclaw restart <discord|telegram|watch>");
-    process.exit(1);
-  }
-  daemonRestart(platform as any);
+  const target = parseDaemonTarget("restart", args);
+  if (!target) process.exit(1);
+  daemonRestart(target.platform, target.jobId);
 }
 
 // ---------------------------------------------------------------------------
-// CLI: `sportsclaw logs <platform>` — tail daemon logs
+// CLI: `sportsclaw logs <platform> [--lines N]` — tail daemon logs
 // ---------------------------------------------------------------------------
 
 function cmdLogs(args: string[]): void {
-  const platform = args[0]?.toLowerCase();
-  if (!platform || !isValidPlatform(platform)) {
-    console.error("Usage: sportsclaw logs <discord|telegram|watch>");
-    process.exit(1);
+  // Pull --lines out of args before positional parsing so the count works
+  // for both `logs discord 100` and `logs operator <jobId> 100`.
+  let lines = 50;
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--lines") {
+      const n = Number.parseInt(args[++i], 10);
+      if (Number.isFinite(n) && n > 0) lines = n;
+    } else if (a.startsWith("--lines=")) {
+      const n = Number.parseInt(a.slice("--lines=".length), 10);
+      if (Number.isFinite(n) && n > 0) lines = n;
+    } else {
+      positional.push(a);
+    }
   }
-  const lines = args[1] ? Number.parseInt(args[1], 10) : 50;
-  daemonLogs(platform, Number.isFinite(lines) && lines > 0 ? lines : 50);
+  // Backwards compat: if a final positional is purely numeric, treat it as N.
+  if (positional.length >= 2) {
+    const tail = positional[positional.length - 1];
+    if (/^\d+$/.test(tail)) {
+      const n = Number.parseInt(tail, 10);
+      if (n > 0) lines = n;
+      positional.pop();
+    }
+  }
+  const target = parseDaemonTarget("logs", positional);
+  if (!target) process.exit(1);
+  daemonLogs(target.platform, lines, target.jobId);
 }
 
 // ---------------------------------------------------------------------------
@@ -2234,9 +2293,12 @@ function printHelp(): void {
   console.log("  sportsclaw init                    Interactive sport selection & install");
   console.log("  sportsclaw init --all              Bootstrap all 14 default sport schemas");
   console.log("  sportsclaw listen <platform>       Start a chat listener (discord, telegram)");
+  console.log("  sportsclaw operate --job <jobId>   Run an autonomous operator daemon (foreground)");
+  console.log("  sportsclaw operate --list          List configured operator jobs");
   console.log("  sportsclaw start <platform>        Start a listener as a background daemon");
+  console.log("  sportsclaw start operator <jobId>  Start a supervised operator daemon");
   console.log("  sportsclaw stop <platform>         Stop a running daemon");
-  console.log("  sportsclaw status                  Show daemon status");
+  console.log("  sportsclaw status                  Show daemon status (all platforms + operator jobs)");
   console.log("  sportsclaw restart <platform>      Restart a running daemon");
   console.log("  sportsclaw logs <platform>         Tail daemon log output");
   console.log("  sportsclaw agents                  List installed agents");
@@ -2448,6 +2510,8 @@ async function main(): Promise<void> {
       return cmdRestart(subArgs);
     case "logs":
       return cmdLogs(subArgs);
+    case "operate":
+      return cmdOperate(subArgs);
     case "agents":
       return cmdAgents();
     case "analytics":

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -1,0 +1,575 @@
+/**
+ * `sportsclaw operate` — autonomous operator daemon CLI.
+ *
+ * Foreground driver for createOperatorDaemon(). Also the implementation
+ * invoked by the supervised form (`sportsclaw start operator <jobId>`)
+ * via daemon.ts → scriptArgsFor.
+ *
+ *   sportsclaw operate --job <jobId>             run forever, ticking
+ *   sportsclaw operate --job <jobId> --once      one tick, exit by status
+ *   sportsclaw operate --job <jobId> --dry-run   resolve + print prompt, no LLM
+ *   sportsclaw operate --list [--json]           list configured jobs
+ *   sportsclaw operate --validate <jobId>        load + validate; exit non-zero on errors
+ *
+ * --once exit code matrix:
+ *   0 — published (LLM produced output)
+ *   0 — silent    (LLM voted [SILENT])
+ *   1 — skipped   (wake gate denied)
+ *   2 — failed    (LLM/tool error)
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+
+import { generateText, tool as defineTool, jsonSchema, type ToolSet } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { openai } from "@ai-sdk/openai";
+import { google } from "@ai-sdk/google";
+
+import {
+  createOperatorDaemon,
+  type TickEvent,
+} from "./operator-daemon.js";
+import {
+  listOperatorJobs,
+  loadOperatorJobConfig,
+  defaultRootDir,
+  validateOperatorJobConfig,
+  operatorConfigPath,
+  type OperatorJobConfig,
+} from "./operator-config.js";
+import { ToolRegistry, type ToolCallInput } from "./tools.js";
+import { McpManager } from "./mcp.js";
+import { loadAllSchemas } from "./schema.js";
+import { resolveConfig } from "./config.js";
+import {
+  BROADCAST_DIRECTIVE_FRAGMENT,
+  buildSystemPrompt,
+  CRON_AUTONOMY_FRAGMENT,
+  EDITORIAL_MEMORY_FRAGMENT_HEADER,
+  SILENT_SENTINEL_FRAGMENT,
+  SILENT_SENTINEL_TOKEN,
+  TICK_BRIEF_FRAGMENT_HEADER,
+  TOOL_DISCIPLINE_FRAGMENT,
+} from "./prompts.js";
+import type { LLMProvider } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public entry — wired into src/index.ts main dispatcher
+// ---------------------------------------------------------------------------
+
+interface ParsedFlags {
+  job?: string;
+  list: boolean;
+  validate?: string;
+  once: boolean;
+  dryRun: boolean;
+  json: boolean;
+  unknown: string[];
+}
+
+function parseFlags(args: string[]): ParsedFlags {
+  const flags: ParsedFlags = {
+    list: false,
+    once: false,
+    dryRun: false,
+    json: false,
+    unknown: [],
+  };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--list") flags.list = true;
+    else if (arg === "--once") flags.once = true;
+    else if (arg === "--dry-run") flags.dryRun = true;
+    else if (arg === "--json") flags.json = true;
+    else if (arg === "--validate") {
+      flags.validate = args[++i];
+    } else if (arg === "--job") {
+      flags.job = args[++i];
+    } else if (arg.startsWith("--job=")) {
+      flags.job = arg.slice("--job=".length);
+    } else if (arg.startsWith("--validate=")) {
+      flags.validate = arg.slice("--validate=".length);
+    } else {
+      flags.unknown.push(arg);
+    }
+  }
+  return flags;
+}
+
+export async function cmdOperate(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+
+  if (flags.unknown.length > 0) {
+    console.error(`Unknown argument(s): ${flags.unknown.join(" ")}`);
+    printOperateHelp();
+    process.exit(2);
+  }
+
+  if (flags.list) return runList({ json: flags.json });
+  if (flags.validate) return runValidate(flags.validate);
+
+  if (!flags.job) {
+    printOperateHelp();
+    process.exit(2);
+  }
+
+  if (flags.dryRun) return runDryRun(flags.job);
+  if (flags.once) return runOnce(flags.job);
+  return runForeground(flags.job);
+}
+
+function printOperateHelp(): void {
+  console.log(
+    [
+      "sportsclaw operate — autonomous operator daemon",
+      "",
+      "Usage:",
+      "  sportsclaw operate --job <jobId>             run forever, ticking",
+      "  sportsclaw operate --job <jobId> --once      one tick, exit by status",
+      "  sportsclaw operate --job <jobId> --dry-run   resolve + print prompt, no LLM",
+      "  sportsclaw operate --list [--json]           list configured jobs",
+      "  sportsclaw operate --validate <jobId>        load + validate; non-zero on errors",
+      "",
+      "Job configs live in ~/.sportsclaw/operator/<jobId>.json.",
+      "",
+      "--once exit codes:",
+      "  0  published (LLM produced output)",
+      "  0  silent    (LLM voted [SILENT])",
+      "  1  skipped   (wake gate denied)",
+      "  2  failed    (LLM / tool error)",
+    ].join("\n"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// `--list`
+// ---------------------------------------------------------------------------
+
+interface ListItem {
+  jobId: string;
+  path: string;
+  intervalMs?: number;
+  label?: string;
+  valid: boolean;
+  issues?: string[];
+}
+
+function runList(opts: { json: boolean }): void {
+  const jobs = listOperatorJobs();
+  const items: ListItem[] = jobs.map(({ jobId, path: filePath }) => {
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      const parsed = JSON.parse(raw);
+      const result = validateOperatorJobConfig(parsed, { sourcePath: filePath });
+      if (!result.valid || !result.config) {
+        return {
+          jobId,
+          path: filePath,
+          valid: false,
+          issues: result.issues.map((i) => `${i.field}: ${i.message}`),
+        };
+      }
+      return {
+        jobId,
+        path: filePath,
+        intervalMs: result.config.intervalMs,
+        label: result.config.label,
+        valid: true,
+      };
+    } catch (err) {
+      return {
+        jobId,
+        path: filePath,
+        valid: false,
+        issues: [err instanceof Error ? err.message : String(err)],
+      };
+    }
+  });
+
+  if (opts.json) {
+    console.log(JSON.stringify(items, null, 2));
+    return;
+  }
+
+  if (items.length === 0) {
+    console.log("No operator jobs configured.");
+    console.log(
+      `Drop a JSON file in ${path.join(homedir(), ".sportsclaw", "operator")}/ to add one.`,
+    );
+    console.log("See examples/operator-jobs/ in the repo for starter configs.");
+    return;
+  }
+
+  console.log("Operator jobs:");
+  console.log("");
+  for (const it of items) {
+    const tag = it.valid ? "\x1b[32m●\x1b[0m" : "\x1b[31m✗\x1b[0m";
+    const interval = it.intervalMs ? `${it.intervalMs}ms` : "—";
+    const label = it.label ? ` "${it.label}"` : "";
+    console.log(`  ${tag} ${it.jobId.padEnd(28)} ${interval.padEnd(12)}${label}`);
+    if (!it.valid && it.issues) {
+      for (const msg of it.issues) console.log(`     ${msg}`);
+    }
+  }
+  console.log("");
+}
+
+// ---------------------------------------------------------------------------
+// `--validate`
+// ---------------------------------------------------------------------------
+
+function runValidate(jobId: string): void {
+  try {
+    const { config, path: filePath } = loadOperatorJobConfig(jobId);
+    console.log(`OK: ${filePath}`);
+    console.log(`  jobId:      ${config.jobId}`);
+    console.log(`  intervalMs: ${config.intervalMs}`);
+    if (config.label) console.log(`  label:      ${config.label}`);
+    process.exit(0);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool source — reuse the engine's ToolRegistry / McpManager logic
+// ---------------------------------------------------------------------------
+
+interface OperatorTools {
+  registry: ToolRegistry;
+  mcpManager: McpManager;
+  toolSet: ToolSet;
+  toolNames: string[];
+}
+
+/**
+ * Build the same ToolSet `sportsclaw chat` would expose, minus engine-state-
+ * specific internal tools (memory ops, sport install, etc.). v1: no per-job
+ * filtering. The registry + mcpManager are returned so callers can use them
+ * for persona resolution and clean shutdown.
+ */
+async function buildOperatorTools(verbose: boolean): Promise<OperatorTools> {
+  const registry = new ToolRegistry();
+  for (const schema of loadAllSchemas()) {
+    registry.injectSchema(schema, false);
+  }
+
+  const mcpManager = new McpManager(verbose, false);
+  if (mcpManager.serverCount > 0) {
+    await mcpManager.connectAll();
+    registry.injectMcpTools(mcpManager);
+  }
+
+  const toolSet: ToolSet = {};
+  const toolNames: string[] = [];
+  for (const spec of registry.getAllToolSpecs()) {
+    toolNames.push(spec.name);
+    toolSet[spec.name] = defineTool({
+      description: spec.description,
+      inputSchema: jsonSchema(spec.input_schema),
+      execute: async (args: Record<string, unknown>) => {
+        const result = await registry.dispatchToolCall(spec.name, args as ToolCallInput);
+        if (result.isError) {
+          throw new Error(result.content);
+        }
+        // Cap output, same policy as engine.buildTools (~30k chars).
+        const MAX = 30_000;
+        return result.content.length > MAX
+          ? result.content.slice(0, MAX) +
+              `\n\n[... output truncated: ${MAX} of ${result.content.length} chars shown]`
+          : result.content;
+      },
+    });
+  }
+
+  return { registry, mcpManager, toolSet, toolNames };
+}
+
+// ---------------------------------------------------------------------------
+// Persona + fragment resolution
+// ---------------------------------------------------------------------------
+
+const FRAGMENT_ALIASES: Record<string, string> = {
+  "broadcast-directive": BROADCAST_DIRECTIVE_FRAGMENT,
+  broadcast: BROADCAST_DIRECTIVE_FRAGMENT,
+  "cron-autonomy": CRON_AUTONOMY_FRAGMENT,
+  "tool-discipline": TOOL_DISCIPLINE_FRAGMENT,
+  "silent-sentinel": SILENT_SENTINEL_FRAGMENT,
+};
+
+function resolveExtraFragments(names: string[] | undefined): string[] {
+  if (!names || names.length === 0) return [];
+  return names.map((n) => {
+    const alias = FRAGMENT_ALIASES[n];
+    return alias !== undefined ? alias : n;
+  });
+}
+
+async function resolvePersona(
+  cfg: OperatorJobConfig,
+  mcpManager: McpManager,
+): Promise<string> {
+  if (cfg.personaText) return cfg.personaText;
+  if (!cfg.persona) {
+    throw new Error(
+      `Job "${cfg.jobId}": neither personaText nor persona is set. Add one to the config.`,
+    );
+  }
+  const machinaServer = mcpManager.getMachinaServerName();
+  if (!machinaServer) {
+    throw new Error(
+      `Job "${cfg.jobId}": persona "${cfg.persona}" requires an MCP server, but none provides get_prompt_by_name. Inline the persona via "personaText" or configure an MCP server.`,
+    );
+  }
+  const result = await mcpManager.callToolDirect(machinaServer, "get_prompt_by_name", {
+    name: cfg.persona,
+  });
+  if (result.isError) {
+    throw new Error(
+      `Job "${cfg.jobId}": failed to resolve persona "${cfg.persona}" via MCP: ${result.content}`,
+    );
+  }
+  // The MCP tool returns either { content: "..." } or a structured prompt;
+  // accept both shapes pragmatically.
+  try {
+    const parsed = JSON.parse(result.content) as
+      | { content?: string; text?: string; prompt?: string }
+      | string;
+    if (typeof parsed === "string") return parsed;
+    return parsed.content ?? parsed.text ?? parsed.prompt ?? result.content;
+  } catch {
+    return result.content;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model resolution — small dup of engine's private helper; spec forbids
+// engine.ts changes, so we reproduce 3 lines rather than expose a getter.
+// ---------------------------------------------------------------------------
+
+function resolveModel(provider: LLMProvider, modelId: string) {
+  switch (provider) {
+    case "anthropic":
+      return anthropic(modelId);
+    case "openai":
+      return openai(modelId);
+    case "google":
+      return google(modelId);
+    default:
+      throw new Error(`Unsupported provider: "${provider}"`);
+  }
+}
+
+interface ResolvedDaemonInputs {
+  provider: LLMProvider;
+  modelId: string;
+  rootDir: string;
+  personaText: string;
+  extraFragments: string[];
+}
+
+async function resolveJobInputs(
+  cfg: OperatorJobConfig,
+  mcpManager: McpManager,
+  opts: { ensureRootDir?: boolean } = {},
+): Promise<ResolvedDaemonInputs> {
+  const sportsclawCfg = resolveConfig();
+  const provider = cfg.provider ?? sportsclawCfg.provider ?? "google";
+  const modelId =
+    cfg.model ?? sportsclawCfg.model ?? defaultModelFor(provider);
+  const rootDir = cfg.rootDir ?? defaultRootDir(cfg.jobId);
+  if (opts.ensureRootDir) {
+    fs.mkdirSync(rootDir, { recursive: true });
+  }
+  const personaText = await resolvePersona(cfg, mcpManager);
+  const extraFragments = resolveExtraFragments(cfg.extraFragments);
+  return { provider, modelId, rootDir, personaText, extraFragments };
+}
+
+function defaultModelFor(provider: LLMProvider): string {
+  switch (provider) {
+    case "anthropic":
+      return "claude-sonnet-4-6";
+    case "openai":
+      return "gpt-4.1";
+    case "google":
+      return "gemini-2.5-flash";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tail-server poster — non-fatal HTTP POST per TickEvent
+// ---------------------------------------------------------------------------
+
+function makeTailServerPoster(
+  tailServer: string,
+  jobId: string,
+): (evt: TickEvent) => void {
+  const url = tailServer.replace(/\/+$/, "") + "/ingest";
+  return (evt: TickEvent) => {
+    fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "tv-telemetry-event",
+        source: "sportsclaw-operate",
+        jobId,
+        event: evt,
+        timestamp: new Date().toISOString(),
+      }),
+    }).catch((err) => {
+      console.error(
+        `[operate] tail-server POST failed (${url}): ${err instanceof Error ? err.message : err}`,
+      );
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `--dry-run`
+// ---------------------------------------------------------------------------
+
+async function runDryRun(jobId: string): Promise<void> {
+  const { config: cfg } = loadOperatorJobConfig(jobId);
+  const tools = await buildOperatorTools(false);
+  try {
+    const inputs = await resolveJobInputs(cfg, tools.mcpManager);
+    const system = buildSystemPrompt({
+      role: inputs.personaText,
+      isCron: true,
+      toolDiscipline: true,
+      silentSentinel: true,
+      extras: inputs.extraFragments,
+    });
+    console.log(`=== Resolved system prompt for "${cfg.jobId}" ===`);
+    console.log("");
+    console.log(system);
+    console.log("");
+    console.log(`=== Tools (${tools.toolNames.length}) ===`);
+    for (const name of tools.toolNames) console.log(`  - ${name}`);
+    console.log("");
+    console.log(`provider: ${inputs.provider}`);
+    console.log(`model:    ${inputs.modelId}`);
+    console.log(`rootDir:  ${inputs.rootDir}`);
+  } finally {
+    await tools.mcpManager.disconnectAll().catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `--once`
+// ---------------------------------------------------------------------------
+
+async function runOnce(jobId: string): Promise<void> {
+  const { config: cfg } = loadOperatorJobConfig(jobId);
+  const tools = await buildOperatorTools(false);
+  try {
+    const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
+    const daemon = createOperatorDaemon({
+      jobId: cfg.jobId,
+      jobLabel: cfg.label,
+      intervalMs: cfg.intervalMs,
+      model: resolveModel(inputs.provider, inputs.modelId),
+      role: inputs.personaText,
+      tools: tools.toolSet,
+      rootDir: inputs.rootDir,
+      extraFragments: inputs.extraFragments,
+      guardOptions: cfg.guardOptions,
+      onTickEvent: cfg.tailServer ? makeTailServerPoster(cfg.tailServer, cfg.jobId) : undefined,
+    });
+    const event = await daemon.tickOnce();
+    console.log(JSON.stringify(event, null, 2));
+    process.exit(exitCodeFor(event));
+  } finally {
+    await tools.mcpManager.disconnectAll().catch(() => {});
+  }
+}
+
+function exitCodeFor(event: TickEvent): number {
+  switch (event.type) {
+    case "tick_published":
+    case "tick_silent":
+      return 0;
+    case "tick_skipped":
+      return 1;
+    case "tick_failed":
+      return 2;
+    default:
+      return 2;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Foreground forever
+// ---------------------------------------------------------------------------
+
+async function runForeground(jobId: string): Promise<void> {
+  const { config: cfg } = loadOperatorJobConfig(jobId);
+  const tools = await buildOperatorTools(false);
+  const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
+
+  const daemon = createOperatorDaemon({
+    jobId: cfg.jobId,
+    jobLabel: cfg.label,
+    intervalMs: cfg.intervalMs,
+    model: resolveModel(inputs.provider, inputs.modelId),
+    role: inputs.personaText,
+    tools: tools.toolSet,
+    rootDir: inputs.rootDir,
+    extraFragments: inputs.extraFragments,
+    guardOptions: cfg.guardOptions,
+    onTickEvent: cfg.tailServer
+      ? makeTailServerPoster(cfg.tailServer, cfg.jobId)
+      : (evt) => console.log(JSON.stringify(evt)),
+  });
+
+  let shuttingDown = false;
+  const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.error(`[operate] received ${signal}, shutting down`);
+    daemon.stop();
+    // Best-effort final brief so the next start sees an explicit handoff.
+    try {
+      await daemon.tickOnce();
+    } catch {
+      // Don't block exit on a final-brief failure.
+    }
+    await tools.mcpManager.disconnectAll().catch(() => {});
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+  console.error(
+    `[operate] job=${cfg.jobId} interval=${cfg.intervalMs}ms provider=${inputs.provider} model=${inputs.modelId}`,
+  );
+  daemon.start();
+  // Keep the process alive without unref'd heartbeat timers exiting early.
+  await new Promise<void>(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Exports kept for tests
+// ---------------------------------------------------------------------------
+
+export {
+  buildOperatorTools,
+  exitCodeFor,
+  FRAGMENT_ALIASES,
+  makeTailServerPoster,
+  parseFlags,
+  resolveExtraFragments,
+  resolvePersona,
+};
+
+// Suppress unused warnings for fragment-header re-exports that may be
+// consumed by callers in the future.
+void EDITORIAL_MEMORY_FRAGMENT_HEADER;
+void TICK_BRIEF_FRAGMENT_HEADER;
+void SILENT_SENTINEL_TOKEN;
+void operatorConfigPath;

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -1,0 +1,297 @@
+/**
+ * Operator Job Config — schema + loader for `~/.sportsclaw/operator/<jobId>.json`.
+ *
+ * One file per autonomous job. Read by `sportsclaw operate --job <jobId>`
+ * and by the supervised form (`sportsclaw start operator <jobId>`).
+ *
+ * Required: jobId, intervalMs.
+ * Persona: exactly one of `persona` (MCP-resolved by name) or `personaText`.
+ *
+ * No I/O outside `loadOperatorJobConfig` / `listOperatorJobs`. All other
+ * helpers are pure validators so they're easy to test.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+
+import type { LLMProvider } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OperatorJobConfig {
+  /** Unique job id. Must match the filename basename. */
+  jobId: string;
+  /** Human-readable label, shown in logs + supervisor. Defaults to jobId. */
+  label?: string;
+  /** Tick interval in ms. Must be > 0. */
+  intervalMs: number;
+  /** EITHER an MCP-resolvable prompt name (resolved at runtime via get_prompt_by_name)... */
+  persona?: string;
+  /** ...OR inline persona text. One of these two is required. */
+  personaText?: string;
+  /** AI SDK model id. Defaults to sportsclaw config. */
+  model?: string;
+  /** Provider override. Defaults to sportsclaw config. */
+  provider?: LLMProvider;
+  /** Persistence + brief root. Defaults to ~/.sportsclaw/operator/<jobId>/. */
+  rootDir?: string;
+  /** If set, POST every TickEvent to <tailServer>/ingest. Failures are non-fatal. */
+  tailServer?: string;
+  /**
+   * Extra system-prompt fragments. Each string is resolved against
+   * prompts.ts exports first (e.g. "broadcast-directive" →
+   * BROADCAST_DIRECTIVE_FRAGMENT) and used as inline text otherwise.
+   */
+  extraFragments?: string[];
+  /** Tool guardrail overrides — passed through to ToolGuardController. */
+  guardOptions?: Record<string, unknown>;
+}
+
+export interface ValidationIssue {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: ValidationIssue[];
+  /** Populated only when valid. */
+  config?: OperatorJobConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+/** Directory holding all operator job configs. */
+export function operatorConfigDir(): string {
+  return path.join(homedir(), ".sportsclaw", "operator");
+}
+
+/** Path to the JSON file for a given jobId. */
+export function operatorConfigPath(jobId: string): string {
+  return path.join(operatorConfigDir(), `${jobId}.json`);
+}
+
+/** Default rootDir for a job — used by HeartbeatService persistence + briefs. */
+export function defaultRootDir(jobId: string): string {
+  return path.join(operatorConfigDir(), jobId);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const VALID_PROVIDERS: ReadonlySet<LLMProvider> = new Set<LLMProvider>([
+  "anthropic",
+  "openai",
+  "google",
+]);
+
+const JOB_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Validate a parsed JSON object against the OperatorJobConfig schema.
+ * Returns line-precise field errors via `issues`. `valid: true` guarantees
+ * `config` is populated and safe to cast.
+ */
+export function validateOperatorJobConfig(
+  input: unknown,
+  opts: { sourcePath?: string } = {},
+): ValidationResult {
+  const issues: ValidationIssue[] = [];
+  const push = (field: string, message: string) => issues.push({ field, message });
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    push("", "expected a JSON object at the top level");
+    return { valid: false, issues };
+  }
+  const raw = input as Record<string, unknown>;
+
+  // jobId
+  if (typeof raw.jobId !== "string" || !raw.jobId) {
+    push("jobId", "missing required string");
+  } else if (!JOB_ID_PATTERN.test(raw.jobId)) {
+    push(
+      "jobId",
+      `must match ${JOB_ID_PATTERN.source} (got ${JSON.stringify(raw.jobId)})`,
+    );
+  } else if (opts.sourcePath) {
+    const expected = path.basename(opts.sourcePath, ".json");
+    if (raw.jobId !== expected) {
+      push(
+        "jobId",
+        `jobId "${raw.jobId}" must match filename basename "${expected}"`,
+      );
+    }
+  }
+
+  // intervalMs
+  if (typeof raw.intervalMs !== "number" || !Number.isFinite(raw.intervalMs)) {
+    push("intervalMs", "missing required number");
+  } else if (raw.intervalMs <= 0) {
+    push("intervalMs", `must be > 0 (got ${raw.intervalMs})`);
+  }
+
+  // persona / personaText — exactly one required
+  const hasPersona = typeof raw.persona === "string" && raw.persona.length > 0;
+  const hasPersonaText =
+    typeof raw.personaText === "string" && raw.personaText.length > 0;
+  if (!hasPersona && !hasPersonaText) {
+    push("persona|personaText", "exactly one of 'persona' or 'personaText' is required");
+  } else if (hasPersona && hasPersonaText) {
+    push(
+      "persona|personaText",
+      "exactly one of 'persona' or 'personaText' may be set, not both",
+    );
+  }
+  if (raw.persona !== undefined && typeof raw.persona !== "string") {
+    push("persona", "must be a string (MCP prompt name)");
+  }
+  if (raw.personaText !== undefined && typeof raw.personaText !== "string") {
+    push("personaText", "must be a string");
+  }
+
+  // label
+  if (raw.label !== undefined && typeof raw.label !== "string") {
+    push("label", "must be a string");
+  }
+
+  // model
+  if (raw.model !== undefined && typeof raw.model !== "string") {
+    push("model", "must be a string");
+  }
+
+  // provider
+  if (raw.provider !== undefined) {
+    if (typeof raw.provider !== "string" || !VALID_PROVIDERS.has(raw.provider as LLMProvider)) {
+      push(
+        "provider",
+        `must be one of ${[...VALID_PROVIDERS].join(", ")} (got ${JSON.stringify(raw.provider)})`,
+      );
+    }
+  }
+
+  // rootDir
+  if (raw.rootDir !== undefined && typeof raw.rootDir !== "string") {
+    push("rootDir", "must be a string");
+  }
+
+  // tailServer
+  if (raw.tailServer !== undefined) {
+    if (typeof raw.tailServer !== "string") {
+      push("tailServer", "must be a string URL");
+    } else {
+      try {
+        const url = new URL(raw.tailServer);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          push("tailServer", "must be http(s)");
+        }
+      } catch {
+        push("tailServer", `not a valid URL: ${JSON.stringify(raw.tailServer)}`);
+      }
+    }
+  }
+
+  // extraFragments
+  if (raw.extraFragments !== undefined) {
+    if (!Array.isArray(raw.extraFragments)) {
+      push("extraFragments", "must be an array of strings");
+    } else {
+      for (let i = 0; i < raw.extraFragments.length; i++) {
+        if (typeof raw.extraFragments[i] !== "string") {
+          push(`extraFragments[${i}]`, "must be a string");
+        }
+      }
+    }
+  }
+
+  // guardOptions
+  if (
+    raw.guardOptions !== undefined &&
+    (typeof raw.guardOptions !== "object" || raw.guardOptions === null || Array.isArray(raw.guardOptions))
+  ) {
+    push("guardOptions", "must be an object");
+  }
+
+  if (issues.length > 0) {
+    return { valid: false, issues };
+  }
+
+  return {
+    valid: true,
+    issues: [],
+    config: {
+      jobId: raw.jobId as string,
+      label: raw.label as string | undefined,
+      intervalMs: raw.intervalMs as number,
+      persona: raw.persona as string | undefined,
+      personaText: raw.personaText as string | undefined,
+      model: raw.model as string | undefined,
+      provider: raw.provider as LLMProvider | undefined,
+      rootDir: raw.rootDir as string | undefined,
+      tailServer: raw.tailServer as string | undefined,
+      extraFragments: raw.extraFragments as string[] | undefined,
+      guardOptions: raw.guardOptions as Record<string, unknown> | undefined,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// I/O
+// ---------------------------------------------------------------------------
+
+/** Load + validate a job config by id. Throws with line-precise errors on failure. */
+export function loadOperatorJobConfig(jobId: string): { config: OperatorJobConfig; path: string } {
+  if (!jobId || !JOB_ID_PATTERN.test(jobId)) {
+    throw new Error(
+      `Invalid jobId ${JSON.stringify(jobId)} — must match ${JOB_ID_PATTERN.source}`,
+    );
+  }
+  const filePath = operatorConfigPath(jobId);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Operator job config not found: ${filePath}`);
+  }
+  let parsed: unknown;
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to read ${filePath}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+  const result = validateOperatorJobConfig(parsed, { sourcePath: filePath });
+  if (!result.valid || !result.config) {
+    const lines = result.issues.map((i) => `  - ${i.field || "<root>"}: ${i.message}`);
+    throw new Error(
+      `Operator job config invalid: ${filePath}\n${lines.join("\n")}`,
+    );
+  }
+  return { config: result.config, path: filePath };
+}
+
+/** List all job config files in `~/.sportsclaw/operator/`. */
+export function listOperatorJobs(): Array<{ jobId: string; path: string }> {
+  const dir = operatorConfigDir();
+  if (!fs.existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      const jobId = f.slice(0, -".json".length);
+      return { jobId, path: path.join(dir, f) };
+    })
+    // Operator-controlled filenames may not match JOB_ID_PATTERN — quietly hide
+    // those rather than fail listing.
+    .filter(({ jobId }) => JOB_ID_PATTERN.test(jobId))
+    .sort((a, b) => (a.jobId < b.jobId ? -1 : a.jobId > b.jobId ? 1 : 0));
+}

--- a/test/daemon-operator.test.mjs
+++ b/test/daemon-operator.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * Daemon driver — operator-platform-aware routing tests.
+ *
+ * Tests the *pure* parts of the routing: scriptArgsFor, logPaths,
+ * platformRequiresJobId, isValidPlatform. The actual driver methods
+ * (launchctl / systemctl / schtasks) can't run in CI; those are
+ * exercised manually per the PR test plan.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  isValidPlatform,
+  platformRequiresJobId,
+  scriptArgsFor,
+  logPaths,
+} from "../dist/daemon.js";
+
+// ---------------------------------------------------------------------------
+// Platform recognition
+// ---------------------------------------------------------------------------
+
+describe("isValidPlatform", () => {
+  it("accepts the four supported platforms", () => {
+    for (const p of ["discord", "telegram", "watch", "operator"]) {
+      assert.strictEqual(isValidPlatform(p), true, p);
+    }
+  });
+
+  it("rejects anything else", () => {
+    for (const p of ["", "slack", "DISCORD", "operator-jobs", "foo"]) {
+      assert.strictEqual(isValidPlatform(p), false, p);
+    }
+  });
+});
+
+describe("platformRequiresJobId", () => {
+  it("is true only for operator", () => {
+    assert.strictEqual(platformRequiresJobId("operator"), true);
+    for (const p of ["discord", "telegram", "watch"]) {
+      assert.strictEqual(platformRequiresJobId(p), false, p);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scriptArgsFor
+// ---------------------------------------------------------------------------
+
+describe("scriptArgsFor", () => {
+  it("returns `listen <platform>` for simple chat platforms", () => {
+    assert.deepStrictEqual(scriptArgsFor("discord"), ["listen", "discord"]);
+    assert.deepStrictEqual(scriptArgsFor("telegram"), ["listen", "telegram"]);
+  });
+
+  it("returns `watch --config=<path>` for watch", () => {
+    const args = scriptArgsFor("watch");
+    assert.strictEqual(args[0], "watch");
+    assert.ok(args[1].startsWith("--config="));
+  });
+
+  it("returns `operate --job <id>` for operator", () => {
+    assert.deepStrictEqual(scriptArgsFor("operator", "tv-operator"), [
+      "operate",
+      "--job",
+      "tv-operator",
+    ]);
+  });
+
+  it("throws when operator is missing jobId", () => {
+    assert.throws(() => scriptArgsFor("operator"), /requires a jobId/);
+  });
+
+  it("throws when operator jobId has unsafe chars", () => {
+    for (const bad of ["../escape", "with spaces", "a/b"]) {
+      assert.throws(
+        () => scriptArgsFor("operator", bad),
+        /requires a jobId/,
+        `jobId=${bad}`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logPaths
+// ---------------------------------------------------------------------------
+
+describe("logPaths", () => {
+  const logsDir = join(homedir(), ".sportsclaw", "logs");
+
+  it("returns plain platform paths for simple platforms", () => {
+    const { out, err } = logPaths("discord");
+    assert.strictEqual(out, join(logsDir, "discord-out.log"));
+    assert.strictEqual(err, join(logsDir, "discord-err.log"));
+  });
+
+  it("namespaces operator paths by jobId", () => {
+    const { out, err } = logPaths("operator", "tv-operator");
+    assert.strictEqual(out, join(logsDir, "operator-tv-operator-out.log"));
+    assert.strictEqual(err, join(logsDir, "operator-tv-operator-err.log"));
+  });
+
+  it("different jobIds → different log files", () => {
+    const a = logPaths("operator", "job-a");
+    const b = logPaths("operator", "job-b");
+    assert.notStrictEqual(a.out, b.out);
+    assert.notStrictEqual(a.err, b.err);
+  });
+});

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * `sportsclaw operate` CLI — focused tests on the pure pieces and on
+ * the public helpers exported for tests.
+ *
+ * The flag parser is fully unit-testable. The persona resolver, tail-server
+ * poster, and exit-code matrix are tested with stubs — no real LLM, no
+ * real HTTP server unless we explicitly stand one up here.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import http from "node:http";
+
+import {
+  exitCodeFor,
+  FRAGMENT_ALIASES,
+  makeTailServerPoster,
+  parseFlags,
+  resolveExtraFragments,
+  resolvePersona,
+} from "../dist/operate.js";
+
+// ---------------------------------------------------------------------------
+// parseFlags
+// ---------------------------------------------------------------------------
+
+describe("operate parseFlags", () => {
+  it("parses --job <id>", () => {
+    const r = parseFlags(["--job", "tv-operator"]);
+    assert.strictEqual(r.job, "tv-operator");
+    assert.strictEqual(r.once, false);
+    assert.strictEqual(r.dryRun, false);
+  });
+
+  it("parses --job=<id>", () => {
+    const r = parseFlags(["--job=tv-operator"]);
+    assert.strictEqual(r.job, "tv-operator");
+  });
+
+  it("parses --once", () => {
+    const r = parseFlags(["--job", "j", "--once"]);
+    assert.strictEqual(r.once, true);
+  });
+
+  it("parses --dry-run", () => {
+    const r = parseFlags(["--job", "j", "--dry-run"]);
+    assert.strictEqual(r.dryRun, true);
+  });
+
+  it("parses --list and --json", () => {
+    const r = parseFlags(["--list", "--json"]);
+    assert.strictEqual(r.list, true);
+    assert.strictEqual(r.json, true);
+  });
+
+  it("parses --validate <id>", () => {
+    const r = parseFlags(["--validate", "tv-operator"]);
+    assert.strictEqual(r.validate, "tv-operator");
+  });
+
+  it("captures unknown flags for caller to reject", () => {
+    const r = parseFlags(["--bogus", "--job", "x"]);
+    assert.deepStrictEqual(r.unknown, ["--bogus"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveExtraFragments
+// ---------------------------------------------------------------------------
+
+describe("resolveExtraFragments", () => {
+  it("returns [] for empty/undefined input", () => {
+    assert.deepStrictEqual(resolveExtraFragments(undefined), []);
+    assert.deepStrictEqual(resolveExtraFragments([]), []);
+  });
+
+  it("resolves 'broadcast-directive' to the matching exported fragment", () => {
+    const out = resolveExtraFragments(["broadcast-directive"]);
+    assert.strictEqual(out.length, 1);
+    assert.match(out[0], /on-air/i);
+  });
+
+  it("resolves 'broadcast' as an alias for broadcast-directive", () => {
+    const out = resolveExtraFragments(["broadcast"]);
+    assert.match(out[0], /on-air/i);
+  });
+
+  it("passes through unknown names as inline text", () => {
+    const out = resolveExtraFragments(["my-custom-policy", "broadcast"]);
+    assert.strictEqual(out[0], "my-custom-policy");
+    assert.match(out[1], /on-air/i);
+  });
+
+  it("FRAGMENT_ALIASES surface is non-empty", () => {
+    assert.ok(Object.keys(FRAGMENT_ALIASES).length >= 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exitCodeFor
+// ---------------------------------------------------------------------------
+
+describe("exitCodeFor", () => {
+  const base = { jobId: "x", tickId: "t", timestamp: "2026-01-01T00:00:00.000Z" };
+  it("0 for published", () => {
+    assert.strictEqual(exitCodeFor({ ...base, type: "tick_published" }), 0);
+  });
+  it("0 for silent", () => {
+    assert.strictEqual(exitCodeFor({ ...base, type: "tick_silent" }), 0);
+  });
+  it("1 for skipped", () => {
+    assert.strictEqual(exitCodeFor({ ...base, type: "tick_skipped" }), 1);
+  });
+  it("2 for failed", () => {
+    assert.strictEqual(exitCodeFor({ ...base, type: "tick_failed" }), 2);
+  });
+  it("2 for any unknown variant", () => {
+    assert.strictEqual(exitCodeFor({ ...base, type: "tick_started" }), 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePersona — uses inline text wins; MCP fallback; error path
+// ---------------------------------------------------------------------------
+
+describe("resolvePersona", () => {
+  /** Make a minimal mock McpManager surface the resolver needs. */
+  function makeMockMcp(opts = {}) {
+    return {
+      getMachinaServerName: () => opts.serverName,
+      callToolDirect: async (server, tool, args) => {
+        if (opts.callToolDirect) return opts.callToolDirect(server, tool, args);
+        return { isError: false, content: opts.content ?? "" };
+      },
+    };
+  }
+
+  it("returns personaText verbatim when set", async () => {
+    const cfg = {
+      jobId: "j",
+      intervalMs: 60_000,
+      personaText: "You are SportsClaw.",
+    };
+    const text = await resolvePersona(cfg, makeMockMcp());
+    assert.strictEqual(text, "You are SportsClaw.");
+  });
+
+  it("throws when neither personaText nor persona is provided", async () => {
+    await assert.rejects(
+      resolvePersona({ jobId: "j", intervalMs: 60_000 }, makeMockMcp()),
+      /neither personaText nor persona/,
+    );
+  });
+
+  it("throws when persona is set but no Machina MCP server is configured", async () => {
+    await assert.rejects(
+      resolvePersona(
+        { jobId: "j", intervalMs: 60_000, persona: "tv-host" },
+        makeMockMcp({ serverName: undefined }),
+      ),
+      /requires an MCP server/,
+    );
+  });
+
+  it("calls MCP get_prompt_by_name when persona is set + server present", async () => {
+    let receivedArgs;
+    const mcp = makeMockMcp({
+      serverName: "machina",
+      callToolDirect: async (_s, tool, args) => {
+        receivedArgs = { tool, args };
+        return { isError: false, content: "Resolved persona body." };
+      },
+    });
+    const text = await resolvePersona(
+      { jobId: "j", intervalMs: 60_000, persona: "tv-host" },
+      mcp,
+    );
+    assert.strictEqual(receivedArgs.tool, "get_prompt_by_name");
+    assert.deepStrictEqual(receivedArgs.args, { name: "tv-host" });
+    assert.strictEqual(text, "Resolved persona body.");
+  });
+
+  it("unwraps a JSON-shaped MCP response if present", async () => {
+    const mcp = makeMockMcp({
+      serverName: "machina",
+      callToolDirect: async () => ({
+        isError: false,
+        content: JSON.stringify({ content: "wrapped persona" }),
+      }),
+    });
+    const text = await resolvePersona(
+      { jobId: "j", intervalMs: 60_000, persona: "tv-host" },
+      mcp,
+    );
+    assert.strictEqual(text, "wrapped persona");
+  });
+
+  it("surfaces MCP errors as resolver errors", async () => {
+    const mcp = makeMockMcp({
+      serverName: "machina",
+      callToolDirect: async () => ({ isError: true, content: "prompt not found" }),
+    });
+    await assert.rejects(
+      resolvePersona(
+        { jobId: "j", intervalMs: 60_000, persona: "tv-host" },
+        mcp,
+      ),
+      /prompt not found/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeTailServerPoster — non-fatal HTTP delivery
+// ---------------------------------------------------------------------------
+
+describe("makeTailServerPoster", () => {
+  let server;
+  let received;
+  let baseUrl;
+
+  beforeEach(async () => {
+    received = [];
+    server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        try {
+          received.push({ url: req.url, body: JSON.parse(body) });
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end("{}");
+        } catch {
+          res.writeHead(500);
+          res.end("bad json");
+        }
+      });
+    });
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const event = {
+    type: "tick_published",
+    jobId: "tv-operator",
+    tickId: "tick_001",
+    text: "Argentina vs Brazil opens.",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("POSTs to <tailServer>/ingest with structured envelope", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator");
+    post(event);
+    await new Promise((r) => setTimeout(r, 50));
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].url, "/ingest");
+    assert.strictEqual(received[0].body.kind, "tv-telemetry-event");
+    assert.strictEqual(received[0].body.source, "sportsclaw-operate");
+    assert.strictEqual(received[0].body.jobId, "tv-operator");
+    assert.deepStrictEqual(received[0].body.event, event);
+  });
+
+  it("normalises trailing slash on the server URL", async () => {
+    const post = makeTailServerPoster(`${baseUrl}///`, "tv-operator");
+    post(event);
+    await new Promise((r) => setTimeout(r, 50));
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].url, "/ingest");
+  });
+
+  it("does NOT throw when the server is unreachable (network error)", async () => {
+    const post = makeTailServerPoster("http://127.0.0.1:1", "tv-operator");
+    // Should not throw synchronously...
+    post(event);
+    // ...nor should it surface as an unhandled rejection (the poster
+    // catches and logs to stderr). Give it a tick for the fetch to fail.
+    await new Promise((r) => setTimeout(r, 50));
+    // If we got here without a crash, the contract holds.
+    assert.ok(true);
+  });
+
+  it("does NOT throw when the server returns 5xx", async () => {
+    // Replace the handler to return 503
+    await new Promise((resolve) => server.close(resolve));
+    server = http.createServer((_req, res) => {
+      res.writeHead(503);
+      res.end();
+    });
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+    const post = makeTailServerPoster(`http://127.0.0.1:${port}`, "tv-operator");
+    post(event);
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(true);
+  });
+});

--- a/test/operator-config.test.mjs
+++ b/test/operator-config.test.mjs
@@ -1,0 +1,211 @@
+/**
+ * Operator job config — schema validation + loader tests.
+ *
+ * The validator is pure (no I/O) so most tests pass plain objects in.
+ * The loader needs a temp config dir, which we redirect via the path
+ * helpers exported alongside the loader.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  validateOperatorJobConfig,
+} from "../dist/operator-config.js";
+
+// ---------------------------------------------------------------------------
+// validateOperatorJobConfig — required fields
+// ---------------------------------------------------------------------------
+
+describe("validateOperatorJobConfig — required fields", () => {
+  it("rejects a non-object input", () => {
+    const r = validateOperatorJobConfig("not an object");
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.length > 0);
+  });
+
+  it("rejects an array at the top level", () => {
+    const r = validateOperatorJobConfig([]);
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("rejects a config with no jobId", () => {
+    const r = validateOperatorJobConfig({
+      intervalMs: 60_000,
+      personaText: "...",
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "jobId"));
+  });
+
+  it("rejects a config with no intervalMs", () => {
+    const r = validateOperatorJobConfig({
+      jobId: "tv-operator",
+      personaText: "...",
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "intervalMs"));
+  });
+
+  it("rejects intervalMs <= 0", () => {
+    for (const bad of [0, -1, -60_000]) {
+      const r = validateOperatorJobConfig({
+        jobId: "tv-operator",
+        intervalMs: bad,
+        personaText: "...",
+      });
+      assert.strictEqual(r.valid, false, `intervalMs=${bad}`);
+      assert.ok(r.issues.find((i) => i.field === "intervalMs"));
+    }
+  });
+
+  it("rejects non-numeric intervalMs", () => {
+    const r = validateOperatorJobConfig({
+      jobId: "x",
+      intervalMs: "60000",
+      personaText: "...",
+    });
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("rejects a config with neither persona nor personaText", () => {
+    const r = validateOperatorJobConfig({
+      jobId: "x",
+      intervalMs: 60_000,
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "persona|personaText"));
+  });
+
+  it("rejects a config with BOTH persona and personaText", () => {
+    const r = validateOperatorJobConfig({
+      jobId: "x",
+      intervalMs: 60_000,
+      persona: "tv-host",
+      personaText: "You are...",
+    });
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("rejects a jobId that does not match the filename basename", () => {
+    const r = validateOperatorJobConfig(
+      {
+        jobId: "different-id",
+        intervalMs: 60_000,
+        personaText: "...",
+      },
+      { sourcePath: "/tmp/foo/tv-operator.json" },
+    );
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => /must match filename/.test(i.message)));
+  });
+
+  it("rejects a jobId with path-separators or special chars", () => {
+    for (const bad of ["../escape", "a/b", "with spaces", "you+me"]) {
+      const r = validateOperatorJobConfig({
+        jobId: bad,
+        intervalMs: 60_000,
+        personaText: "...",
+      });
+      assert.strictEqual(r.valid, false, `jobId=${bad}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateOperatorJobConfig — optional fields & type checks
+// ---------------------------------------------------------------------------
+
+describe("validateOperatorJobConfig — optional fields", () => {
+  const base = {
+    jobId: "ok-id",
+    intervalMs: 60_000,
+    personaText: "You are an autonomous operator.",
+  };
+
+  it("accepts a minimal valid config", () => {
+    const r = validateOperatorJobConfig(base);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.config.jobId, "ok-id");
+    assert.strictEqual(r.config.intervalMs, 60_000);
+  });
+
+  it("rejects an unknown provider", () => {
+    const r = validateOperatorJobConfig({ ...base, provider: "mystery-corp" });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "provider"));
+  });
+
+  it("accepts known providers", () => {
+    for (const provider of ["anthropic", "openai", "google"]) {
+      const r = validateOperatorJobConfig({ ...base, provider });
+      assert.strictEqual(r.valid, true, `provider=${provider}`);
+    }
+  });
+
+  it("rejects a non-string label", () => {
+    const r = validateOperatorJobConfig({ ...base, label: 42 });
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("rejects a non-array extraFragments", () => {
+    const r = validateOperatorJobConfig({ ...base, extraFragments: "broadcast" });
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("rejects an extraFragments entry that is not a string", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      extraFragments: ["ok", 42],
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "extraFragments[1]"));
+  });
+
+  it("rejects a tailServer that isn't a URL", () => {
+    const r = validateOperatorJobConfig({ ...base, tailServer: "not a url" });
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("rejects a tailServer with file:// scheme", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      tailServer: "file:///etc/passwd",
+    });
+    assert.strictEqual(r.valid, false);
+  });
+
+  it("accepts a tailServer over http(s)", () => {
+    for (const url of ["http://localhost:8090", "https://relay.example.com/sink"]) {
+      const r = validateOperatorJobConfig({ ...base, tailServer: url });
+      assert.strictEqual(r.valid, true, `url=${url}`);
+    }
+  });
+
+  it("rejects guardOptions that is not an object", () => {
+    for (const bad of [["a"], 42, "string", null]) {
+      const r = validateOperatorJobConfig({ ...base, guardOptions: bad });
+      assert.strictEqual(r.valid, false, `guardOptions=${JSON.stringify(bad)}`);
+    }
+  });
+
+  it("accepts an empty guardOptions object", () => {
+    const r = validateOperatorJobConfig({ ...base, guardOptions: {} });
+    assert.strictEqual(r.valid, true);
+  });
+
+  it("collects multiple errors at once (line-precise)", () => {
+    const r = validateOperatorJobConfig({
+      intervalMs: -1,
+      label: 42,
+      provider: "wrong",
+    });
+    assert.strictEqual(r.valid, false);
+    const fields = new Set(r.issues.map((i) => i.field));
+    assert.ok(fields.has("jobId"));
+    assert.ok(fields.has("intervalMs"));
+    assert.ok(fields.has("label"));
+    assert.ok(fields.has("provider"));
+    assert.ok(fields.has("persona|personaText"));
+  });
+});


### PR DESCRIPTION
## Summary

Adds the CLI surface that drives `createOperatorDaemon()` (from #41) into the same supervisor / foreground pattern as `listen` and `watch`. Two forms, one shared implementation.

## Foreground form

```
sportsclaw operate --job <jobId>             run forever, ticking
sportsclaw operate --job <jobId> --once      one tick, exit by status
sportsclaw operate --job <jobId> --dry-run   resolve + print prompt, no LLM
sportsclaw operate --list [--json]           list configured jobs
sportsclaw operate --validate <jobId>        load + validate; non-zero on errors
```

`--once` exit codes:

| code | outcome |
|---|---|
| 0 | published (LLM produced output) |
| 0 | silent (LLM voted `[SILENT]`) |
| 1 | skipped (wake gate denied) |
| 2 | failed (LLM / tool error) |

## Supervised form

Extends `DaemonPlatform` with `"operator"` so the existing supervisor handles it — no new daemon driver, no new pid/log code.

```
sportsclaw start    operator <jobId>
sportsclaw stop     operator <jobId>
sportsclaw logs     operator <jobId> [--lines N]
sportsclaw restart  operator <jobId>
sportsclaw status                            # lists ALL daemons
```

- launchd label: `gg.sportsclaw.operator.<jobId>`
- systemd unit:  `sportsclaw-operator-<jobId>.service`
- Windows task:  `sportsclaw-operator-<jobId>`
- Log files:     `~/.sportsclaw/logs/operator-<jobId>-{out,err}.log`

`status` enumerates every installed service and surfaces operator jobs alongside the simple platforms. Existing `discord` / `telegram` / `watch` flows keep their zero-arg signature; passing a stray jobId to a non-operator platform errors cleanly.

## Job config schema

`~/.sportsclaw/operator/<jobId>.json`:

```json
{
  \"jobId\": \"tv-operator\",                     // required, matches filename basename
  \"label\": \"Machina Sports TV — operator\",   // optional
  \"intervalMs\": 300000,                         // required, > 0
  \"personaText\": \"You are SportsClaw...\",    // EITHER inline text...
  \"persona\": \"tv-host\",                       // ...OR MCP get_prompt_by_name
  \"model\": \"gemini-2.5-flash\",                // optional, default = sportsclaw config
  \"provider\": \"google\",                       // optional
  \"rootDir\": \"~/.sportsclaw/operator/tv-operator\",  // optional
  \"tailServer\": \"http://localhost:8090\",     // optional — POST every TickEvent
  \"extraFragments\": [\"broadcast-directive\"], // optional, names match prompts.ts exports
  \"guardOptions\": {}                            // optional ToolGuardOptions overrides
}
```

See `examples/operator-jobs/tv-operator.example.json` and `examples/operator-jobs/markets-monitor.example.json`.

## Tool source = engine ToolRegistry

`buildOperatorTools()` instantiates its own `ToolRegistry` + `McpManager` using the same `loadAllSchemas()` + `McpManager.connectAll()` the engine uses. Every operator job sees what \`sportsclaw chat\` sees on the same install. No per-job tool filter in v1. **No engine.ts changes.**

## Worked example — dry-run

```
$ sportsclaw operate --dry-run --job markets-monitor
=== Resolved system prompt for \"markets-monitor\" ===

You are an autonomous markets analyst. Every tick, inspect the major
event contracts on Kalshi and Polymarket for sports we cover. Surface
a short structured report ONLY when you detect a meaningful edge or
a notable line move; otherwise return [SILENT].

---

# Autonomous mode

You are running on a scheduler, not in a chat. There is no human present.
...

---

# Tool use discipline
...

---

# The [SILENT] sentinel
...

=== Tools (292) ===
  - betting_convert_odds
  - betting_devig
  ...
  - mcp__sportsclaw-machina__connector_search

provider: anthropic
model:    claude-sonnet-4-6
rootDir:  /Users/.../operator/markets-monitor
```

## Worked example — supervised lifecycle

```
$ sportsclaw start operator tv-operator
operator tv-operator daemon started via launchd.
  Status: sportsclaw status
  Logs:   sportsclaw logs operator tv-operator
  Stop:   sportsclaw stop operator tv-operator

$ sportsclaw status
Daemon Status:

  ● operator [tv-operator]              online (PID 64218)

  Logs: ~/.sportsclaw/logs

$ sportsclaw logs operator tv-operator
=== ~/.sportsclaw/logs/operator-tv-operator-out.log ===
...

$ sportsclaw stop operator tv-operator
operator tv-operator daemon stopped.
```

## Tests

| file | new tests | what |
|---|---:|---|
| `test/operator-config.test.mjs` | 22 | required fields; intervalMs > 0; persona/personaText exclusivity; filename basename match; provider enum; tailServer URL; extraFragments types; guardOptions shape; multi-error collection |
| `test/operate.test.mjs` | 27 | parseFlags variants; resolveExtraFragments alias resolution; exitCodeFor matrix; resolvePersona inline-wins / MCP-success / MCP-error / JSON-unwrap / missing-server; makeTailServerPoster envelope shape + trailing-slash + unreachable-host + 5xx non-fatal |
| `test/daemon-operator.test.mjs` | 11 | platform recognition; jobId requirement; scriptArgsFor routing; logPaths jobId namespacing |

**Full suite: 381 pass** (was 321, +60 new). \`tsc\` clean.

## Test plan

- [x] \`npm run build\`
- [x] \`npm run test:operator-config\`
- [x] \`npm run test:operate\`
- [x] \`npm run test:daemon-operator\`
- [x] full suite (\`node --test test/*.test.mjs\`)
- [x] \`sportsclaw operate --list\` against empty + populated config dir
- [x] \`sportsclaw operate --validate\` on valid + invalid file
- [x] \`sportsclaw operate --dry-run\` resolves persona + 292 tools + composed system prompt, no LLM call, no rootDir side-effects
- [x] \`sportsclaw start operator <jobId>\` rejects missing jobId
- [x] \`sportsclaw start discord extra-arg\` rejects stray positional
- [x] All pre-existing daemon flows untouched
- [ ] Manual: \`sportsclaw start operator <id>\` against a real model with API keys configured — see operator-jobs/markets-monitor.example.json
- [ ] CI green

## Out of scope (deferred follow-ups)

- Engine.ts changes; chat REPL is untouched
- Per-job tool filtering (v1 inherits the engine registry as-is)
- Named wake gates (config schema accepts them in a follow-up)
- Multi-job batch \`start operator --all\`
- Approval / Slack-review wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)