### PR TITLE
feat(operate): add recall_library tool — pull tv-content-library by scope

### DIFF
--- a/src/operate.ts
+++ b/src/operate.ts
@@ -423,6 +423,83 @@ async function buildOperatorTools(cfg: OperatorJobConfig, verbose: boolean): Pro
   });
   toolNames.push("recall_recent_content");
 
+  // recall_library — pull evergreen pieces from the pod's tv-content-library
+  // (hand-curated team / group / venue / player / historical / tactical pieces).
+  // Distinct from recall_recent_content (which queries the per-tick archive):
+  // library pieces are persistent, scope-tagged, and recalled when a tick's
+  // lead matches a scope we have canonical framing for.
+  toolSet["recall_library"] = defineTool({
+    description:
+      "Recall evergreen library pieces about a specific scope (team, group, venue, " +
+      "player, historical moment, tactical concept). Call this when the broadcast " +
+      "lead names a scope you have a canonical library piece on — e.g. lead mentions " +
+      "Brazil → recall_library({scope_type:'team', scope_ref:'BRA'}) → get the canonical " +
+      "Hexa-hunt framing to weave into the live narrative. Returns " +
+      "{count, results: [{title, body, scope_type, scope_ref, tags}]} from the pod's " +
+      "tv-content-library document store. Library pieces are persistent (not the " +
+      "per-tick archive — for that use recall_recent_content).",
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {
+        scope_type: {
+          type: "string",
+          enum: ["team", "group", "venue", "player", "historical", "tactical"],
+          description: "Filter by scope type. Omit for any scope.",
+        },
+        scope_ref: {
+          type: "string",
+          description: "Exact scope reference (e.g. 'BRA' for Brazil, 'group-A', 'metlife', 'messi'). Use with scope_type for canonical lookup.",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter to pieces tagged with ANY of these tags (e.g. ['favorites'], ['host'], ['europe']).",
+        },
+        limit: {
+          type: "number",
+          description: "Max pieces to return. Default 3.",
+        },
+      },
+    }),
+    execute: async (args: Record<string, unknown>) => {
+      const scope_type = typeof args.scope_type === "string" ? args.scope_type : undefined;
+      const scope_ref = typeof args.scope_ref === "string" ? args.scope_ref : undefined;
+      const tags = Array.isArray(args.tags) ? args.tags.filter((t): t is string => typeof t === "string") : undefined;
+      const limit = typeof args.limit === "number" ? args.limit : 3;
+      const server = mcpManager.getMachinaServerName();
+      if (!server) return JSON.stringify({ error: "no pod available", count: 0, results: [] });
+      const filters: Record<string, unknown> = { name: "tv-content-library" };
+      if (scope_type) filters["metadata.scope_type"] = scope_type;
+      if (scope_ref) filters["metadata.scope_ref"] = scope_ref;
+      if (tags && tags.length > 0) filters["value.tags"] = { $in: tags };
+      const result = await mcpManager.callToolDirect(server, "search_documents", {
+        filters,
+        sorters: [["created", -1]],
+        page_size: limit,
+      });
+      if (result.isError) return JSON.stringify({ error: result.content, count: 0, results: [] });
+      try {
+        const parsed = JSON.parse(result.content);
+        const docs = (parsed as Record<string, unknown>)?.data ?? [];
+        const innerDocs = (docs as Record<string, unknown>)?.data ?? docs;
+        const items = (Array.isArray(innerDocs) ? innerDocs : []).map((d: Record<string, unknown>) => {
+          const value = (d.value ?? {}) as Record<string, unknown>;
+          return {
+            title: value.title,
+            body: value.body,
+            scope_type: value.scope_type,
+            scope_ref: value.scope_ref,
+            tags: value.tags,
+          };
+        });
+        return JSON.stringify({ count: items.length, results: items });
+      } catch (e) {
+        return JSON.stringify({ error: e instanceof Error ? e.message : String(e), count: 0, results: [] });
+      }
+    },
+  });
+  toolNames.push("recall_library");
+
   return { registry, mcpManager, toolSet, toolNames };
 }
 

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -572,3 +572,46 @@ describe("buildOperatorTools recall_recent_content", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// buildOperatorTools — recall_library tool (tv-content-library)
+// ---------------------------------------------------------------------------
+
+describe("buildOperatorTools recall_library", () => {
+  const baseCfg = {
+    jobId: "test-recall-library-job",
+    intervalMs: 60_000,
+    personaText: "x",
+    provider: "google",
+  };
+
+  it("registers recall_library in the toolset", async () => {
+    const t = await buildOperatorTools(baseCfg, false);
+    try {
+      assert.ok(
+        t.toolNames.includes("recall_library"),
+        `toolNames did not include recall_library: ${t.toolNames.slice(0, 8).join(", ")}…`,
+      );
+      assert.ok(t.toolSet["recall_library"]);
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
+  });
+
+  it("recall_library description mentions tv-content-library + canonical/library framing", async () => {
+    // The description must distinguish this tool from recall_recent_content
+    // so the LLM picks the right tool. Pin the key wording.
+    const t = await buildOperatorTools(baseCfg, false);
+    try {
+      const tool = t.toolSet["recall_library"];
+      assert.ok(tool);
+      const desc = String(tool.description ?? "");
+      assert.match(desc, /tv-content-library/i);
+      assert.match(desc, /persistent|evergreen|canonical/i);
+      // Ensures the LLM knows when NOT to pick this tool
+      assert.match(desc, /recall_recent_content/i);
+    } finally {
+      await t.mcpManager.disconnectAll().catch(() => {});
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Companion to `recall_recent_content`. While that tool queries the per-tick archive (broadcasts / markets / fixtures / news / images), `recall_library` queries the **persistent hand-curated content library** — team profiles, group previews, venue cards, player profiles, historical moments, tactical concepts.

### Signature
```ts
recall_library({
  scope_type?: 'team' | 'group' | 'venue' | 'player' | 'historical' | 'tactical',
  scope_ref?: string,   // 'BRA', 'group-A', 'metlife', 'messi'
  tags?: string[],      // any-match
  limit?: number        // default 3
})
```

Returns `{count, results: [{title, body, scope_type, scope_ref, tags}]}` from the pod's `tv-content-library` document store.

### When the LLM calls it
Updated persona invites the tool when the broadcast lead names a known scope. Examples:
- Lead mentions Brazil → `recall_library({scope_type:'team', scope_ref:'BRA'})` → quote the canonical Hexa-hunt framing
- Lead mentions hosting → `recall_library({tags:['host']})` → pull all 3 host-nation pieces

### Verified live
After landing this branch locally and pointing the tv-operator daemon at it:
- 12 team profiles seeded in `tv-content-library` (Brazil / Argentina / France / USA / England / Mexico / Canada / Germany / Spain / Portugal / Netherlands / Japan), authored via the new `machina-sports-tv-generate-library-piece` pod workflow.
- `--dry-run` lists `recall_library` in the resolved tool set.
- `--once` tick: daemon called `recall_library({scope_type:'team', scope_ref:'BRA'})` (280ms), got the Brazil piece, and quoted *"Brazil's 'Hexa Hunt' begins under Carlo Ancelotti"* into the live broadcast narrative — the canonical library framing surfacing through the daemon for the first time.

## Test plan
- [ ] Smoke: `npm run build` clean, `--dry-run` lists `recall_library`.
- [ ] Live: with the persona inviting the tool and at least one `tv-content-library` doc seeded on the pod, run `--once`. Confirm at least one tick references library content (look for telemetry `ingest · recall_library · ok` in the trail).
- [ ] Edge: call with `scope_type:'team', scope_ref:'NONEXISTENT'` — expect `{count:0, results:[]}` not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)