### PR TITLE
feat(operate): description override + HTTP src for generate_image (followup to #48)

### DIFF
--- a/src/image-gen.ts
+++ b/src/image-gen.ts
@@ -103,18 +103,22 @@ export interface CreateGenerateImageToolOpts {
   onImage: (image: GeneratedImage) => void | Promise<void>;
   /** Optional: engine-internal halt-signal detector. Operator daemon doesn't need it. */
   isHalt?: (err: unknown) => boolean;
+  /** Optional: override the default tool description. The default is chat-oriented ("sent to the user in their channel"); the operator daemon should pass a broadcaster-oriented description so the LLM knows when to call it. */
+  description?: string;
 }
+
+const DEFAULT_DESCRIPTION =
+  "Generate an image from a text prompt. Routes to the appropriate image " +
+  "generation API based on the configured provider:\n" +
+  "- Google → Gemini image generation\n" +
+  "- OpenAI → DALL-E 3\n" +
+  "- Anthropic → Not supported (will return an error)\n" +
+  "The generated image is automatically sent to the user in their channel.";
 
 export function createGenerateImageTool(opts: CreateGenerateImageToolOpts) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (defineTool as any)({
-    description:
-      "Generate an image from a text prompt. Routes to the appropriate image " +
-      "generation API based on the configured provider:\n" +
-      "- Google → Gemini image generation\n" +
-      "- OpenAI → DALL-E 3\n" +
-      "- Anthropic → Not supported (will return an error)\n" +
-      "The generated image is automatically sent to the user in their channel.",
+    description: opts.description ?? DEFAULT_DESCRIPTION,
     inputSchema: jsonSchema({
       type: "object",
       properties: {

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -297,6 +297,13 @@ async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Pro
   const imagesDir = path.join(rootDir, "images");
   toolSet["generate_image"] = createGenerateImageTool({
     provider,
+    description:
+      "Generate a broadcast-overlay image (poster card, hero graphic, fan-cam still) from a text prompt. " +
+      "Routes to Google Gemini image generation. The image is delivered to the on-air overlay as a kind:\"image\" " +
+      "telemetry event. Use this when the lead story has strong visual potential (a stadium, an iconic player, " +
+      "a final-whistle moment, a tournament-hype beat). Prompts should describe a poster-style composition " +
+      "explicitly — e.g. \"broadcast graphic: France national team huddle, World Cup 2026, dramatic stadium " +
+      "lighting, hero composition, 16:9 poster.\" Returns a short confirmation string after the image lands.",
     onImage: async (image) => {
       try { fs.mkdirSync(imagesDir, { recursive: true }); } catch {}
       const ext = (image.mimeType || "").includes("png") ? "png" : "jpg";
@@ -317,7 +324,10 @@ async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Pro
               model: image.provider === "google" ? "gemini-3.1-flash-image-preview" : "dall-e-3",
               prompt_excerpt: image.prompt,
               workflow_name: `sportsclaw-operate:${cfg.jobId}`,
-              src: `file://${filePath}`,
+              // The tail-server's /images/<filename> route serves files from
+              // IMAGES_DIR (defaults to this same dir for the tv-operator job).
+              // Use the relative path the browser can load via the tail-server.
+              src: `${cfg.tailServer.replace(/\/+$/, "")}/images/${id}.${ext}`,
             }),
           });
         } catch { /* non-fatal */ }

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -503,4 +503,25 @@ describe("buildOperatorTools generate_image", () => {
       await t.mcpManager.disconnectAll().catch(() => {});
     }
   });
+
+  it("registers a broadcaster-oriented description on the daemon tool (not the chat-mode default)", async () => {
+    // The chat-mode default description says "sent to the user in their
+    // channel," which empirically caused Gemini to skip the tool in
+    // operator ticks. The daemon must override with broadcaster wording.
+    const t = await buildOperatorTools(baseCfg, false);
+    try {
+      const tool = t.toolSet["generate_image"];
+      assert.ok(tool);
+      const desc = String(tool.description ?? "");
+      assert.match(desc, /broadcast/i, "daemon description must invoke broadcast wording");
+      assert.match(desc, /on-air overlay/i, "daemon description must reference the on-air overlay");
+      assert.doesNotMatch(
+        desc,
+        /sent to the user in their channel/i,
+        "daemon must NOT use the chat-mode default description",
+      );
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Two follow-ups to #48 that close the gap between "the tool is registered" and "the operator daemon can actually use it end-to-end."

### 1. Optional `description` override on the factory
The default description is chat-oriented: *"The generated image is automatically sent to the user in their channel."* Empirically, Gemini reads this and decides the tool is for reply-style delivery — it **skipped the tool across two consecutive `--once` ticks** with the default description, even with an explicit persona invitation.

Adding a `description?: string` option to `CreateGenerateImageToolOpts` lets the operator daemon pass broadcaster-oriented language ("*poster card, hero graphic, fan-cam still ... delivered as a `kind:\"image\"` telemetry event*"). After this change, Gemini called the tool on the next tick. Chat-side behavior in `engine.ts` is unchanged (still uses the default).

### 2. Emit HTTP src URL instead of `file://`
The daemon writes image bytes to `<rootDir>/images/<uuid>.<ext>` and emits a `kind:"image"` telemetry event. The previous `src: file://<abs path>` value isn't loadable from a browser-hosted overlay. Now: `src: http://<tailServer>/images/<uuid>.<ext>`, which the tail-server's new `/images/<filename>` route serves (matching change shipped on the `machina-sports-tv` repo, commit `b592617`).

## Verified
- `npm run build` clean.
- `sportsclaw operate --job tv-operator --dry-run` still lists `generate_image` in the resolved tool set.
- `sportsclaw operate --job tv-operator --once`:
  - LLM called `generate_image` (with the new broadcaster description).
  - Image bytes landed at `~/.sportsclaw/operator/tv-operator/images/<uuid>.jpg`.
  - `kind:"image"` event hit the tail-server with `src=http://localhost:8090/images/<uuid>.jpg`.
  - `curl http://localhost:8090/images/<uuid>.jpg` returned 200 image/jpeg with the right bytes.

## Test plan
- [ ] Smoke: build + `operate --job tv-operator --dry-run` lists `generate_image`.
- [ ] Smoke: with a tv-operator persona that invites `generate_image`, run `--once`; confirm image file lands in `<rootDir>/images/` and the emitted `kind:"image"` telemetry event has an http:// `src` URL.
- [ ] Regression: chat-side `generate_image` (Discord/Telegram) still works with the default description (engine.ts passes no `description` option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)