### PR TITLE
feat: operate driver — structured packet protocol + real-world fixes

### DIFF
--- a/src/operate.ts
+++ b/src/operate.ts
@@ -30,6 +30,7 @@ import { google } from "@ai-sdk/google";
 import {
   createOperatorDaemon,
   type TickEvent,
+  type ToolCallEvent,
 } from "./operator-daemon.js";
 import {
   listOperatorJobs,
@@ -42,7 +43,7 @@ import {
 import { ToolRegistry, type ToolCallInput } from "./tools.js";
 import { McpManager } from "./mcp.js";
 import { loadAllSchemas } from "./schema.js";
-import { resolveConfig } from "./config.js";
+import { resolveConfig, applyConfigToEnv } from "./config.js";
 import {
   BROADCAST_DIRECTIVE_FRAGMENT,
   buildSystemPrompt,
@@ -377,16 +378,24 @@ async function resolveJobInputs(
   opts: { ensureRootDir?: boolean } = {},
 ): Promise<ResolvedDaemonInputs> {
   const sportsclawCfg = resolveConfig();
+  applyConfigToEnv();
   const provider = cfg.provider ?? sportsclawCfg.provider ?? "google";
   const modelId =
     cfg.model ?? sportsclawCfg.model ?? defaultModelFor(provider);
-  const rootDir = cfg.rootDir ?? defaultRootDir(cfg.jobId);
+  const rawRootDir = cfg.rootDir ?? defaultRootDir(cfg.jobId);
+  const rootDir = expandTilde(rawRootDir);
   if (opts.ensureRootDir) {
     fs.mkdirSync(rootDir, { recursive: true });
   }
   const personaText = await resolvePersona(cfg, mcpManager);
   const extraFragments = resolveExtraFragments(cfg.extraFragments);
   return { provider, modelId, rootDir, personaText, extraFragments };
+}
+
+function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return path.join(homedir(), p.slice(2));
+  return p;
 }
 
 function defaultModelFor(provider: LLMProvider): string {
@@ -401,30 +410,255 @@ function defaultModelFor(provider: LLMProvider): string {
 }
 
 // ---------------------------------------------------------------------------
+// Structured packet — the persona may end its narrative with a JSON packet
+// delimited by <<<DATA>>>...<<<END>>>. The packet carries arrays the overlay
+// renders as widgets (prediction_markets, fixtures, news). We strip the
+// packet from the broadcast text, parse the JSON, and post each array as
+// its own telemetry event.
+// ---------------------------------------------------------------------------
+
+interface MarketItem {
+  question?: string;
+  prob?: number | string;
+  trend?: string;
+  source?: string;
+}
+interface FixtureItem {
+  home?: string;
+  away?: string;
+  odds?: string;
+  kickoff?: string;
+  source?: string;
+}
+interface NewsItem {
+  headline?: string;
+  source?: string;
+  ts?: string;
+}
+interface StructuredPacket {
+  prediction_markets?: MarketItem[];
+  fixtures?: FixtureItem[];
+  news?: NewsItem[];
+}
+interface ParsedBroadcast {
+  narrative: string;
+  data: StructuredPacket | null;
+  parseError?: string;
+}
+
+const PACKET_RE = /<<<DATA>>>\s*([\s\S]*?)\s*<<<END>>>/;
+
+export function parseStructuredBroadcast(text: string): ParsedBroadcast {
+  const match = text.match(PACKET_RE);
+  if (!match) return { narrative: text.trim(), data: null };
+  const raw = match[1].trim();
+  let data: StructuredPacket | null = null;
+  let parseError: string | undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      data = parsed as StructuredPacket;
+    }
+  } catch (err) {
+    parseError = err instanceof Error ? err.message : String(err);
+  }
+  const narrative = text.replace(PACKET_RE, "").trim();
+  return { narrative, data, parseError };
+}
+
+// ---------------------------------------------------------------------------
 // Tail-server poster — non-fatal HTTP POST per TickEvent
 // ---------------------------------------------------------------------------
+
+/**
+ * Map a TickEvent type to the overlay's kind vocabulary (see
+ * machina-sports-tv/agent-templates/.../docs/telemetry-event-shape.md).
+ * Returns kind + a human-readable message + an optional model name.
+ */
+function mapTickEventToTelemetry(
+  evt: TickEvent,
+  jobId: string,
+  modelId: string | undefined,
+  intervalMs: number | undefined,
+): {
+  kind: string;
+  message: string;
+  level: "info" | "warn" | "error";
+  model?: string;
+  prompt_excerpt?: string;
+  phase?: string;
+  intervalMs?: number;
+} {
+  switch (evt.type) {
+    case "tick_started":
+      // "tick" kind drives the overlay's countdown / upcoming strip — it
+      // carries the schedule interval so the overlay can sync its timer.
+      return {
+        kind: "tick",
+        message: `tick ${evt.tickId.slice(0, 12)}… started · job ${jobId}`,
+        level: "info",
+        phase: "started",
+        intervalMs: intervalMs,
+      };
+    case "tick_published":
+      // "broadcast" kind tells the overlay to take over the main renderer
+      // slot AND populate the spotlight + "last covered" tease.
+      return {
+        kind: "broadcast",
+        message: `${evt.toolCalls ?? 0} tool calls · ${(evt.text ?? "").length} chars`,
+        level: "info",
+        model: modelId,
+        prompt_excerpt: evt.text,
+      };
+    case "tick_silent":
+      return {
+        kind: "reasoning",
+        message: `tick ${evt.tickId.slice(0, 12)}… silent · no broadcast`,
+        level: "info",
+      };
+    case "tick_failed":
+      return {
+        kind: "error",
+        message: `tick failed: ${evt.reason ?? "unknown"}`,
+        level: "error",
+      };
+    case "tick_skipped":
+      return {
+        kind: "gate",
+        message: `tick skipped · ${evt.reason ?? "wake gate denied"}`,
+        level: "warn",
+      };
+    default:
+      return { kind: "reasoning", message: String(evt.type), level: "info" };
+  }
+}
+
+async function postTelemetry(url: string, body: Record<string, unknown>): Promise<void> {
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error(
+      `[operate] tail-server POST failed (${url}): ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
 
 function makeTailServerPoster(
   tailServer: string,
   jobId: string,
-): (evt: TickEvent) => void {
+  modelId?: string,
+  intervalMs?: number,
+): (evt: TickEvent) => Promise<void> {
   const url = tailServer.replace(/\/+$/, "") + "/ingest";
-  return (evt: TickEvent) => {
+  const wfName = `sportsclaw-operate:${jobId}`;
+  return async (evt: TickEvent) => {
+    // For tick_published events, strip the structured packet from the
+    // narrative before posting, then fan out the packet's arrays as their
+    // own kind-specific events (prediction_markets / fixtures / news).
+    let textOverride: string | undefined;
+    let packet: StructuredPacket | null = null;
+    if (evt.type === "tick_published" && evt.text) {
+      const parsed = parseStructuredBroadcast(evt.text);
+      textOverride = parsed.narrative;
+      packet = parsed.data;
+      if (parsed.parseError) {
+        console.error(`[operate] structured packet parse error: ${parsed.parseError}`);
+      }
+    }
+
+    const eventForMap: TickEvent = textOverride !== undefined
+      ? { ...evt, text: textOverride }
+      : evt;
+    const mapped = mapTickEventToTelemetry(eventForMap, jobId, modelId, intervalMs);
+    try {
+      await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ts: evt.timestamp,
+          kind: mapped.kind,
+          message: mapped.message,
+          level: mapped.level,
+          model: mapped.model ?? "",
+          prompt_excerpt: mapped.prompt_excerpt ?? "",
+          phase: mapped.phase ?? "",
+          intervalMs: mapped.intervalMs ?? 0,
+          workflow_name: wfName,
+        }),
+      });
+    } catch (err) {
+      console.error(
+        `[operate] tail-server POST failed (${url}): ${err instanceof Error ? err.message : err}`,
+      );
+    }
+
+    // Fan out the structured packet — each array becomes a widget event.
+    if (packet) {
+      const ts = evt.timestamp;
+      if (Array.isArray(packet.prediction_markets) && packet.prediction_markets.length > 0) {
+        await postTelemetry(url, {
+          ts,
+          kind: "prediction_markets",
+          message: `${packet.prediction_markets.length} markets live`,
+          level: "info",
+          workflow_name: wfName,
+          items: packet.prediction_markets,
+        });
+      }
+      if (Array.isArray(packet.fixtures) && packet.fixtures.length > 0) {
+        await postTelemetry(url, {
+          ts,
+          kind: "fixtures",
+          message: `${packet.fixtures.length} fixtures`,
+          level: "info",
+          workflow_name: wfName,
+          items: packet.fixtures,
+        });
+      }
+      if (Array.isArray(packet.news) && packet.news.length > 0) {
+        await postTelemetry(url, {
+          ts,
+          kind: "news",
+          message: `${packet.news.length} headlines`,
+          level: "info",
+          workflow_name: wfName,
+          items: packet.news,
+        });
+      }
+    }
+  };
+}
+
+/**
+ * Map ToolCallEvent → tv-telemetry-event. Each tool call shows up in the
+ * reasoning trail as an "ingest" line with the tool name + duration so the
+ * overlay surfaces which tools the LLM actually picked.
+ */
+function makeToolCallPoster(
+  tailServer: string,
+  jobId: string,
+): (evt: ToolCallEvent) => void {
+  const url = tailServer.replace(/\/+$/, "") + "/ingest";
+  return (evt: ToolCallEvent) => {
+    const level: "info" | "warn" | "error" =
+      evt.outcome === "ok" ? "info" : evt.outcome === "blocked" ? "warn" : "error";
+    const msg = `${evt.toolName} · ${evt.outcome} · ${evt.durationMs}ms` +
+      (evt.reason ? ` · ${evt.reason}` : "");
     fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        kind: "tv-telemetry-event",
-        source: "sportsclaw-operate",
-        jobId,
-        event: evt,
-        timestamp: new Date().toISOString(),
+        ts: evt.timestamp,
+        kind: "ingest",
+        message: msg,
+        level,
+        workflow_name: `sportsclaw-operate:${jobId}`,
       }),
-    }).catch((err) => {
-      console.error(
-        `[operate] tail-server POST failed (${url}): ${err instanceof Error ? err.message : err}`,
-      );
-    });
+    }).catch(() => { /* non-fatal */ });
   };
 }
 
@@ -478,10 +712,20 @@ async function runOnce(jobId: string): Promise<void> {
       rootDir: inputs.rootDir,
       extraFragments: inputs.extraFragments,
       guardOptions: cfg.guardOptions,
-      onTickEvent: cfg.tailServer ? makeTailServerPoster(cfg.tailServer, cfg.jobId) : undefined,
+      onTickEvent: cfg.tailServer
+        ? makeTailServerPoster(cfg.tailServer, cfg.jobId, inputs.modelId, cfg.intervalMs)
+        : undefined,
+      onToolCall: cfg.tailServer
+        ? makeToolCallPoster(cfg.tailServer, cfg.jobId)
+        : undefined,
     });
     const event = await daemon.tickOnce();
     console.log(JSON.stringify(event, null, 2));
+    // Bug #12 drain: onTickEvent posters are fire-and-forget — give them a
+    // short window to flush before process.exit kills any pending fetches.
+    if (cfg.tailServer) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+    }
     process.exit(exitCodeFor(event));
   } finally {
     await tools.mcpManager.disconnectAll().catch(() => {});
@@ -522,8 +766,11 @@ async function runForeground(jobId: string): Promise<void> {
     extraFragments: inputs.extraFragments,
     guardOptions: cfg.guardOptions,
     onTickEvent: cfg.tailServer
-      ? makeTailServerPoster(cfg.tailServer, cfg.jobId)
+      ? makeTailServerPoster(cfg.tailServer, cfg.jobId, inputs.modelId, cfg.intervalMs)
       : (evt) => console.log(JSON.stringify(evt)),
+    onToolCall: cfg.tailServer
+      ? makeToolCallPoster(cfg.tailServer, cfg.jobId)
+      : undefined,
   });
 
   let shuttingDown = false;

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -36,6 +36,7 @@
 import path from "node:path";
 import {
   generateText,
+  stepCountIs,
   type LanguageModel,
   type ToolSet,
   type Tool,
@@ -61,6 +62,19 @@ import {
 // ---------------------------------------------------------------------------
 
 export type TickStatus = "silent" | "published" | "failed" | "skipped";
+
+export interface ToolCallEvent {
+  jobId: string;
+  tickId: string;
+  toolName: string;
+  /** ms from beforeCall to execute resolution */
+  durationMs: number;
+  /** "ok" — tool ran successfully, "error" — tool threw, "blocked" — guardrail blocked it */
+  outcome: "ok" | "error" | "blocked";
+  /** Reason string when outcome is "blocked" or "error". */
+  reason?: string;
+  timestamp: string;
+}
 
 export interface TickEvent {
   type:
@@ -103,6 +117,9 @@ export interface OperatorDaemonConfig {
   tools?: ToolSet;
   /** Max output tokens for the tick. Default 2048. */
   maxOutputTokens?: number;
+  /** Maximum LLM steps per tick. Default 8. Allows the model to call tools
+   *  and then produce a final synthesis text within one tick. */
+  maxSteps?: number;
   /** Append additional fragments to the system prompt (project-specific guides, etc.). */
   extraFragments?: string[];
 
@@ -133,6 +150,8 @@ export interface OperatorDaemonConfig {
   onTickEvent?: (event: TickEvent) => void;
   /** Heartbeat event hook — surfaces cron_fired / cron_skipped / etc. */
   onHeartbeatEvent?: (event: HeartbeatEvent) => void;
+  /** Per-tool-call hook — fires once per tool execution with timing + result. */
+  onToolCall?: (event: ToolCallEvent) => void;
 
   /** Inject a HeartbeatService (tests). Default: a fresh instance. */
   heartbeat?: HeartbeatService;
@@ -172,6 +191,7 @@ const DEFAULT_TICK_PROMPT = [
 ].join("\n");
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+const DEFAULT_MAX_STEPS = 16;
 const DEFAULT_RECENT_BRIEF_LIMIT = 1;
 
 // ---------------------------------------------------------------------------
@@ -248,7 +268,13 @@ export function createOperatorDaemon(
     // 4. Wrap tools with the guardrail.
     const guard = new ToolGuardController(cfg.guardOptions);
     const counts = { calls: 0, warnings: 0, blocks: 0 };
-    const wrappedTools = wrapTools(cfg.tools, guard, counts);
+    const toolCallSink = (event: ToolCallEvent): void => {
+      try { cfg.onToolCall?.(event); } catch { /* swallow */ }
+    };
+    const wrappedTools = wrapTools(
+      cfg.tools, guard, counts,
+      { jobId: cfg.jobId, tickId, onToolCall: toolCallSink },
+    );
 
     const tickPrompt = tickPromptTemplate
       .replace("{tickId}", tickId)
@@ -264,6 +290,11 @@ export function createOperatorDaemon(
         prompt: tickPrompt,
         ...(wrappedTools ? { tools: wrappedTools } : {}),
         maxOutputTokens: cfg.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+        // Allow the model multiple steps so it can call tools and THEN
+        // produce a final synthesis text. Without stopWhen, generateText
+        // takes a single step and ends with empty text whenever the
+        // model chose to call tools first.
+        stopWhen: stepCountIs(cfg.maxSteps ?? DEFAULT_MAX_STEPS),
       });
       text = (result.text ?? "").trim();
     } catch (err) {
@@ -421,15 +452,22 @@ interface TickCounts {
  * warn, or block. Returns undefined (so generateText omits the tools field)
  * when no tools were provided.
  */
+interface ToolCallCtx {
+  jobId: string;
+  tickId: string;
+  onToolCall: (event: ToolCallEvent) => void;
+}
+
 function wrapTools(
   tools: ToolSet | undefined,
   guard: ToolGuardController,
   counts: TickCounts,
+  toolCallCtx: ToolCallCtx,
 ): ToolSet | undefined {
   if (!tools) return undefined;
   const wrapped: ToolSet = {};
   for (const [name, def] of Object.entries(tools)) {
-    wrapped[name] = wrapOneTool(name, def, guard, counts);
+    wrapped[name] = wrapOneTool(name, def, guard, counts, toolCallCtx);
   }
   return wrapped;
 }
@@ -439,14 +477,29 @@ function wrapOneTool(
   def: Tool,
   guard: ToolGuardController,
   counts: TickCounts,
+  toolCallCtx: ToolCallCtx,
 ): Tool {
   const original = (def as { execute?: Tool["execute"] }).execute;
   if (!original) return def; // declarative-only tools (no runtime execute) — pass through
 
+  const emit = (outcome: "ok" | "error" | "blocked", startedAt: number, reason?: string): void => {
+    toolCallCtx.onToolCall({
+      jobId: toolCallCtx.jobId,
+      tickId: toolCallCtx.tickId,
+      toolName: name,
+      durationMs: Date.now() - startedAt,
+      outcome,
+      reason,
+      timestamp: new Date().toISOString(),
+    });
+  };
+
   const wrappedExecute: NonNullable<Tool["execute"]> = async (args, ctx) => {
+    const startedAt = Date.now();
     const decision = guard.beforeCall(name, args);
     if (decision.action === "block") {
       counts.blocks++;
+      emit("blocked", startedAt, decision.message);
       return decision.syntheticResult as unknown;
     }
     if (decision.action === "warn") counts.warnings++;
@@ -456,6 +509,7 @@ function wrapOneTool(
       result = await original(args, ctx);
     } catch (err) {
       guard.afterCall(name, args, false);
+      emit("error", startedAt, err instanceof Error ? err.message : String(err));
       throw err;
     }
     // Compute the digest defensively: a successful tool returning a
@@ -469,6 +523,7 @@ function wrapOneTool(
       digest = undefined;
     }
     guard.afterCall(name, args, true, digest);
+    emit("ok", startedAt);
     return result;
   };
 

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -16,6 +16,7 @@ import {
   FRAGMENT_ALIASES,
   makeTailServerPoster,
   parseFlags,
+  parseStructuredBroadcast,
   resolveExtraFragments,
   resolvePersona,
 } from "../dist/operate.js";
@@ -244,7 +245,7 @@ describe("makeTailServerPoster", () => {
     await new Promise((resolve) => server.close(resolve));
   });
 
-  const event = {
+  const baseEvent = {
     type: "tick_published",
     jobId: "tv-operator",
     tickId: "tick_001",
@@ -252,39 +253,113 @@ describe("makeTailServerPoster", () => {
     timestamp: "2026-01-01T00:00:00.000Z",
   };
 
-  it("POSTs to <tailServer>/ingest with structured envelope", async () => {
-    const post = makeTailServerPoster(baseUrl, "tv-operator");
-    post(event);
-    await new Promise((r) => setTimeout(r, 50));
+  it("POSTs to <tailServer>/ingest with a flat tv-telemetry-event shape", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator", "gemini-3.1-pro-preview", 60000);
+    await post(baseEvent);
     assert.strictEqual(received.length, 1);
     assert.strictEqual(received[0].url, "/ingest");
-    assert.strictEqual(received[0].body.kind, "tv-telemetry-event");
-    assert.strictEqual(received[0].body.source, "sportsclaw-operate");
-    assert.strictEqual(received[0].body.jobId, "tv-operator");
-    assert.deepStrictEqual(received[0].body.event, event);
+    const body = received[0].body;
+    assert.strictEqual(body.kind, "broadcast");
+    assert.strictEqual(body.workflow_name, "sportsclaw-operate:tv-operator");
+    assert.strictEqual(body.model, "gemini-3.1-pro-preview");
+    assert.strictEqual(body.prompt_excerpt, "Argentina vs Brazil opens.");
+    assert.strictEqual(body.ts, baseEvent.timestamp);
+  });
+
+  it("maps tick_started → kind=tick with phase+intervalMs", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator", undefined, 90000);
+    await post({ ...baseEvent, type: "tick_started" });
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].body.kind, "tick");
+    assert.strictEqual(received[0].body.phase, "started");
+    assert.strictEqual(received[0].body.intervalMs, 90000);
+  });
+
+  it("maps tick_failed → kind=error", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator");
+    await post({ ...baseEvent, type: "tick_failed", reason: "upstream timeout" });
+    assert.strictEqual(received[0].body.kind, "error");
+    assert.match(received[0].body.message, /upstream timeout/);
+    assert.strictEqual(received[0].body.level, "error");
+  });
+
+  it("strips <<<DATA>>>...<<<END>>> from broadcast text before POSTing", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator");
+    await post({
+      ...baseEvent,
+      text: 'Big news today.\n\n<<<DATA>>>{"prediction_markets":[{"question":"Q","prob":0.5,"source":"Kalshi"}]}<<<END>>>',
+    });
+    // First post is the broadcast — narrative ONLY, packet stripped.
+    assert.strictEqual(received[0].body.kind, "broadcast");
+    assert.strictEqual(received[0].body.prompt_excerpt, "Big news today.");
+    assert.doesNotMatch(received[0].body.prompt_excerpt, /<<<DATA>>>/);
+  });
+
+  it("fans out the structured packet as kind-specific events", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator");
+    const packet = JSON.stringify({
+      prediction_markets: [{ question: "Will X win?", prob: 0.3, source: "Polymarket" }],
+      news: [{ headline: "Breaking", source: "NYT", ts: "2026-05-11" }],
+    });
+    await post({
+      ...baseEvent,
+      text: `Narrative.\n\n<<<DATA>>>${packet}<<<END>>>`,
+    });
+    // Should produce 3 POSTs: broadcast, prediction_markets, news
+    assert.strictEqual(received.length, 3);
+    const kinds = received.map((r) => r.body.kind);
+    assert.deepStrictEqual(kinds, ["broadcast", "prediction_markets", "news"]);
+    const marketsBody = received.find((r) => r.body.kind === "prediction_markets").body;
+    assert.strictEqual(marketsBody.items.length, 1);
+    assert.strictEqual(marketsBody.items[0].question, "Will X win?");
+    const newsBody = received.find((r) => r.body.kind === "news").body;
+    assert.strictEqual(newsBody.items[0].headline, "Breaking");
+  });
+
+  it("omits empty arrays from the packet fan-out", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator");
+    const packet = JSON.stringify({
+      prediction_markets: [{ question: "Q", prob: 0.5, source: "Kalshi" }],
+      news: [], // empty — should NOT fan out
+      fixtures: [], // empty — should NOT fan out
+    });
+    await post({
+      ...baseEvent,
+      text: `Hello.\n\n<<<DATA>>>${packet}<<<END>>>`,
+    });
+    assert.strictEqual(received.length, 2);
+    const kinds = received.map((r) => r.body.kind);
+    assert.deepStrictEqual(kinds, ["broadcast", "prediction_markets"]);
+  });
+
+  it("tolerates malformed JSON in the packet (does not crash)", async () => {
+    const post = makeTailServerPoster(baseUrl, "tv-operator");
+    await post({
+      ...baseEvent,
+      text: "Body.\n\n<<<DATA>>>{ not valid json <<<END>>>",
+    });
+    // Broadcast still posts even when packet parse fails.
+    assert.ok(received.length >= 1);
+    assert.strictEqual(received[0].body.kind, "broadcast");
+    // The packet should still be stripped from the narrative.
+    assert.doesNotMatch(received[0].body.prompt_excerpt, /<<<DATA>>>/);
   });
 
   it("normalises trailing slash on the server URL", async () => {
     const post = makeTailServerPoster(`${baseUrl}///`, "tv-operator");
-    post(event);
-    await new Promise((r) => setTimeout(r, 50));
+    await post(baseEvent);
     assert.strictEqual(received.length, 1);
     assert.strictEqual(received[0].url, "/ingest");
   });
 
   it("does NOT throw when the server is unreachable (network error)", async () => {
     const post = makeTailServerPoster("http://127.0.0.1:1", "tv-operator");
-    // Should not throw synchronously...
-    post(event);
-    // ...nor should it surface as an unhandled rejection (the poster
-    // catches and logs to stderr). Give it a tick for the fetch to fail.
-    await new Promise((r) => setTimeout(r, 50));
+    await post(baseEvent);
     // If we got here without a crash, the contract holds.
     assert.ok(true);
   });
 
   it("does NOT throw when the server returns 5xx", async () => {
-    // Replace the handler to return 503
     await new Promise((resolve) => server.close(resolve));
     server = http.createServer((_req, res) => {
       res.writeHead(503);
@@ -293,8 +368,63 @@ describe("makeTailServerPoster", () => {
     await new Promise((resolve) => server.listen(0, resolve));
     const port = server.address().port;
     const post = makeTailServerPoster(`http://127.0.0.1:${port}`, "tv-operator");
-    post(event);
-    await new Promise((r) => setTimeout(r, 50));
+    await post(baseEvent);
     assert.ok(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStructuredBroadcast — packet extraction
+// ---------------------------------------------------------------------------
+
+describe("parseStructuredBroadcast", () => {
+  it("returns the full text and null data when no packet present", () => {
+    const r = parseStructuredBroadcast("Just a broadcast paragraph.");
+    assert.strictEqual(r.narrative, "Just a broadcast paragraph.");
+    assert.strictEqual(r.data, null);
+  });
+
+  it("extracts a well-formed packet and strips it from the narrative", () => {
+    const r = parseStructuredBroadcast(
+      'Hello world.\n\n<<<DATA>>>{"prediction_markets":[{"question":"Q","prob":0.5}]}<<<END>>>',
+    );
+    assert.strictEqual(r.narrative, "Hello world.");
+    assert.ok(r.data);
+    assert.strictEqual(r.data.prediction_markets.length, 1);
+    assert.strictEqual(r.data.prediction_markets[0].question, "Q");
+  });
+
+  it("trims surrounding whitespace inside the delimiters", () => {
+    const r = parseStructuredBroadcast(
+      'Text.\n\n<<<DATA>>>\n  {"news":[{"headline":"H"}]}  \n<<<END>>>',
+    );
+    assert.ok(r.data);
+    assert.strictEqual(r.data.news[0].headline, "H");
+  });
+
+  it("reports a parseError when the JSON is malformed", () => {
+    const r = parseStructuredBroadcast(
+      "Text.\n\n<<<DATA>>>{ not valid json <<<END>>>",
+    );
+    assert.strictEqual(r.data, null);
+    assert.ok(r.parseError);
+    // The narrative is still recovered without the packet.
+    assert.strictEqual(r.narrative, "Text.");
+  });
+
+  it("handles multiple newlines + multi-line JSON inside the packet", () => {
+    const r = parseStructuredBroadcast(
+      "Para 1.\n\nPara 2.\n\n<<<DATA>>>\n{\n  \"news\": [\n    {\"headline\":\"H1\"},\n    {\"headline\":\"H2\"}\n  ]\n}\n<<<END>>>",
+    );
+    assert.ok(r.data);
+    assert.strictEqual(r.data.news.length, 2);
+    assert.strictEqual(r.narrative, "Para 1.\n\nPara 2.");
+  });
+
+  it("ignores stray <<<DATA>>> with no matching <<<END>>>", () => {
+    const r = parseStructuredBroadcast("Text. <<<DATA>>> not closed");
+    // No match — returns the full text as narrative, data null.
+    assert.strictEqual(r.data, null);
+    assert.match(r.narrative, /Text\./);
   });
 });

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -490,6 +490,108 @@ describe("onTickEvent telemetry hook", () => {
 });
 
 // ---------------------------------------------------------------------------
+// onToolCall telemetry hook — per-tool execution observability
+// ---------------------------------------------------------------------------
+
+describe("onToolCall telemetry hook", () => {
+  it("fires once per tool execution with timing + outcome", async () => {
+    const calls = [];
+    const tools = {
+      search_documents: makeTool(async () => ({ documents: [] })),
+    };
+    const generateTextImpl = async ({ tools: passedTools }) => {
+      await passedTools.search_documents.execute(
+        { name: "tv-news" },
+        { toolCallId: "1", messages: [] },
+      );
+      return { text: "done" };
+    };
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        tools,
+        generateTextImpl,
+        onToolCall: (e) => calls.push(e),
+      }),
+    );
+    await daemon.tickOnce();
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].toolName, "search_documents");
+    assert.strictEqual(calls[0].outcome, "ok");
+    assert.strictEqual(typeof calls[0].durationMs, "number");
+    assert.ok(calls[0].tickId.startsWith("tick_"));
+    assert.strictEqual(calls[0].jobId, "tv-operator-test");
+  });
+
+  it("records outcome=error when the underlying tool throws", async () => {
+    const calls = [];
+    const tools = {
+      execute_workflow: makeTool(async () => {
+        throw new Error("workflow not found");
+      }),
+    };
+    const generateTextImpl = async ({ tools: passedTools }) => {
+      try {
+        await passedTools.execute_workflow.execute(
+          { workflow: "ingest" },
+          { toolCallId: "1", messages: [] },
+        );
+      } catch {
+        // expected
+      }
+      return { text: "tried" };
+    };
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        tools,
+        generateTextImpl,
+        onToolCall: (e) => calls.push(e),
+      }),
+    );
+    await daemon.tickOnce();
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].outcome, "error");
+    assert.match(calls[0].reason, /workflow not found/);
+  });
+
+  it("records outcome=blocked when the guardrail blocks a tool", async () => {
+    const calls = [];
+    const tools = {
+      execute_workflow: makeTool(async () => {
+        throw new Error("workflow not found");
+      }),
+    };
+    const generateTextImpl = async ({ tools: passedTools }) => {
+      // Drive the same failing call 6 times — guardrail blocks at 5+.
+      for (let i = 0; i < 6; i++) {
+        try {
+          await passedTools.execute_workflow.execute(
+            { workflow: "ingest" },
+            { toolCallId: String(i), messages: [] },
+          );
+        } catch {
+          // expected
+        }
+      }
+      return { text: "tried" };
+    };
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        tools,
+        generateTextImpl,
+        onToolCall: (e) => calls.push(e),
+      }),
+    );
+    await daemon.tickOnce();
+    const outcomes = calls.map((c) => c.outcome);
+    // 5 error outcomes + at least one block.
+    assert.ok(
+      outcomes.includes("blocked"),
+      "expected at least one outcome=blocked, got " + JSON.stringify(outcomes),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Discovered while running the first live ticks of `sportsclaw operate --once` against the machina-sports-tv tenant pod. The Phase-1 daemon driver from #45 worked end-to-end on the first try, but with several small production gaps plus a missing protocol for the LLM to surface structured data alongside its broadcast narrative. This PR is the cleanup.

**Themes:** real-world bug fixes · structured packet protocol · per-tool observability · LLM step budget.

## Real-world fixes (operate.ts)
- **Tilde expansion on rootDir** — `~/.sportsclaw/operator/foo` was being written to a literal `~/` directory inside CWD. `expandTilde()` now applied at config resolution.
- **applyConfigToEnv() at startup** — operate read the sportsclaw config but never published it to env, so the AI SDK couldn't find `GOOGLE_GENERATIVE_AI_API_KEY`. Chat REPL already does this; daemon driver now does too.
- **Drain before exit** — `--once` called `process.exit` immediately after `tickOnce` returned, killing fire-and-forget fetch POSTs to the tail-server mid-flight. Added a 1.5s drain.

## Structured packet protocol

The LLM can emit a JSON packet at the end of its broadcast text:

```
<<<DATA>>>
{
  "prediction_markets": [{"question":"...","prob":0.22,"source":"Kalshi"}],
  "fixtures":           [{"home":"...","away":"...","odds":"..."}],
  "news":               [{"headline":"...","source":"..."}]
}
<<<END>>>
```

`parseStructuredBroadcast(text)` extracts + strips the packet. `makeTailServerPoster` then:
1. POSTs the cleaned narrative as `kind=broadcast` (no more raw `<<<DATA>>>` in the on-air card).
2. Fans out each non-empty array as its own kind-specific event: `prediction_markets` / `fixtures` / `news`, each carrying `items[]`.

Empty arrays omitted. Malformed JSON logged but does not crash the tick — narrative still recovered.

## TickEvent → overlay kind mapping

\`mapTickEventToTelemetry\` produces a flat \`tv-telemetry-event\` shape the overlay understands:

| TickEvent.type | overlay kind |
|---|---|
| tick_started | tick (phase + intervalMs anchor countdown) |
| tick_published | broadcast (model + prompt_excerpt drive the card) |
| tick_silent | reasoning |
| tick_failed | error |
| tick_skipped | gate |

`intervalMs` threaded through so the overlay countdown is anchored to the actual tick timestamp + interval (stable across page refreshes).

## onToolCall hook (operator-daemon.ts)

New per-tool observability — fires once per tool execution with name, `durationMs`, `outcome` (\`ok\` | \`error\` | \`blocked\`), and \`reason\`. \`ToolCallEvent\` type exported. Operate.ts wires it through \`makeToolCallPoster\` to emit \`kind=ingest\` trail events showing which tools the LLM actually picked.

## maxSteps default (operator-daemon.ts)

\`DEFAULT_MAX_STEPS = 16\` (was effectively 1 — single \`generateText\` step ended with empty text when the LLM chose tool calls). Now the model has room to make tool calls AND a final synthesis pass within one tick. Configurable via \`maxSteps\` in \`OperatorDaemonConfig\`.

## Test plan
- [x] +12 tests in \`test/operate.test.mjs\`: poster envelope, kind mapping, packet strip + fan-out, empty arrays, malformed JSON, plus a 6-case \`parseStructuredBroadcast\` suite
- [x] +3 tests in \`test/operator-daemon.test.mjs\`: \`onToolCall\` fires with timing + outcome=ok / error / blocked
- [x] Full suite: **396 passing** (was 381 + 15 new)
- [x] \`npm run build\` clean
- [x] Verified manually against the tenant pod — one \`--once\` tick now produces:
  - broadcast event with 76-word World Cup narrative (sources cited inline)
  - prediction_markets event with 2 items (parsed from the LLM's structured packet)
  - news event with 2 items (parsed from same packet)
  - 3 ingest events for the tool calls
  - tick event with phase+intervalMs
- [ ] CI green