### PR TITLE
chore(operate): deprecate bundled broadcast sink + implicit tailServer fallback

### DIFF
--- a/src/operator-sink.ts
+++ b/src/operator-sink.ts
@@ -146,8 +146,10 @@ export const noopSink: OperatorSinkPlugin = {
  * Resolve which sink to use for a given job config. Resolution order:
  *
  *   1. cfg.sink === "noop"      → noopSink (built-in)
- *   2. cfg.sink === "broadcast" → bundled broadcast sink (deprecated path,
- *                                 to be removed when TV ships its own pkg)
+ *   2. cfg.sink === "broadcast" → bundled broadcast sink — DEPRECATED. Emits
+ *                                 a stderr warning. Install the
+ *                                 @machina-sports/tv-operator-sink package
+ *                                 and set cfg.sink to it instead.
  *   3. cfg.sink begins with "./", "../" or "/", or ends in ".js" / ".mjs"
  *                               → filesystem path. Dynamic-import relative to
  *                                 process.cwd() (or use as-is when absolute).
@@ -155,7 +157,9 @@ export const noopSink: OperatorSinkPlugin = {
  *                                 import — the package must be installed
  *                                 alongside sportsclaw (workspace dep, npm
  *                                 link, or published).
- *   5. cfg.tailServer is set    → backward-compat: use bundled broadcast sink
+ *   5. cfg.tailServer is set    → DEPRECATED implicit fallback to the
+ *                                 bundled broadcast sink. Same warning as
+ *                                 case 2.
  *   6. otherwise                → noopSink
  *
  * External modules (cases 3 and 4) must expose the sink as one of:
@@ -171,6 +175,7 @@ export async function resolveSink(
 ): Promise<OperatorSinkPlugin> {
   if (cfg.sink === "noop") return noopSink;
   if (cfg.sink === "broadcast") {
+    emitBroadcastDeprecationWarning("explicit");
     const { broadcastSink } = await import("./sinks/broadcast.js");
     return broadcastSink;
   }
@@ -180,10 +185,43 @@ export async function resolveSink(
   // Backward-compat: legacy configs without `sink` but with a `tailServer`
   // got the broadcast sink implicitly. Preserve that.
   if (cfg.tailServer) {
+    emitBroadcastDeprecationWarning("implicit");
     const { broadcastSink } = await import("./sinks/broadcast.js");
     return broadcastSink;
   }
   return noopSink;
+}
+
+// ---------------------------------------------------------------------------
+// Deprecation warning
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit a one-line stderr warning when the bundled broadcast sink resolves.
+ * Fires for both code paths:
+ *   - "explicit": `cfg.sink === "broadcast"` — caller asked for it by name
+ *   - "implicit": `cfg.tailServer` set without `cfg.sink` — legacy fallback
+ *
+ * Both will be removed in a follow-up PR after a soak window. The migration
+ * target is the @machina-sports/tv-operator-sink package, which exposes the
+ * same plugin at its public name.
+ *
+ * Suppress via env: SPORTSCLAW_SUPPRESS_DEPRECATION=1 (for deployments still
+ * in transition that don't want warning lines polluting their logs).
+ */
+function emitBroadcastDeprecationWarning(mode: "explicit" | "implicit"): void {
+  if (process.env.SPORTSCLAW_SUPPRESS_DEPRECATION === "1") return;
+  const reason =
+    mode === "explicit"
+      ? `cfg.sink="broadcast" resolves to the BUNDLED broadcast sink.`
+      : `cfg.tailServer is set but cfg.sink is not — falling back to the BUNDLED broadcast sink.`;
+  console.error(
+    `[sportsclaw] DEPRECATED: ${reason} ` +
+      `The bundled broadcast sink is scheduled for removal. ` +
+      `Install @machina-sports/tv-operator-sink and set ` +
+      `\`"sink": "@machina-sports/tv-operator-sink"\` in your operator job config. ` +
+      `Suppress this warning with SPORTSCLAW_SUPPRESS_DEPRECATION=1.`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/test/operator-sink.test.mjs
+++ b/test/operator-sink.test.mjs
@@ -8,9 +8,28 @@
  */
 
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 
 import { noopSink, resolveSink } from "../dist/operator-sink.js";
+
+// ---------------------------------------------------------------------------
+// stderr capture — the bundled broadcast sink emits a deprecation warning
+// on every resolution. Capture stderr per-test so the assertions can pin it
+// AND so the warning doesn't pollute the test run output.
+// ---------------------------------------------------------------------------
+
+function captureStderr() {
+  const original = process.stderr.write;
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  };
+  return {
+    text: () => chunks.join(""),
+    restore: () => { process.stderr.write = original; },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // noopSink contract
@@ -40,24 +59,38 @@ describe("resolveSink", () => {
     personaText: "x",
   };
 
+  let capture;
+  beforeEach(() => {
+    capture = captureStderr();
+  });
+  afterEach(() => {
+    capture.restore();
+  });
+
   it("returns noopSink for cfg.sink=\"noop\"", async () => {
     const s = await resolveSink({ ...baseCfg, sink: "noop" });
     assert.strictEqual(s.name, "noop");
+    assert.strictEqual(capture.text(), "", "noop must not emit any deprecation warning");
   });
 
-  it("returns the broadcast sink for cfg.sink=\"broadcast\"", async () => {
+  it("returns the broadcast sink for cfg.sink=\"broadcast\" (with deprecation warning)", async () => {
     const s = await resolveSink({ ...baseCfg, sink: "broadcast" });
     assert.strictEqual(s.name, "broadcast");
+    assert.match(capture.text(), /DEPRECATED/);
+    assert.match(capture.text(), /@machina-sports\/tv-operator-sink/);
   });
 
-  it("falls back to broadcast when cfg.tailServer is set (backward compat)", async () => {
+  it("falls back to broadcast when cfg.tailServer is set (with deprecation warning)", async () => {
     const s = await resolveSink({ ...baseCfg, tailServer: "http://localhost:8090" });
     assert.strictEqual(s.name, "broadcast");
+    assert.match(capture.text(), /DEPRECATED/);
+    assert.match(capture.text(), /falling back to the BUNDLED broadcast sink/i);
   });
 
-  it("returns noopSink when neither sink nor tailServer is set", async () => {
+  it("returns noopSink when neither sink nor tailServer is set (no warning)", async () => {
     const s = await resolveSink(baseCfg);
     assert.strictEqual(s.name, "noop");
+    assert.strictEqual(capture.text(), "");
   });
 
   it("prefers cfg.sink over cfg.tailServer when both are set", async () => {
@@ -67,6 +100,20 @@ describe("resolveSink", () => {
       tailServer: "http://localhost:8090",
     });
     assert.strictEqual(s.name, "noop");
+    assert.strictEqual(capture.text(), "");
+  });
+
+  it("SPORTSCLAW_SUPPRESS_DEPRECATION=1 silences the warning", async () => {
+    const prev = process.env.SPORTSCLAW_SUPPRESS_DEPRECATION;
+    process.env.SPORTSCLAW_SUPPRESS_DEPRECATION = "1";
+    try {
+      const s = await resolveSink({ ...baseCfg, sink: "broadcast" });
+      assert.strictEqual(s.name, "broadcast");
+      assert.strictEqual(capture.text(), "");
+    } finally {
+      if (prev === undefined) delete process.env.SPORTSCLAW_SUPPRESS_DEPRECATION;
+      else process.env.SPORTSCLAW_SUPPRESS_DEPRECATION = prev;
+    }
   });
 
   // External sink resolution (filesystem path + npm package name) is


### PR DESCRIPTION
The broadcast sink shipped out as a standalone package from machina-sports-tv (\`@machina-sports/tv-operator-sink\`, see TV-side PR). The bundled copy at \`src/sinks/broadcast.ts\` is now a backward-compat shim. This PR adds a stderr warning so deployments still using the bundled path get an explicit migration prompt.

## Two trigger paths, same warning

| Path | Trigger | Diagnostic |
|---|---|---|
| Explicit | \`cfg.sink === \"broadcast\"\` | \`cfg.sink=\"broadcast\" resolves to the BUNDLED broadcast sink.\` |
| Implicit | \`cfg.tailServer\` set without \`cfg.sink\` | \`cfg.tailServer is set but cfg.sink is not — falling back to the BUNDLED broadcast sink.\` |

Both warnings end with the same actionable advice:

> The bundled broadcast sink is scheduled for removal. Install \`@machina-sports/tv-operator-sink\` and set \`\"sink\": \"@machina-sports/tv-operator-sink\"\` in your operator job config. Suppress this warning with \`SPORTSCLAW_SUPPRESS_DEPRECATION=1\`.

## Suppression

Set \`SPORTSCLAW_SUPPRESS_DEPRECATION=1\` to silence the warning for deployments still in transition that don't want log noise.

## Tests

- Existing \`resolveSink\` tests now capture stderr per-test (via a small \`captureStderr()\` helper). Three things this gives us:
  - Test output isn't polluted with deprecation lines
  - Each test can pin warning presence / absence (positive AND negative assertions)
  - The suppress-env case is testable
- **+1 test**: \`SPORTSCLAW_SUPPRESS_DEPRECATION=1 silences the warning\`
- Full suite: **442 pass** (was 441)

## Live verification

\`\`\`
$ node dist/index.js operate --dry-run --job _test-deprecated
[sportsclaw] DEPRECATED: cfg.sink=\"broadcast\" resolves to the BUNDLED broadcast
sink. The bundled broadcast sink is scheduled for removal. Install
@machina-sports/tv-operator-sink and set \`\"sink\": \"@machina-sports/tv-operator-sink\"\`
in your operator job config. Suppress this warning with
SPORTSCLAW_SUPPRESS_DEPRECATION=1.
sink:     broadcast
\`\`\`

## Migration path

A deployment on the bundled sink today only needs to change one line in its operator job config:

\`\`\`diff
- \"sink\": \"broadcast\"
+ \"sink\": \"@machina-sports/tv-operator-sink\"
\`\`\`

The plugin's identity name stays \`\"broadcast\"\` (visible in \`--dry-run\` output), so dashboards / log filters that key on the sink name don't break.

## Sequencing

- **TV-side PR** (open in machina-sports-tv): publishes \`@machina-sports/tv-operator-sink\`. Verified end-to-end against the bundled implementation — byte-identical telemetry, all three tools register.
- **This PR**: deprecate, soak for ~2 weeks. Warnings give existing operators a window to migrate without surprise breakage.
- **Removal PR** (later): drop \`src/sinks/broadcast.ts\` + the \`cfg.tailServer\`-implicit-broadcast fallback in \`resolveSink\`. After this lands, \`cfg.sink\` is the only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)