### PR TITLE
feat(operate): tv-content-archive on pod + recall_recent_content tool

### DIFF
--- a/src/operate.ts
+++ b/src/operate.ts
@@ -332,9 +332,92 @@ async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Pro
           });
         } catch { /* non-fatal */ }
       }
+      // Archive the image to the pod (best-effort).
+      const imageUrl = cfg.tailServer
+        ? `${cfg.tailServer.replace(/\/+$/, "")}/images/${id}.${ext}`
+        : `file://${filePath}`;
+      await archiveToPod(mcpManager, {
+        ts: new Date().toISOString(),
+        category: "image",
+        workflow_name: `sportsclaw-operate:${cfg.jobId}`,
+        prompt: image.prompt,
+        image_url: imageUrl,
+        image_provider: image.provider,
+      });
     },
   });
   toolNames.push("generate_image");
+
+  // recall_recent_content — pull earlier content from the pod's tv-content-archive
+  // so the daemon can resurface a relevant past beat when fresh data is thin
+  // instead of recycling the same headline. The persona invites this tool.
+  toolSet["recall_recent_content"] = defineTool({
+    description:
+      "Recall earlier broadcasts, prediction markets, fixtures, news headlines, " +
+      "or generated images from today's content archive. Call this when current " +
+      "data is thin or the same story has repeated across recent ticks and you " +
+      "want to resurface an earlier moment instead of recycling. Returns a JSON " +
+      "object {count, results: [...]} with past archive entries — each has ts, " +
+      "category, and narrative/items/prompt/image_url depending on category.",
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {
+        category: {
+          type: "string",
+          enum: ["broadcast", "image", "prediction_markets", "fixtures", "news"],
+          description: "Type of past content to recall.",
+        },
+        since_minutes: {
+          type: "number",
+          description: "Look back this many minutes. Defaults to 240 (4 hours).",
+        },
+        limit: {
+          type: "number",
+          description: "Max entries to return. Defaults to 5.",
+        },
+      },
+      required: ["category"],
+    }),
+    execute: async (args: Record<string, unknown>) => {
+      const category = typeof args.category === "string" ? args.category : "";
+      const sinceMin = typeof args.since_minutes === "number" ? args.since_minutes : 240;
+      const limit = typeof args.limit === "number" ? args.limit : 5;
+      if (!category) return JSON.stringify({ error: "category required" });
+      const server = mcpManager.getMachinaServerName();
+      if (!server) return JSON.stringify({ error: "no pod available", count: 0, results: [] });
+      const sinceIso = new Date(Date.now() - sinceMin * 60_000).toISOString();
+      const result = await mcpManager.callToolDirect(server, "search_documents", {
+        filters: {
+          name: "tv-content-archive",
+          "metadata.category": category,
+          created: { $gte: sinceIso },
+        },
+        sorters: [["created", -1]],
+        page_size: limit,
+      });
+      if (result.isError) return JSON.stringify({ error: result.content, count: 0, results: [] });
+      try {
+        const parsed = JSON.parse(result.content);
+        const docs = (parsed as Record<string, unknown>)?.data ?? [];
+        const innerDocs = (docs as Record<string, unknown>)?.data ?? docs;
+        const items = (Array.isArray(innerDocs) ? innerDocs : []).map((d: Record<string, unknown>) => {
+          const value = (d.value ?? {}) as Record<string, unknown>;
+          return {
+            ts: value.ts,
+            category: value.category,
+            narrative: value.narrative,
+            items: value.items,
+            prompt: value.prompt,
+            image_url: value.image_url,
+          };
+        });
+        return JSON.stringify({ count: items.length, results: items });
+      } catch (e) {
+        return JSON.stringify({ error: e instanceof Error ? e.message : String(e), count: 0, results: [] });
+      }
+    },
+  });
+  toolNames.push("recall_recent_content");
 
   return { registry, mcpManager, toolSet, toolNames };
 }
@@ -612,9 +695,67 @@ async function postTelemetry(url: string, body: Record<string, unknown>): Promis
   }
 }
 
+/**
+ * Persist a content event into the pod's tv-content-archive so the daemon
+ * (or any other consumer) can recall it later. Best-effort, non-fatal.
+ *
+ * One doc per archivable event (broadcast / prediction_markets / fixtures /
+ * news / image). Indexable by date + category for fast MCP search later
+ * via the recall_recent_content tool.
+ */
+async function archiveToPod(
+  mcpManager: McpManager,
+  data: {
+    ts: string;
+    tickId?: string;
+    category: "broadcast" | "prediction_markets" | "fixtures" | "news" | "image";
+    workflow_name: string;
+    narrative?: string;
+    items?: unknown[];
+    prompt?: string;
+    image_url?: string;
+    image_provider?: string;
+  },
+): Promise<void> {
+  const server = mcpManager.getMachinaServerName();
+  if (!server) return;
+  const date = data.ts.slice(0, 10); // "2026-05-11"
+  const content = {
+    ts: data.ts,
+    tickId: data.tickId ?? "",
+    date,
+    category: data.category,
+    workflow_name: data.workflow_name,
+    narrative: data.narrative ?? "",
+    items: data.items ?? [],
+    prompt: data.prompt ?? "",
+    image_url: data.image_url ?? "",
+    image_provider: data.image_provider ?? "",
+    replayed_count: 0,
+  };
+  try {
+    await mcpManager.callToolDirect(server, "create_document", {
+      name: "tv-content-archive",
+      content,
+      metadata: {
+        document_type: "tv-content-archive",
+        date,
+        category: data.category,
+        workflow_name: data.workflow_name,
+        tickId: data.tickId ?? "",
+      },
+    });
+  } catch (err) {
+    console.error(
+      `[operate] archive failed: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
 function makeTailServerPoster(
   tailServer: string,
   jobId: string,
+  mcpManager: McpManager,
   modelId?: string,
   intervalMs?: number,
 ): (evt: TickEvent) => Promise<void> {
@@ -661,9 +802,22 @@ function makeTailServerPoster(
       );
     }
 
-    // Fan out the structured packet — each array becomes a widget event.
+    // Archive the broadcast narrative to the pod (best-effort).
+    if (evt.type === "tick_published" && textOverride !== undefined) {
+      await archiveToPod(mcpManager, {
+        ts: evt.timestamp,
+        tickId: "tickId" in evt && typeof evt.tickId === "string" ? evt.tickId : undefined,
+        category: "broadcast",
+        workflow_name: wfName,
+        narrative: textOverride,
+      });
+    }
+
+    // Fan out the structured packet — each array becomes a widget event
+    // AND an archive doc on the pod.
     if (packet) {
       const ts = evt.timestamp;
+      const tickId = "tickId" in evt && typeof evt.tickId === "string" ? evt.tickId : undefined;
       if (Array.isArray(packet.prediction_markets) && packet.prediction_markets.length > 0) {
         await postTelemetry(url, {
           ts,
@@ -672,6 +826,10 @@ function makeTailServerPoster(
           level: "info",
           workflow_name: wfName,
           items: packet.prediction_markets,
+        });
+        await archiveToPod(mcpManager, {
+          ts, tickId, category: "prediction_markets",
+          workflow_name: wfName, items: packet.prediction_markets,
         });
       }
       if (Array.isArray(packet.fixtures) && packet.fixtures.length > 0) {
@@ -683,6 +841,10 @@ function makeTailServerPoster(
           workflow_name: wfName,
           items: packet.fixtures,
         });
+        await archiveToPod(mcpManager, {
+          ts, tickId, category: "fixtures",
+          workflow_name: wfName, items: packet.fixtures,
+        });
       }
       if (Array.isArray(packet.news) && packet.news.length > 0) {
         await postTelemetry(url, {
@@ -692,6 +854,10 @@ function makeTailServerPoster(
           level: "info",
           workflow_name: wfName,
           items: packet.news,
+        });
+        await archiveToPod(mcpManager, {
+          ts, tickId, category: "news",
+          workflow_name: wfName, items: packet.news,
         });
       }
     }
@@ -778,7 +944,7 @@ async function runOnce(jobId: string): Promise<void> {
       extraFragments: inputs.extraFragments,
       guardOptions: cfg.guardOptions,
       onTickEvent: cfg.tailServer
-        ? makeTailServerPoster(cfg.tailServer, cfg.jobId, inputs.modelId, cfg.intervalMs)
+        ? makeTailServerPoster(cfg.tailServer, cfg.jobId, tools.mcpManager, inputs.modelId, cfg.intervalMs)
         : undefined,
       onToolCall: cfg.tailServer
         ? makeToolCallPoster(cfg.tailServer, cfg.jobId)
@@ -831,7 +997,7 @@ async function runForeground(jobId: string): Promise<void> {
     extraFragments: inputs.extraFragments,
     guardOptions: cfg.guardOptions,
     onTickEvent: cfg.tailServer
-      ? makeTailServerPoster(cfg.tailServer, cfg.jobId, inputs.modelId, cfg.intervalMs)
+      ? makeTailServerPoster(cfg.tailServer, cfg.jobId, tools.mcpManager, inputs.modelId, cfg.intervalMs)
       : (evt) => console.log(JSON.stringify(evt)),
     onToolCall: cfg.tailServer
       ? makeToolCallPoster(cfg.tailServer, cfg.jobId)

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -310,6 +310,38 @@ async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Pro
       const id = randomUUID();
       const filePath = path.join(imagesDir, `${id}.${ext}`);
       fs.writeFileSync(filePath, Buffer.from(image.data, "base64"));
+
+      // Try to upload to GCS via the pod's tv-upload-image-to-gcs workflow.
+      // Returns a public https://storage.googleapis.com/... URL the overlay
+      // can load directly. Falls back to the local tail-server URL if the
+      // pod isn't reachable or the upload fails.
+      const localUrl = cfg.tailServer
+        ? `${cfg.tailServer.replace(/\/+$/, "")}/images/${id}.${ext}`
+        : `file://${filePath}`;
+      let publicUrl = localUrl;
+      const machinaServer = mcpManager.getMachinaServerName();
+      if (machinaServer) {
+        try {
+          const dataUri = `data:image/${ext === "png" ? "png" : "jpeg"};base64,${image.data}`;
+          const res = await mcpManager.callToolDirect(machinaServer, "execute_workflow", {
+            name: "machina-sports-tv-upload-image-to-gcs",
+            context: {
+              image_data: dataUri,
+              filename: `${id}.${ext}`,
+              content_type: `image/${ext === "png" ? "png" : "jpeg"}`,
+            },
+          });
+          if (!res.isError) {
+            const parsed = JSON.parse(res.content) as Record<string, unknown>;
+            const outputs = ((parsed?.data as Record<string, unknown>)?.data as Record<string, unknown>)?.outputs as Record<string, unknown> | undefined;
+            const gcsUrl = typeof outputs?.url === "string" ? outputs.url : "";
+            if (gcsUrl) publicUrl = gcsUrl;
+          }
+        } catch (err) {
+          console.error(`[operate] GCS upload failed (falling back to local): ${err instanceof Error ? err.message : err}`);
+        }
+      }
+
       if (cfg.tailServer) {
         const url = cfg.tailServer.replace(/\/+$/, "") + "/ingest";
         try {
@@ -324,24 +356,18 @@ async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Pro
               model: image.provider === "google" ? "gemini-3.1-flash-image-preview" : "dall-e-3",
               prompt_excerpt: image.prompt,
               workflow_name: `sportsclaw-operate:${cfg.jobId}`,
-              // The tail-server's /images/<filename> route serves files from
-              // IMAGES_DIR (defaults to this same dir for the tv-operator job).
-              // Use the relative path the browser can load via the tail-server.
-              src: `${cfg.tailServer.replace(/\/+$/, "")}/images/${id}.${ext}`,
+              src: publicUrl,
             }),
           });
         } catch { /* non-fatal */ }
       }
       // Archive the image to the pod (best-effort).
-      const imageUrl = cfg.tailServer
-        ? `${cfg.tailServer.replace(/\/+$/, "")}/images/${id}.${ext}`
-        : `file://${filePath}`;
       await archiveToPod(mcpManager, {
         ts: new Date().toISOString(),
         category: "image",
         workflow_name: `sportsclaw-operate:${cfg.jobId}`,
         prompt: image.prompt,
-        image_url: imageUrl,
+        image_url: publicUrl,
         image_provider: image.provider,
       });
     },
@@ -704,7 +730,7 @@ async function postTelemetry(url: string, body: Record<string, unknown>): Promis
  * via the recall_recent_content tool.
  */
 async function archiveToPod(
-  mcpManager: McpManager,
+  mcpManager: McpManager | undefined,
   data: {
     ts: string;
     tickId?: string;
@@ -717,6 +743,10 @@ async function archiveToPod(
     image_provider?: string;
   },
 ): Promise<void> {
+  // Best-effort, non-fatal: a missing mcpManager (test callers, deployments
+  // without an MCP server) or a manager with no Machina pod is treated the
+  // same as "no archive backend available" — silently skip.
+  if (!mcpManager) return;
   const server = mcpManager.getMachinaServerName();
   if (!server) return;
   const date = data.ts.slice(0, 10); // "2026-05-11"
@@ -755,7 +785,7 @@ async function archiveToPod(
 function makeTailServerPoster(
   tailServer: string,
   jobId: string,
-  mcpManager: McpManager,
+  mcpManager?: McpManager,
   modelId?: string,
   intervalMs?: number,
 ): (evt: TickEvent) => Promise<void> {

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -255,7 +255,15 @@ describe("makeTailServerPoster", () => {
   };
 
   it("POSTs to <tailServer>/ingest with a flat tv-telemetry-event shape", async () => {
-    const post = makeTailServerPoster(baseUrl, "tv-operator", "gemini-3.1-pro-preview", 60000);
+    // makeTailServerPoster signature: (tailServer, jobId, mcpManager?, modelId?, intervalMs?)
+    // Pass undefined for mcpManager — archive is best-effort and skipped without one.
+    const post = makeTailServerPoster(
+      baseUrl,
+      "tv-operator",
+      undefined,
+      "gemini-3.1-pro-preview",
+      60000,
+    );
     await post(baseEvent);
     assert.strictEqual(received.length, 1);
     assert.strictEqual(received[0].url, "/ingest");
@@ -268,7 +276,7 @@ describe("makeTailServerPoster", () => {
   });
 
   it("maps tick_started → kind=tick with phase+intervalMs", async () => {
-    const post = makeTailServerPoster(baseUrl, "tv-operator", undefined, 90000);
+    const post = makeTailServerPoster(baseUrl, "tv-operator", undefined, undefined, 90000);
     await post({ ...baseEvent, type: "tick_started" });
     assert.strictEqual(received.length, 1);
     assert.strictEqual(received[0].body.kind, "tick");
@@ -520,6 +528,45 @@ describe("buildOperatorTools generate_image", () => {
         /sent to the user in their channel/i,
         "daemon must NOT use the chat-mode default description",
       );
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOperatorTools — recall_recent_content tool (tv-content-archive)
+// ---------------------------------------------------------------------------
+
+describe("buildOperatorTools recall_recent_content", () => {
+  const baseCfg = {
+    jobId: "test-recall-job",
+    intervalMs: 60_000,
+    personaText: "x",
+    provider: "google",
+  };
+
+  it("registers recall_recent_content in the toolset", async () => {
+    const t = await buildOperatorTools(baseCfg, false);
+    try {
+      assert.ok(
+        t.toolNames.includes("recall_recent_content"),
+        `toolNames did not include recall_recent_content: ${t.toolNames.slice(0, 8).join(", ")}…`,
+      );
+      assert.ok(t.toolSet["recall_recent_content"]);
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
+  });
+
+  it("recall_recent_content returns {error:'category required'} when category is missing", async () => {
+    const t = await buildOperatorTools(baseCfg, false);
+    try {
+      const tool = t.toolSet["recall_recent_content"];
+      assert.ok(tool);
+      const result = await tool.execute({}, { toolCallId: "t1", messages: [] });
+      const parsed = JSON.parse(String(result));
+      assert.match(String(parsed.error), /category required/i);
     } finally {
       await t.mcpManager.disconnectAll().catch(() => {});
     }


### PR DESCRIPTION
## Summary
For a 24/7 channel, dead air is the worst outcome. The operator daemon already produces broadcasts, prediction-market snapshots, fixture lists, news headlines, and generated images every tick — but those were one-shot telemetry events. After they scrolled off the trail, they were gone.

This change persists them to the pod and gives the daemon a queryable memory it can pull from when fresh data is thin.

### What it does
- **`archiveToPod(mcpManager, data)`** — best-effort helper that writes a `tv-content-archive` document on the pod for every archivable event (`broadcast` / `prediction_markets` / `fixtures` / `news` / `image`). Indexed by `metadata.date` and `metadata.category` for fast MCP search. Body carries `ts, tickId, narrative/items/prompt/image_url` as appropriate plus a `replayed_count` counter for future fallback bookkeeping.
- **`makeTailServerPoster` now takes the `McpManager`** and archives the broadcast narrative and each fanned-out packet array alongside the existing tail-server POSTs. Non-fatal: archive failures log but never interrupt the on-air telemetry flow.
- **Image sink in `buildOperatorTools`** also archives after the bytes hit disk and the `kind:"image"` telemetry fires.
- **New tool: `recall_recent_content({category, since_minutes?, limit?})`.** LLM can call it inside a tick to pull prior content from the archive — useful when news is slow or the same headline keeps reappearing. Searches the pod via MCP, returns a JSON `{count, results: [...]}` payload.

### Verified
- `npm run build` clean.
- `sportsclaw operate --job tv-operator --dry-run` reports 352 tools, with `generate_image` and `recall_recent_content` both listed.

### Follow-ups (deferred to separate work)
- Persona doesn't mention `recall_recent_content` yet — the LLM won't call it without an invite. Persona edit lives in the operator job JSON, outside this repo.
- Image bytes still served by the local tail-server's `/images` route. Next sprint: import `machina-templates`' `google-storage` connector, add a `tv-upload-image-to-gcs` workflow, swap the `src` URL in the archive doc + telemetry from localhost to GCS.

## Test plan
- [ ] Smoke: `npm run build` clean; `--dry-run` lists both `generate_image` and `recall_recent_content`.
- [ ] Live: with the daemon running, after one tick that fires a broadcast + structured packet + image, confirm 5 new `tv-content-archive` docs on the pod (broadcast + prediction_markets + fixtures + news + image), each with the correct metadata.category.
- [ ] Live: invoke `recall_recent_content` (via a persona prompt or a direct tool test) with `category=broadcast, since_minutes=60` — expect the most recent broadcast to come back with its narrative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)