### PR TITLE
feat(operate): packet-strip hardening + generate_image for daemon

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -82,6 +82,7 @@ import {
 } from "./bracket-sim.js";
 import { subagentManager } from "./subagent.js";
 import { heartbeatService } from "./heartbeat.js";
+import { createGenerateImageTool } from "./image-gen.js";
 import { buildTemplatePrompt, type QueryIntent } from "./response-templates.js";
 import { evaluateResponse } from "./evaluator.js";
 import { getSportDisplayName } from "./buttons.js";
@@ -1878,45 +1879,10 @@ export class sportsclawEngine {
     // Image + Video generation tools
     // -----------------------------------------------------------------
 
-    toolMap["generate_image"] = defineTool({
-      description:
-        "Generate an image from a text prompt. Routes to the appropriate image " +
-        "generation API based on the configured provider:\n" +
-        "- Google → Gemini image generation\n" +
-        "- OpenAI → DALL-E 3\n" +
-        "- Anthropic → Not supported (will return an error)\n" +
-        "The generated image is automatically sent to the user in their channel.",
-      inputSchema: jsonSchema({
-        type: "object",
-        properties: {
-          prompt: {
-            type: "string",
-            description:
-              "Detailed text description of the image to generate. Be specific " +
-              "about style, composition, colors, and subject matter.",
-          },
-          size: {
-            type: "string",
-            enum: ["1024x1024", "1024x1792", "1792x1024"],
-            description: "Image dimensions. Default: 1024x1024.",
-          },
-        },
-        required: ["prompt"],
-      }),
-      execute: async (args: { prompt?: string; size?: string }) => {
-        if (!args.prompt) return "Error: prompt is required.";
-        if (config.provider === "anthropic") {
-          return "Anthropic does not support image generation. Please switch to Google or OpenAI.";
-        }
-        try {
-          const image = await generateImageForProvider(config.provider, args.prompt, args.size);
-          this._generatedImages.push(image);
-          return `Image generated successfully with prompt: "${args.prompt}"`;
-        } catch (error) {
-          if (isHalt(error)) throw error;
-          return `Failed to generate image: ${error instanceof Error ? error.message : String(error)}`;
-        }
-      },
+    toolMap["generate_image"] = createGenerateImageTool({
+      provider: config.provider,
+      onImage: (image) => { this._generatedImages.push(image); },
+      isHalt,
     });
 
     toolMap["generate_video"] = defineTool({
@@ -3791,78 +3757,6 @@ export class sportsclawEngine {
     const result = await this.run(userPrompt, options);
     console.log(result);
   }
-}
-
-// ---------------------------------------------------------------------------
-// Image generation helpers (standalone, outside the class)
-// ---------------------------------------------------------------------------
-
-async function generateImageForProvider(
-  provider: LLMProvider,
-  prompt: string,
-  size?: string
-): Promise<GeneratedImage> {
-  if (provider === "google") return generateImageGoogle(prompt);
-  if (provider === "openai") return generateImageOpenAI(prompt, size);
-  throw new Error("Provider does not support image generation.");
-}
-
-async function generateImageGoogle(prompt: string): Promise<GeneratedImage> {
-  const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-  if (!apiKey) throw new Error("GOOGLE_GENERATIVE_AI_API_KEY is not set.");
-
-  const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent?key=${apiKey}`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { responseModalities: ["IMAGE", "TEXT"] },
-      }),
-    }
-  );
-
-  if (!res.ok) {
-    const errBody = await res.text();
-    throw new Error(`Google image generation failed (${res.status}): ${errBody}`);
-  }
-
-  const data = (await res.json()) as any;
-  const parts = data.candidates?.[0]?.content?.parts;
-  if (!parts) throw new Error("Google image generation returned no content.");
-
-  const imagePart = parts.find((p: any) => p.inlineData);
-  if (!imagePart?.inlineData?.data) throw new Error("No image data in response.");
-
-  return {
-    data: imagePart.inlineData.data,
-    mimeType: imagePart.inlineData.mimeType || "image/jpeg",
-    prompt,
-    provider: "google",
-  };
-}
-
-async function generateImageOpenAI(prompt: string, size?: string): Promise<GeneratedImage> {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error("OPENAI_API_KEY is not set.");
-
-  const res = await fetch("https://api.openai.com/v1/images/generations", {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({ model: "dall-e-3", prompt, n: 1, size: size || "1024x1024", response_format: "b64_json" }),
-  });
-
-  if (!res.ok) {
-    const errBody = await res.text();
-    throw new Error(`OpenAI image generation failed (${res.status}): ${errBody}`);
-  }
-
-  const data = (await res.json()) as any;
-  const imageData = data.data?.[0]?.b64_json;
-  if (!imageData) throw new Error("OpenAI image generation returned no image data.");
-
-  return { data: imageData, mimeType: "image/png", prompt, provider: "openai" };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/image-gen.ts
+++ b/src/image-gen.ts
@@ -1,0 +1,152 @@
+/**
+ * Image generation — provider-agnostic helpers + a tool factory.
+ *
+ * Used by:
+ *   - engine.ts (conversational/chat side; sink pushes into per-run image array)
+ *   - operate.ts (operator daemon; sink writes to disk + emits telemetry)
+ *
+ * Provider routing matches engine's prior behavior:
+ *   - google  → Gemini image generation (gemini-3.1-flash-image-preview)
+ *   - openai  → DALL-E 3
+ *   - anthropic → unsupported (tool returns a friendly error string)
+ */
+
+import { tool as defineTool, jsonSchema } from "ai";
+import type { GeneratedImage, LLMProvider } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Provider helpers
+// ---------------------------------------------------------------------------
+
+export async function generateImageForProvider(
+  provider: LLMProvider,
+  prompt: string,
+  size?: string,
+): Promise<GeneratedImage> {
+  if (provider === "google") return generateImageGoogle(prompt);
+  if (provider === "openai") return generateImageOpenAI(prompt, size);
+  throw new Error("Provider does not support image generation.");
+}
+
+export async function generateImageGoogle(prompt: string): Promise<GeneratedImage> {
+  const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+  if (!apiKey) throw new Error("GOOGLE_GENERATIVE_AI_API_KEY is not set.");
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { responseModalities: ["IMAGE", "TEXT"] },
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`Google image generation failed (${res.status}): ${errBody}`);
+  }
+
+  const data = (await res.json()) as any;
+  const parts = data.candidates?.[0]?.content?.parts;
+  if (!parts) throw new Error("Google image generation returned no content.");
+
+  const imagePart = parts.find((p: any) => p.inlineData);
+  if (!imagePart?.inlineData?.data) throw new Error("No image data in response.");
+
+  return {
+    data: imagePart.inlineData.data,
+    mimeType: imagePart.inlineData.mimeType || "image/jpeg",
+    prompt,
+    provider: "google",
+  };
+}
+
+export async function generateImageOpenAI(prompt: string, size?: string): Promise<GeneratedImage> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY is not set.");
+
+  const res = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      model: "dall-e-3",
+      prompt,
+      n: 1,
+      size: size || "1024x1024",
+      response_format: "b64_json",
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`OpenAI image generation failed (${res.status}): ${errBody}`);
+  }
+
+  const data = (await res.json()) as any;
+  const imageData = data.data?.[0]?.b64_json;
+  if (!imageData) throw new Error("OpenAI image generation returned no image data.");
+
+  return { data: imageData, mimeType: "image/png", prompt, provider: "openai" };
+}
+
+// ---------------------------------------------------------------------------
+// Tool factory — same input schema for both call sites; only the sink differs
+// ---------------------------------------------------------------------------
+
+export interface CreateGenerateImageToolOpts {
+  /** LLM provider routing target. Currently must be "google" or "openai". */
+  provider: LLMProvider;
+  /** Called with the generated image. Caller decides where it goes (in-memory buffer, disk, telemetry, etc). */
+  onImage: (image: GeneratedImage) => void | Promise<void>;
+  /** Optional: engine-internal halt-signal detector. Operator daemon doesn't need it. */
+  isHalt?: (err: unknown) => boolean;
+}
+
+export function createGenerateImageTool(opts: CreateGenerateImageToolOpts) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (defineTool as any)({
+    description:
+      "Generate an image from a text prompt. Routes to the appropriate image " +
+      "generation API based on the configured provider:\n" +
+      "- Google → Gemini image generation\n" +
+      "- OpenAI → DALL-E 3\n" +
+      "- Anthropic → Not supported (will return an error)\n" +
+      "The generated image is automatically sent to the user in their channel.",
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {
+        prompt: {
+          type: "string",
+          description:
+            "Detailed text description of the image to generate. Be specific " +
+            "about style, composition, colors, and subject matter.",
+        },
+        size: {
+          type: "string",
+          enum: ["1024x1024", "1024x1792", "1792x1024"],
+          description: "Image dimensions. Default: 1024x1024.",
+        },
+      },
+      required: ["prompt"],
+    }),
+    execute: async (args: Record<string, unknown>) => {
+      const prompt = typeof args.prompt === "string" ? args.prompt : "";
+      const size = typeof args.size === "string" ? args.size : undefined;
+      if (!prompt) return "Error: prompt is required.";
+      if (opts.provider === "anthropic") {
+        return "Anthropic does not support image generation. Please switch to Google or OpenAI.";
+      }
+      try {
+        const image = await generateImageForProvider(opts.provider, prompt, size);
+        await opts.onImage(image);
+        return `Image generated successfully with prompt: "${prompt}"`;
+      } catch (error) {
+        if (opts.isHalt?.(error)) throw error;
+        return `Failed to generate image: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    },
+  });
+}

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -447,23 +447,38 @@ interface ParsedBroadcast {
 }
 
 const PACKET_RE = /<<<DATA>>>\s*([\s\S]*?)\s*<<<END>>>/;
+const PACKET_OPEN_RE = /<<<DATA>>>/;
 
 export function parseStructuredBroadcast(text: string): ParsedBroadcast {
   const match = text.match(PACKET_RE);
-  if (!match) return { narrative: text.trim(), data: null };
-  const raw = match[1].trim();
-  let data: StructuredPacket | null = null;
-  let parseError: string | undefined;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object") {
-      data = parsed as StructuredPacket;
+  if (match) {
+    const raw = match[1].trim();
+    let data: StructuredPacket | null = null;
+    let parseError: string | undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        data = parsed as StructuredPacket;
+      }
+    } catch (err) {
+      parseError = err instanceof Error ? err.message : String(err);
     }
-  } catch (err) {
-    parseError = err instanceof Error ? err.message : String(err);
+    const narrative = text.replace(PACKET_RE, "").trim();
+    return { narrative, data, parseError };
   }
-  const narrative = text.replace(PACKET_RE, "").trim();
-  return { narrative, data, parseError };
+  // Defensive: LLM started a packet but never closed it (token-limit truncation,
+  // malformed output). Strip from <<<DATA>>> onward so raw JSON doesn't bleed
+  // into the renderer card. Data is lost for this tick, but the narrative stays
+  // clean and the parse error is surfaced via telemetry.
+  const openMatch = text.match(PACKET_OPEN_RE);
+  if (openMatch && openMatch.index !== undefined) {
+    return {
+      narrative: text.slice(0, openMatch.index).trim(),
+      data: null,
+      parseError: "packet opened but never closed (truncated)",
+    };
+  }
+  return { narrative: text.trim(), data: null };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -21,6 +21,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 import { tool as defineTool, jsonSchema, type ToolSet } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
@@ -44,6 +45,7 @@ import { ToolRegistry, type ToolCallInput } from "./tools.js";
 import { McpManager } from "./mcp.js";
 import { loadAllSchemas } from "./schema.js";
 import { resolveConfig, applyConfigToEnv } from "./config.js";
+import { createGenerateImageTool } from "./image-gen.js";
 import {
   BROADCAST_DIRECTIVE_FRAGMENT,
   buildSystemPrompt,
@@ -252,7 +254,7 @@ interface OperatorTools {
  * filtering. The registry + mcpManager are returned so callers can use them
  * for persona resolution and clean shutdown.
  */
-async function buildOperatorTools(verbose: boolean): Promise<OperatorTools> {
+async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Promise<OperatorTools> {
   const registry = new ToolRegistry();
   for (const schema of loadAllSchemas()) {
     registry.injectSchema(schema, false);
@@ -285,6 +287,44 @@ async function buildOperatorTools(verbose: boolean): Promise<OperatorTools> {
       },
     });
   }
+
+  // generate_image — extracted from engine.ts so the operator daemon can call
+  // it alongside sport skills + MCP tools. Sink writes bytes to <rootDir>/images
+  // and POSTs a kind:"image" telemetry event to the tail-server (best-effort).
+  const sportsclawCfg = resolveConfig();
+  const provider = cfg.provider ?? sportsclawCfg.provider ?? "google";
+  const rootDir = expandTilde(cfg.rootDir ?? defaultRootDir(cfg.jobId));
+  const imagesDir = path.join(rootDir, "images");
+  toolSet["generate_image"] = createGenerateImageTool({
+    provider,
+    onImage: async (image) => {
+      try { fs.mkdirSync(imagesDir, { recursive: true }); } catch {}
+      const ext = (image.mimeType || "").includes("png") ? "png" : "jpg";
+      const id = randomUUID();
+      const filePath = path.join(imagesDir, `${id}.${ext}`);
+      fs.writeFileSync(filePath, Buffer.from(image.data, "base64"));
+      if (cfg.tailServer) {
+        const url = cfg.tailServer.replace(/\/+$/, "") + "/ingest";
+        try {
+          await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              ts: new Date().toISOString(),
+              kind: "image",
+              message: `image generated · ${image.prompt.slice(0, 80)}`,
+              level: "info",
+              model: image.provider === "google" ? "gemini-3.1-flash-image-preview" : "dall-e-3",
+              prompt_excerpt: image.prompt,
+              workflow_name: `sportsclaw-operate:${cfg.jobId}`,
+              src: `file://${filePath}`,
+            }),
+          });
+        } catch { /* non-fatal */ }
+      }
+    },
+  });
+  toolNames.push("generate_image");
 
   return { registry, mcpManager, toolSet, toolNames };
 }
@@ -683,7 +723,7 @@ function makeToolCallPoster(
 
 async function runDryRun(jobId: string): Promise<void> {
   const { config: cfg } = loadOperatorJobConfig(jobId);
-  const tools = await buildOperatorTools(false);
+  const tools = await buildOperatorTools(cfg, false);
   try {
     const inputs = await resolveJobInputs(cfg, tools.mcpManager);
     const system = buildSystemPrompt({
@@ -714,7 +754,7 @@ async function runDryRun(jobId: string): Promise<void> {
 
 async function runOnce(jobId: string): Promise<void> {
   const { config: cfg } = loadOperatorJobConfig(jobId);
-  const tools = await buildOperatorTools(false);
+  const tools = await buildOperatorTools(cfg, false);
   try {
     const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
     const daemon = createOperatorDaemon({
@@ -767,7 +807,7 @@ function exitCodeFor(event: TickEvent): number {
 
 async function runForeground(jobId: string): Promise<void> {
   const { config: cfg } = loadOperatorJobConfig(jobId);
-  const tools = await buildOperatorTools(false);
+  const tools = await buildOperatorTools(cfg, false);
   const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
 
   const daemon = createOperatorDaemon({

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -12,6 +12,7 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import http from "node:http";
 
 import {
+  buildOperatorTools,
   exitCodeFor,
   FRAGMENT_ALIASES,
   makeTailServerPoster,
@@ -421,10 +422,85 @@ describe("parseStructuredBroadcast", () => {
     assert.strictEqual(r.narrative, "Para 1.\n\nPara 2.");
   });
 
-  it("ignores stray <<<DATA>>> with no matching <<<END>>>", () => {
+  it("defensively strips an open <<<DATA>>> with no matching <<<END>>>", () => {
+    // When the LLM truncates mid-packet (token limit, malformed output),
+    // strip everything from <<<DATA>>> onward so raw JSON doesn't bleed
+    // into the broadcast card. Data is lost for this tick (would have been
+    // malformed JSON anyway); narrative stays clean.
     const r = parseStructuredBroadcast("Text. <<<DATA>>> not closed");
-    // No match — returns the full text as narrative, data null.
     assert.strictEqual(r.data, null);
-    assert.match(r.narrative, /Text\./);
+    assert.ok(
+      !r.narrative.includes("<<<DATA>>>"),
+      "narrative must not contain the open marker",
+    );
+    assert.ok(
+      !r.narrative.includes("not closed"),
+      "narrative must not contain anything after the open marker",
+    );
+    assert.match(r.narrative, /^Text\.\s*$/);
+    assert.match(r.parseError ?? "", /truncated|never closed/i);
+  });
+
+  it("strips an open packet that contains a half-written JSON object", () => {
+    const r = parseStructuredBroadcast(
+      'World Cup recap.\n\n<<<DATA>>>{"prediction_markets":[{"question":"Will',
+    );
+    assert.strictEqual(r.data, null);
+    assert.ok(!r.narrative.includes("<<<DATA>>>"));
+    assert.ok(!r.narrative.includes("prediction_markets"));
+    assert.strictEqual(r.narrative, "World Cup recap.");
+    assert.ok(r.parseError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOperatorTools — generate_image registration
+// ---------------------------------------------------------------------------
+
+describe("buildOperatorTools generate_image", () => {
+  // These tests instantiate a fresh ToolRegistry + McpManager, which may
+  // attempt MCP connection if SPORTSCLAW_MCP_SERVERS / ~/.sportsclaw/mcp.json
+  // is configured. Connect is non-fatal; we just need the toolset to come
+  // back with generate_image in it.
+
+  const baseCfg = {
+    jobId: "test-image-job",
+    intervalMs: 60_000,
+    personaText: "test persona",
+    provider: "google",
+  };
+
+  it("registers generate_image in the toolset (named in toolNames + present in toolSet)", async () => {
+    const t = await buildOperatorTools(baseCfg, false);
+    try {
+      assert.ok(
+        t.toolNames.includes("generate_image"),
+        `toolNames did not include generate_image: ${t.toolNames.slice(0, 8).join(", ")}…`,
+      );
+      assert.ok(
+        t.toolSet["generate_image"],
+        "toolSet has no generate_image entry",
+      );
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
+  });
+
+  it("generate_image execute returns an Anthropic-unsupported message when provider=anthropic", async () => {
+    const t = await buildOperatorTools(
+      { ...baseCfg, provider: "anthropic" },
+      false,
+    );
+    try {
+      const tool = t.toolSet["generate_image"];
+      assert.ok(tool);
+      const result = await tool.execute({ prompt: "irrelevant" }, {
+        toolCallId: "t1",
+        messages: [],
+      });
+      assert.match(String(result), /Anthropic does not support image generation/i);
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
   });
 });


### PR DESCRIPTION
## Summary
Two fixes for the operator daemon, captured while bringing up the Machina Sports TV channel:

- **Defensive packet stripping** (`a9759a0`) — when the LLM truncates its broadcast mid-`<<<DATA>>>` block, the old `parseStructuredBroadcast` returned the entire text (open packet and all) as the narrative, and raw JSON bled into the overlay's renderer card. Now: if `<<<DATA>>>` opens but never closes, strip from that point forward. Data lost for that tick, narrative stays clean.

- **Extract `generate_image` so the operator daemon can use it** (`d86cc39`) — pulled the provider helpers and tool definition out of `engine.ts` into a new `src/image-gen.ts` module. `engine.ts` keeps its existing per-run image sink. `operate.ts` registers `generate_image` alongside sport skills + MCP tools, with a sink that writes bytes to `<rootDir>/images/<uuid>.<ext>` and emits a `kind:"image"` telemetry event to the tail-server.

  Also bumps the Google image model from `gemini-3-pro-image-preview` → `gemini-3.1-flash-image-preview`.

## Verified
- `npm run build` clean.
- `sportsclaw operate --job tv-operator --dry-run` shows `generate_image` in the resolved tool set (351 tools).
- Live daemon restarted, ticking.

## Known follow-ups (separate work)
- Persona's "Tool guidance" section doesn't mention `generate_image` yet — the LLM picks tools by description + persona hints, so it won't call this until the persona invites it.
- Tail-server doesn't serve the saved image files yet; the event's `src: file://...` URL isn't browser-reachable.
- Overlay's renderer slot has no `kind: "image"` layer; today the `image` filler only renders metadata in the sidebar.

## Test plan
- [ ] Smoke: `node dist/index.js operate --job tv-operator --dry-run | grep generate_image`
- [ ] Smoke: `node dist/index.js operate --job tv-operator --once` with a persona instructed to call `generate_image` once — confirm bytes land on disk + `kind:"image"` event hits the tail-server
- [ ] Regression: existing chat-side `generate_image` (Discord/Telegram) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)