### PR TITLE
feat(openshell): opt-in NVIDIA OpenShell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ sportsclaw is built for:
 - **Prototyping sports AI products** — Test whether an AI sports feature is viable before building infrastructure. sportsclaw gives you the agent loop and data access so you can focus on the product idea.
 - **Learning how agents work** — The core loop is ~220 lines on the Vercel AI SDK. Read it, modify it, extend it.
 
+### Optional: Run inside NVIDIA OpenShell
+
+For deployments that want sandboxed execution and policy-enforced LLM routing, SportsClaw operator daemons can run inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with calls routed through the Privacy Router. **This is opt-in via the job config** — direct LLM calls remain the default for everyone else. See [`openshell/README.md`](openshell/README.md) for the runbook and [`docs/openshell-integration-plan.md`](docs/openshell-integration-plan.md) for the integration design.
+
 ### Built-in Sports Data Skills
 
 sportsclaw ships with **14 sports data skills** out of the box, powered by [`sports-skills`](https://sports-skills.sh):

--- a/docs/openshell-integration-plan.md
+++ b/docs/openshell-integration-plan.md
@@ -1,0 +1,272 @@
+# OpenShell Integration Plan — Phase 1
+
+**Status:** draft, decisions D1–D5 captured (2026-05-19), awaiting overall plan approval before Phase 2.
+**Prereq:** [Phase 0 research](./openshell-research.md).
+**Scope:** engine-side integration design only. No production code in this document.
+
+## Decisions captured (2026-05-19)
+
+- **D1 Gemini** — Drop Gemini for OpenShell-enabled jobs. Validator errors on `openshell` block + `provider: "google"`. Existing direct-call Gemini users unaffected.
+- **D2 Multi-provider** — Accept the Privacy Router's one-provider-one-model-per-gateway constraint for v1. Multi-provider ticks remain a direct-call feature.
+- **D3 Engine.ts policy** — Relaxed. Centralizing the three duplicated `resolveModel` helpers is now on the table as a separate follow-up. The OpenShell plan itself does not require engine.ts changes (env-var seam stands).
+- **D4 Plugin location** — Subdirectory of sportsclaw (`sportsclaw/openshell/`). No separate package or repo. Engine and OpenShell recipe ship in the same release. See [§4](#4-engine-vs-sportsclawopenshell-subdirectory) and [Risk R8](#risks).
+- **D5 Telemetry** — Optional `inferenceRoute` field on existing tick events. No new event type, no sink contract change.
+
+---
+
+## TL;DR
+
+The cleanest integration uses Vercel AI SDK's **environment-variable-driven base URL override** as the routing seam, plus a new optional `openshell` block in the job config that drives an **opt-in launcher** which sets those env vars before the daemon constructs models. Engine internals (`engine.ts`, `heartbeat.ts`, `subagent.ts`, `router.ts`) require **zero source changes** for the default direct-call path. The OpenShell-specific image, policy, and sandbox runbook ship as a **separate `sportsclaw-openshell` plugin/recipe** outside this repo so the engine stays vendor-neutral.
+
+Two architectural decisions need a human call before Phase 2 starts (see [Decisions needed](#decisions-needed)).
+
+---
+
+## Grounding facts from the current codebase
+
+These ground every design choice below. I checked the code, not memory.
+
+- The Vercel AI SDK is wired in via three packages: `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google`. The default singleton imports (`anthropic`, `openai`, `google`) read their base URL from env vars (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GOOGLE_GENERATIVE_AI_BASE_URL`) at construction time.
+- `generateText` is called from at least seven files: `engine.ts` (≥6 sites), `heartbeat.ts`, `router.ts`, `operator-daemon.ts`, `subagent.ts`, `setup.ts`.
+- The `provider → model` switch (`anthropic(modelId)` / `openai(modelId)` / `google(modelId)`) is duplicated in three places: `engine.ts:194`, `operate.ts:394`, `setup.ts:51`. The comment at `operate.ts:391–392` claims an older spec forbade engine.ts changes — see [Risk R3](#risks).
+- The job config (`operator-config.ts:24-`) already has optional `provider` and `model` fields with sensible defaults. The work envelope explicitly allows adding a new optional field; that's our seam.
+- `operate.ts` is the launcher. It loads the config, sets env via `applyConfigToEnv`, resolves the sink, and calls `createOperatorDaemon`. This is the only file that needs new logic for the launcher path.
+- `TickEvent` (operator-daemon.ts:80) is an open discriminated union — adding a new event type or extending an existing one with optional fields does not break the sink plugin contract (sinks subscribe to events; unknown fields are ignored by structural typing).
+
+---
+
+## 1. Where the provider abstraction lives
+
+### The seam: env-var-driven base URL override
+
+The Vercel AI SDK default exports honor `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, and `GOOGLE_GENERATIVE_AI_BASE_URL` at construction time. We exploit this:
+
+- Production code keeps calling `anthropic(modelId)` / `openai(modelId)` / `google(modelId)` exactly as today.
+- The launcher (`operate.ts`) sets the appropriate base URL env var **before** any provider singleton is constructed (i.e. before the daemon's first model resolution).
+- When `https://inference.local` is set as the base URL, every call routes through the Privacy Router.
+
+This means **engine.ts is not modified for the default path.** The env-var trick is invisible to anyone who isn't running under OpenShell.
+
+### Constraint imposed by Privacy Router
+
+The Privacy Router exposes **one provider+model per gateway** (Phase 0 §a). Two consequences:
+
+1. If the gateway is configured for Anthropic, only `POST /v1/messages` calls succeed. `openai()` SDK calls would route to `inference.local/v1/chat/completions` which is rejected. We therefore need the job config's `provider` to match the gateway's configured provider. The launcher validates this on startup and fails fast.
+2. Inside a single OpenShell sandbox there is no native way to call Anthropic *and* OpenAI *and* Gemini in the same tick. For Phase 2 we standardize on **one provider per OpenShell-enabled job** and accept that multi-provider ticks remain a direct-call feature only.
+
+### Gemini
+
+The `@ai-sdk/google` provider does **not** speak the same protocol the Privacy Router exposes. Three options, exactly as in Phase 0:
+
+- **Option A (recommended for the case study):** standardize Machina Sports TV on a Nemotron-local + Anthropic-frontier story. Drop Gemini from the OpenShell-enabled job config. Existing Gemini users with no `openshell` block see no change.
+- **Option B:** allow Gemini under OpenShell but route it direct (network policy allow + bypass Privacy Router). Asterisk on the NVIDIA marketing story.
+- **Option C:** swap `@ai-sdk/google` for Google's OpenAI-compat endpoint when OpenShell mode is on. More engineering, brittle behaviour delta vs. native Gemini.
+
+**Default plan: Option A.** Surface in config as a startup error when `provider: "google"` and `openshell` block is present together.
+
+### Why not a centralized `resolveModel`?
+
+We could refactor the three duplicated `resolveModel` helpers into one. We don't need to for OpenShell — env-var routing already covers the case. Doing the refactor opportunistically inside this work would couple the OpenShell change to a broader cleanup; better to keep the diff narrow and propose the refactor as a separate follow-up.
+
+---
+
+## 2. Routing telemetry
+
+OpenShell's gateway already logs every routing decision (`openshell logs <sandbox> --tail`). We don't reimplement that. What the engine adds:
+
+### A single `inference_route` field on `TickEvent`s that go through `generateText`
+
+Add an optional field on the `tick_started` / `tick_completed` (or whatever the relevant tick events are — re-check during implementation) event payload:
+
+```
+inferenceRoute?: {
+  via: "direct" | "openshell";
+  baseUrl?: string;       // present when via === "openshell"
+  provider: LLMProvider;
+  model: string;
+}
+```
+
+Sinks that want to render or forward this (tail-server, console) opt in by reading the field. Sinks that don't care ignore it. **No sink plugin contract change** — the field is optional and additive.
+
+### Startup banner
+
+When the launcher detects `openshell` config, log a one-line banner before the first tick:
+
+```
+[operate] openshell mode: routing inference via https://inference.local (provider=anthropic, model=claude-...)
+```
+
+This is the user-visible signal that the env-var trick is in effect.
+
+### Why not richer telemetry?
+
+The Privacy Router's own log stream is more authoritative than anything we'd emit (it sees every request, including credential injection metadata). Duplicating it in the engine would invite drift. Defer richer telemetry to a follow-up if there's demand.
+
+---
+
+## 3. How the optional-at-install constraint is enforced
+
+Three layers:
+
+### Layer 1 — runtime dependency layer
+
+- Engine ships with **no new npm dependencies.** The env-var trick uses existing `@ai-sdk/*` packages.
+- Engine ships with **no `openshell` CLI dependency.** The launcher does not shell out to `openshell ...`; it just reads config and sets env vars. Anyone running on a laptop with no `openshell` binary on PATH is unaffected.
+- A separate `sportsclaw-openshell` plugin (see §4) holds the Dockerfile, policy YAML, and sandbox lifecycle docs. The engine repo has no knowledge of it beyond a README pointer.
+
+### Layer 2 — config layer
+
+- New optional `openshell?: OpenShellConfig` field on `OperatorJobConfig`. Its absence is the default; behaviour is identical to today's engine.
+- When `openshell` is present, validator enforces:
+  - `provider` is set and matches the gateway's expected provider (Anthropic/OpenAI/NVIDIA).
+  - `model` is set (no implicit defaults — OpenShell uses one model per gateway, so be explicit).
+  - `provider !== "google"` (unless we accept Option B/C from §1).
+- Config-level migration: existing config files don't have the field, validator skips the block, daemon launches with direct LLM calls. **Zero changes for current users.**
+
+Rough shape (for design discussion, not literal source):
+```
+openshell?: {
+  // Whether to set ANTHROPIC_BASE_URL / OPENAI_BASE_URL on launch.
+  // Default: when this block exists, true.
+  enabled?: boolean;
+
+  // The URL the launcher sets as the SDK base URL. Defaults to
+  // "https://inference.local" — the only value that makes sense inside
+  // an OpenShell sandbox. Field is here for future use (e.g. pointing
+  // at a LiteLLM-on-host proxy that mimics inference.local).
+  baseUrl?: string;
+};
+```
+
+### Layer 3 — install/packaging layer
+
+- The engine's existing Dockerfile stays as the deployable artifact. The OpenShell case-study image either:
+  - is the same Dockerfile run via `openshell sandbox create --from <sportsclaw-image>`, or
+  - is a thin downstream image in the `sportsclaw-openshell` plugin repo that pins a known-good sportsclaw version + bundled `policy.yaml`.
+- No changes to `package.json` deps. No changes to `npm install` flow.
+
+---
+
+## 4. Engine vs. `sportsclaw/openshell/` subdirectory
+
+Per D4, the OpenShell recipe lives as a subdirectory of this repo, not a separate package. The split is therefore between **engine source** (existing TypeScript) and a **recipe directory** (Dockerfile, YAML, runbook).
+
+### Engine source (existing layout)
+
+- The optional `openshell` config block (schema + validator) — `src/operator-config.ts`.
+- The launcher logic that reads the block and sets env vars — `src/operate.ts`.
+- The optional `inferenceRoute` field on `TickEvent` payloads — `src/operator-daemon.ts`.
+- The startup banner — `src/operate.ts`.
+- A README section explaining OpenShell mode and pointing at `openshell/` for the recipe.
+
+Approximate engine-side diff: ~80–150 LOC across `operator-config.ts`, `operate.ts`, `operator-daemon.ts`, plus tests.
+
+### `sportsclaw/openshell/` subdirectory (new)
+
+- `openshell/policy.yaml` — reference policy with network rules for known sink dependencies (YouTube Live, image-gen APIs, tail-server URL).
+- `openshell/Dockerfile` — a thin downstream image (or a build script that produces one) that combines the repo-root Dockerfile + the Machina Sports TV sink + an entry point that respects the `openshell` config block.
+- `openshell/README.md` — runbook: install OpenShell, create gateway, configure provider, `openshell sandbox create --from sportsclaw-openshell:latest`, expose tail-server.
+- `openshell/models.md` — the Nemotron model-id table (which Nemotron variant pairs with which gateway provider type).
+- Optional: `openshell/generate-policy.ts` — a thin `policy.yaml` synthesizer from sink manifest. Could be deferred and replaced by OpenShell's `generate-sandbox-policy` agent skill.
+
+### Implications of the subdirectory choice (D4)
+
+- **Optional-at-install preserved.** The subdirectory ships as **static files only** — `Dockerfile`, `policy.yaml`, `README.md`, `models.md`. No JavaScript in the npm install path, no new `package.json` dependencies, no `openshell` CLI required on PATH for current users. The engine code paths added in Phase 2a (config block, env-var swap, telemetry field) are **inert** unless a job config opts in via an `openshell` block. A laptop user running `sportsclaw operate --job foo` with no OpenShell config sees zero behavioral change. This honors the hard constraint from the work envelope.
+- **Not vendor-locked.** OpenShell is Apache 2.0, generic, and supports Anthropic, any OpenAI-compatible provider, NVIDIA API Catalog, and local backends (Ollama, vLLM, LM Studio). The subdirectory is named after the *runtime*, not the vendor — same way a `docker/` or `k8s/` subdirectory would be. The Nemotron model table in `openshell/models.md` documents one supported configuration; the recipe itself works with non-NVIDIA backends. The NVIDIA co-marketing story is built *on top of* this neutral integration, not baked into it.
+- **Coupled releases.** The engine and OpenShell recipe ship in the same npm release. A breaking change to the recipe forces an engine release. Mitigate by treating `openshell/` as documentation-grade — versioned only when behavior actually changes.
+- **External tenants pull the recipe whether they use it or not.** Static files, ~tens of KB. Negligible cost.
+- **Faster iteration for the case study.** No second-repo bootstrap, no cross-repo PR coordination, no separate CI. For the World Cup deadline this matters.
+- See [Risk R8](#risks) for the coupling concern.
+
+---
+
+## 5. Migration path
+
+Three phases of engine work, each independently reviewable.
+
+### Phase 2a — config + launcher (minimum to validate the end-to-end path)
+
+1. Extend `OperatorJobConfig` with optional `openshell` field. Add validator entry.
+2. In `operate.ts`, after `applyConfigToEnv`, branch on `cfg.openshell`: when present and enabled, set `ANTHROPIC_BASE_URL` (or whichever provider matches `cfg.provider`) to `cfg.openshell.baseUrl ?? "https://inference.local"`.
+3. Add a startup banner log.
+4. Add a small fixture-style integration test: load a config with `openshell` block, assert env vars are set, assert provider construction picks up the new base URL.
+
+Gate: a sportsclaw daemon launched against a stub HTTP server (mimicking `inference.local`) should successfully route a tick through the stub.
+
+### Phase 2b — telemetry
+
+1. Add `inferenceRoute` to tick events (optional, additive).
+2. Update the bundled noop sink to log the field when present. Don't touch external sink contract — third-party sinks ignore it.
+
+Gate: a tick with `openshell` enabled emits an event with `inferenceRoute.via === "openshell"`.
+
+### Phase 2c — `sportsclaw/openshell/` subdirectory
+
+Added to this repo (per D4). New files only — no edits to existing engine source beyond the root README pointer added in Phase 2a.
+
+Contents per [§4](#4-engine-vs-sportsclawopenshell-subdirectory): `policy.yaml`, `Dockerfile`, `README.md` (runbook), `models.md`.
+
+Gate: end-to-end demo — Machina Sports TV job config with `openshell` block, run inside `openshell sandbox create --from sportsclaw-openshell:latest`, ticks publish through Privacy Router to Nemotron + Anthropic.
+
+### What's NOT in scope for Phase 2
+
+- The multi-provider-per-tick problem (Phase 0 §optional-at-install leak #2). Defer; single-provider-per-job is the constraint for v1.
+- Per-call routing decisions (LiteLLM-on-host pattern). Defer.
+- Refactoring the three duplicated `resolveModel` helpers. Independently valuable but not load-bearing for OpenShell.
+- Engine.ts changes. The env-var seam avoids them.
+- Gemini compatibility under OpenShell. Currently Option A (drop Gemini for OpenShell-enabled jobs); revisit if a tenant needs it.
+
+---
+
+## 6. Risks
+
+### R1 — Privacy Router rejects calls we didn't anticipate
+
+Privacy Router enforces a strict header allowlist and a strict route allowlist per provider. If `@ai-sdk/anthropic` sends a header we haven't checked is allowed (e.g. a custom user-agent or a new beta header), the router strips it silently — most paths still work because Anthropic SDKs treat those headers as cosmetic, but a future SDK upgrade could surprise us. **Mitigation:** pin the `@ai-sdk/anthropic` version when shipping the OpenShell-enabled case study; have the plugin's CI run a smoke test against a live or mocked `inference.local`.
+
+### R2 — 60s default timeout is short for long reasoning models
+
+Privacy Router defaults to 60s per upstream call. Nemotron-3-Super-120B at long thinking phases can exceed that. **Mitigation:** document `openshell inference set --timeout 300` in the plugin runbook. Surface it as an explicit choice in the recipe.
+
+### R3 — Engine.ts modification policy (resolved)
+
+Per D3, the prior prohibition is relaxed. The OpenShell plan still avoids engine.ts changes via the env-var seam — so this risk is dormant for Phase 2. The follow-up to centralize the three duplicated `resolveModel` helpers (`engine.ts:194`, `operate.ts:394`, `setup.ts:51`) is now permissible as a separate task; out of scope for this plan.
+
+### R4 — `inference.local` is sandbox-only
+
+The Privacy Router is only reachable from inside an OpenShell sandbox. A SportsClaw daemon running on the host with `ANTHROPIC_BASE_URL=https://inference.local` will fail DNS resolution. This is fine if the launcher only sets the env var when actually inside a sandbox, but if a user copies an OpenShell config to a host-only environment they'll get cryptic errors. **Mitigation:** the launcher does a startup probe — if `openshell` is configured but `inference.local` doesn't resolve, fail with an explicit error message before the first tick.
+
+### R5 — Sink contract drift via `inferenceRoute`
+
+If we accidentally promote `inferenceRoute` from optional to required, we break every external sink. **Mitigation:** it's optional and additive. Document this explicitly in the tick-event type comments; cover it in a sink-contract regression test.
+
+### R6 — Privacy Router hot-reload boundary
+
+Hot-reloading the inference provider (`openshell inference update`) takes ~5s. If a tick is in-flight during a reload, the streamed response is closed and reissued. Existing connection-scoped streams are not interrupted. **Mitigation:** for the case study, don't change providers mid-broadcast. For ops docs, call out that `inference update` is safe but causes a brief retry window.
+
+### R7 — Single-provider-per-gateway becomes a hard wall
+
+If Machina Sports TV genuinely needs both Nemotron (for cheap classification) and Claude (for narration) in the same tick — and the case study probably will — single-gateway-single-provider isn't enough. Per D2 we've accepted the constraint for v1, but it might bite during Phase 2c. **Mitigation:** scope the v1 demo to single-provider ticks. If multi-provider becomes a blocker, NemoClaw-style LiteLLM-on-host is the established workaround. Per D4, that workaround would also live under `sportsclaw/openshell/` rather than as a separate plugin.
+
+### R8 — Subdirectory coupling (D4)
+
+`sportsclaw/openshell/` ships in the engine's npm release. Two failure modes: (1) a recipe-only change (e.g. `policy.yaml` update) forces an engine version bump, polluting release history; (2) an engine release breaks the recipe and we don't notice because there's no separate CI gate. **Mitigation:** treat `openshell/` as documentation-grade — version it via doc-update commits only, never publish-blocking. Add a CI smoke test that builds the `openshell/Dockerfile` and runs `--validate` against a fixture job config; failure blocks engine release.
+
+---
+
+## Decisions captured
+
+All five decisions resolved 2026-05-19 (see top of doc). Summary:
+
+| ID | Topic | Decision |
+|----|---|---|
+| D1 | Gemini under OpenShell | Drop for OpenShell jobs; validator errors |
+| D2 | Multi-provider per tick | Accept single-provider constraint for v1 |
+| D3 | Engine.ts modification | Relaxed; centralization permissible as separate follow-up |
+| D4 | Plugin location | Subdirectory of sportsclaw (`sportsclaw/openshell/`) |
+| D5 | Telemetry shape | Optional `inferenceRoute` field on existing tick events |
+
+---
+
+**Stopping here as instructed. No production code written. Awaiting overall plan approval before Phase 2a.**

--- a/docs/openshell-research.md
+++ b/docs/openshell-research.md
@@ -1,0 +1,177 @@
+# OpenShell / NemoClaw Research — Phase 0
+
+**Status:** complete, awaiting human review before Phase 1.
+**Date:** 2026-05-19.
+**Scope:** answer the four research questions, document what's verified vs. inferred, surface tensions for the optional-at-install constraint.
+
+---
+
+## Sources consulted
+
+Primary (verbatim, raw):
+- `NVIDIA/OpenShell` repo, `main` — README.md, docs/index.mdx, docs/get-started/quickstart.mdx,
+  docs/sandboxes/inference-routing.mdx, docs/sandboxes/manage-sandboxes.mdx,
+  docs/sandboxes/policies.mdx, docs/reference/policy-schema.mdx (partial).
+- `NVIDIA/OpenShell` README quickstart + protection-layer table.
+- `NVIDIA/NemoClaw` README and listings (via WebFetch — summarized, not raw).
+- `openclaw/openclaw` README (via WebFetch).
+
+Secondary / corroboration:
+- developer.nvidia.com blog — "Run Autonomous, Self-Evolving Agents More Safely with NVIDIA OpenShell".
+- vietanh.dev — "NVIDIA OpenShell: Policy-Enforced Sandboxes for Autonomous Coding Agents" (2026-03-17).
+- futurumgroup.com — "OpenShell Redraws the Agent Control Plane".
+- codersera.com — "NemoClaw + OpenClaw Secure Sandbox Guide".
+
+Dead ends:
+- `docs.nvidia.com/nemoclaw/latest/index.html` — 404 when fetched. The Developer Guide URL exists in search index but the live page is missing today. Worked around via the NVIDIA blog + ghost.codersera + repo READMEs.
+- `kenhuangus.substack.com` — 403. Not material; covered by other sources.
+- `blogs.cisco.com/.../securing-enterprise-agents-with-nvidia-and-cisco-ai-defense` — promotional, no implementation detail.
+
+Repo versions observed:
+- OpenShell: v0.0.44, May 19 2026, alpha ("proof-of-life — single-player mode").
+- NemoClaw: alpha, released 2026-03-16. Apache 2.0. TypeScript-heavy.
+
+---
+
+## (a) Privacy Router endpoint contract
+
+**Verified.** Privacy Router is a real HTTPS endpoint named `https://inference.local`, intercepted by the gateway, reachable **only from inside a sandbox**. It is not exposed to the host.
+
+Wire protocol: OpenAI-compatible and Anthropic-compatible HTTP. Supported routes per provider:
+
+| Provider type configured | Method + path |
+|---|---|
+| OpenAI-compatible | `POST /v1/chat/completions`, `POST /v1/completions`, `POST /v1/responses`, `GET /v1/models`, `GET /v1/models/*` |
+| Anthropic | `POST /v1/messages` |
+| NVIDIA API Catalog | OpenAI-compatible patterns above |
+
+Behavior:
+- Strips caller `Authorization`. Injects backend credentials from the configured provider record.
+- Header allowlist per provider (e.g. `openai-organization`, `x-model-id`; `anthropic-version`, `anthropic-beta`). All others stripped.
+- 120s tolerance for idle gaps in streamed responses.
+- Per-gateway: **one provider, one model active at a time.** Hot-reloads in ~5s on running sandboxes via `openshell inference set`.
+- Sample usage from inside a sandbox:
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="https://inference.local/v1", api_key="unused")
+  ```
+
+External LLM hosts (e.g. `api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com`) are still reachable from a sandbox if `network_policies` allows them — they don't get Privacy Router credential injection or routing, only the normal egress policy check.
+
+**Implication for SportsClaw:** the Vercel AI SDK's `openai`, `anthropic`, and any OpenAI-compatible provider can be pointed at `https://inference.local/v1` with a placeholder API key and the sandbox handles credential injection. Drop-in.
+
+**Gemini-shaped tension:** Vercel AI SDK's `@ai-sdk/google` provider speaks Google's GenerativeLanguage API (`generativelanguage.googleapis.com/v1beta/...`), which is **not** OpenAI/Anthropic-compatible and therefore **not handled by Privacy Router**. Options if we want Gemini calls to be policy-routed too:
+1. Allow `generativelanguage.googleapis.com` in `network_policies` and accept that Gemini bypasses the Privacy Router (credentials still leak into the sandbox).
+2. Switch the Gemini calls to Google's OpenAI-compat endpoint (`generativelanguage.googleapis.com/v1beta/openai/...`) or to Vertex AI's OpenAI-compat endpoint and route them via `inference.local`. Cost: changes prompts/SDK behavior subtly.
+3. Drop Gemini entirely for the OpenShell-routed configuration and standardize on Nemotron (local) + Anthropic (frontier). This is the cleanest narrative for the NVIDIA co-marketing story but loses Gemini-specific capabilities (e.g. multimodal calls the engine currently uses).
+
+Phase 1 needs a decision here. My read: option 3 for the Nemotron + Anthropic launch case study, option 1 as a transitional fallback so existing direct-call users aren't affected.
+
+---
+
+## (b) Sandbox process model — supported agents only, or arbitrary processes?
+
+**Verified.** The sandbox accepts arbitrary container images and arbitrary commands.
+
+- `openshell sandbox create -- <agent>` is the convenience path: it injects a pre-shipped binary (`claude`, `opencode`, `codex`, `copilot`) into the base image and runs it. The "supported agents" list applies to **bundled tooling and default policy presets**, not a restriction on what the sandbox can run.
+- `openshell sandbox create --from <image>` accepts any container image — base name (`base`, `openclaw`, `ollama`), a local directory with a Dockerfile, or any registry image (`my-registry.example.com/my-image:latest`).
+- `openshell sandbox exec -n <name> -- <command>` runs arbitrary commands inside a sandbox with stdin pipe support and exit-code propagation. There is no allow-list of binaries here; the sandbox-internal `process` policy + `landlock` filesystem rules are what constrain it.
+- `openshell service expose <sandbox> <port> [name]` makes a long-running process inside the sandbox reachable through a gateway-managed URL. Intended explicitly for "development servers, notebooks, dashboards, or other services that keep listening after the sandbox starts."
+
+**Implication for SportsClaw:** the engine can run inside OpenShell unmodified. SportsClaw already has a Dockerfile in repo root, so the path is:
+1. Build a sportsclaw container image (already exists).
+2. `openshell sandbox create --from <sportsclaw-image>` with `--gpu` if Nemotron-local needs the GPU.
+3. Optionally `openshell service expose` for the tail server / overlay.
+4. Inside the sandbox, set `OPENAI_BASE_URL=https://inference.local/v1` (or Anthropic equivalent) and let the Vercel AI SDK hit the Privacy Router.
+
+NemoClaw is **not** a prerequisite. NemoClaw is a sibling stack — it's the "guided onboarding + hardened blueprint" wrapper specifically for OpenClaw assistants, with a LiteLLM proxy on the host. We can borrow ideas (blueprint YAML structure, policy presets) but we don't need to wedge SportsClaw into NemoClaw's blueprint. Running SportsClaw directly as a sandbox under OpenShell is the cleaner path.
+
+---
+
+## (c) Policy authoring
+
+**Verified.** Declarative YAML. Schema is at `docs/reference/policy-schema.mdx` (≈400 lines, not fully read).
+
+Structure:
+- Static sections (locked at sandbox creation, require recreate to change):
+  - `filesystem_policy` — `read_only`, `read_write` path lists; enforced via Landlock LSM.
+  - `landlock` — `compatibility: best_effort | hard_requirement`.
+  - `process` — `run_as_user`, `run_as_group` (root rejected); plus seccomp filters.
+- Dynamic section (hot-reloadable in ~5s on running sandboxes):
+  - `network_policies` — named blocks of `endpoints` (host, port, protocol: `rest` / `websocket` / unset for raw TCP) + `binaries` allowlist + optional `rules` (HTTP method/path). Connections denied if no block matches.
+
+CLI surface:
+- `openshell policy set <sandbox> --policy file.yaml` — full replacement.
+- `openshell policy update <sandbox>` — incremental merge.
+- `OPENSHELL_SANDBOX_POLICY=./policy.yaml` as default.
+
+L7 enforcement: TLS is terminated by the proxy for `protocol: rest` endpoints so it can check HTTP method/path against `rules`. WebSocket upgrades are validated. Raw TCP streams bypass payload inspection.
+
+There is also an `openshell` agent skill named `generate-sandbox-policy` for synthesizing policies from plain-language descriptions or API docs. Probably not relevant to the engine work but useful for tenant onboarding.
+
+---
+
+## (d) Can SportsClaw run inside OpenShell as a process, or does NemoClaw need adapting?
+
+**Answer: SportsClaw can run inside OpenShell directly as a sandbox.** NemoClaw is not on the critical path.
+
+What NemoClaw actually is (separating myth from substance):
+- A reference stack for running **OpenClaw** (the messaging-channel assistant) inside OpenShell.
+- Bundles: CLI plugin (TypeScript Commander extension), blueprint YAML configs, LiteLLM proxy on the host (port 4000) for model routing, state management, onboarding wizard.
+- Adds value when you want OpenClaw's specific shape: multi-channel inbox, voice, Live Canvas, etc.
+- Not generic. The blueprints assume OpenClaw's runtime shape.
+
+What SportsClaw needs that OpenShell provides directly:
+- Container sandbox with policy enforcement.
+- Privacy-aware LLM routing (`inference.local`).
+- Network egress policy (already needed — YouTube Live, tail server, image gen APIs, etc.).
+- Optional GPU passthrough for Nemotron-local.
+
+What SportsClaw needs that OpenShell **does not** provide:
+- Cron-based daemon lifecycle (`sportsclaw operate --job <jobId>` ticking on intervalMs). Sandbox doesn't know what cron is; it just runs whatever process you start. We start the daemon as the sandbox's main process.
+- Tail server + overlay. Either runs inside the sandbox with `openshell service expose`, or runs outside (preferred — separate repo, separate concern).
+- Sink plugin loading. Stays unchanged; npm modules resolved inside the sandbox like anywhere else, subject to `filesystem_policy`.
+
+**The integration shape:** a thin opt-in layer that, when a job config sets `provider: { type: "openshell" }`, swaps the Vercel AI SDK provider to point at `https://inference.local/v1` instead of `api.anthropic.com` / `generativelanguage.googleapis.com`. That's a provider-level swap inside the existing daemon. **No structural changes to the daemon are required** if we standardize on OpenAI/Anthropic-shaped providers. Gemini is the exception (see §(a) tension).
+
+Packaging: ship a Dockerfile that produces a SportsClaw sandbox image. Document `openshell sandbox create --from <image>` as the runbook for the NVIDIA case study. Optional `sportsclaw-openshell` plugin can bundle the recommended `policy.yaml` (network rules for known sink dependencies, filesystem rules for `~/.sportsclaw`) but is not required for the basic path.
+
+---
+
+## Optional-at-install constraint — assessment
+
+**Cleanly satisfiable.** The Privacy Router is OpenAI/Anthropic-compatible HTTP. From the daemon's perspective there is no difference between calling `https://api.anthropic.com/v1/messages` and calling `https://inference.local/v1/messages` — just a `baseURL` swap.
+
+Concrete shape (proposed for Phase 1):
+- New optional field on the job config: `provider` (already hinted at in the work envelope). Existing direct-call code path stays the default.
+- When `provider.type === "openshell"`, the engine sets the Vercel AI SDK provider's `baseURL` to `https://inference.local/v1` and passes a placeholder API key.
+- When unset, current behavior — direct LLM calls — is unchanged.
+- Engine ships with no `openshell` runtime dependency, no NemoClaw dependency, no Docker requirement.
+
+**Where the "optional" story leaks (be honest about this):**
+
+1. **Gemini.** As covered in §(a). If the engine keeps Gemini as a first-class provider, OpenShell deployment forces a per-call routing decision (Gemini bypasses Privacy Router; Anthropic goes through it). Surface as a policy concern: it works, but the "Privacy Router routing between local and frontier" narrative is partly fiction unless we standardize models.
+
+2. **Per-gateway one-provider-one-model.** OpenShell's `inference.local` exposes exactly one configured provider+model per gateway. If the engine wants to call Nemotron for safety check + Anthropic for content + Gemini for image-prompting in one tick, those are three different upstream backends. `inference.local` can't multiplex them. Options:
+   - Multiple gateways (heavy).
+   - Hot-switch model between calls (slow, ~5s reload — kills tick latency).
+   - Run some calls direct (network_policies allow) and only the policy-sensitive ones through `inference.local`.
+   This is an honest constraint that affects how we tell the NVIDIA story. The most defensible architecture: the **default** for any tick that doesn't need frontier reasoning routes to local Nemotron via `inference.local`; tick steps that explicitly need Claude/GPT can either route via a second gateway or go direct with credentials. NemoClaw's LiteLLM-on-host approach exists precisely to dodge this constraint — the LiteLLM proxy multiplexes upstreams behind a single OpenAI-compat endpoint. We could borrow that pattern.
+
+3. **GPU.** Nemotron-local needs a GPU. The Brev credit covers it for the case study, but for "anyone running `sportsclaw operate` on a laptop without NVIDIA infra" the local-model story doesn't apply — they'd point `inference.local` at a hosted Nemotron via NVIDIA API Catalog, or skip OpenShell entirely. The optional-at-install promise still holds; just naming the realistic deployment shapes.
+
+4. **Sandbox-only Privacy Router.** `inference.local` is only reachable from inside an OpenShell sandbox. There is no host-side mode where SportsClaw stays on the host and just uses the router as an LLM proxy. Either you go in-sandbox (NVIDIA case study) or you stay direct (current default). No middle ground without running our own LiteLLM-style proxy on the host.
+
+---
+
+## Open questions for Phase 1
+
+1. Do we standardize on OpenAI/Anthropic-shaped providers (drop or re-route Gemini) for the OpenShell story, or accept a two-track routing (some via `inference.local`, some direct)?
+2. Do we ship a `sportsclaw-openshell` plugin/blueprint with a recommended `policy.yaml`, or document a hand-rolled policy in the README and skip the plugin?
+3. Multi-provider-per-tick problem — solve via NemoClaw-style LiteLLM-on-host, multiple gateways, or accept the constraint and architect ticks so each tick uses one upstream?
+4. Is the SportsClaw Dockerfile production-ready as a sandbox image (writable workspace lives where, where do sink-plugin modules resolve from, how do we mount `~/.sportsclaw/operator/<jobId>.json` into the sandbox), or does it need work?
+5. Do we want the tail server + overlay running inside the same sandbox (via `openshell service expose`) for the case study, or stay external?
+
+---
+
+**Stopping here as instructed. Phase 1 design will not be drafted until this is reviewed.**

--- a/openshell/Dockerfile
+++ b/openshell/Dockerfile
@@ -1,0 +1,49 @@
+# =============================================================================
+# SportsClaw × OpenShell — Sandbox Image
+#
+# A thin downstream image that adds the bits an OpenShell sandbox expects on
+# top of the root SportsClaw container:
+#   - a `sandbox` UNIX user (matches `process.run_as_user` in policy.yaml)
+#   - writable /sandbox + /tmp (already present, just ensures ownership)
+#   - a default entrypoint that loads the operate command
+#
+# Build from the repo root:
+#   docker build -t sportsclaw-openshell:latest -f openshell/Dockerfile .
+#
+# Then create an OpenShell sandbox with it:
+#   openshell sandbox create \
+#       --from sportsclaw-openshell:latest \
+#       --policy openshell/policy.yaml \
+#       --name sportsclaw-tv
+#
+# The image is interchangeable with the root Dockerfile for any use that
+# doesn't need the OpenShell-specific user setup, so external tenants who
+# don't use OpenShell can ignore this file entirely.
+# =============================================================================
+
+# Base on the root sportsclaw image. Build the base image first:
+#   docker build -t sportsclaw:latest .
+ARG SPORTSCLAW_BASE=sportsclaw:latest
+FROM ${SPORTSCLAW_BASE}
+
+USER root
+
+# Create the sandbox user OpenShell's default policy expects.
+RUN groupadd -r sandbox && \
+    useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox && \
+    mkdir -p /sandbox && \
+    chown -R sandbox:sandbox /sandbox
+
+# Daemon state under /app/.sportsclaw must be writable by the sandbox user
+# so it can write briefs, editorial memory, and heartbeat persistence.
+RUN chown -R sandbox:sandbox /app/.sportsclaw
+
+USER sandbox
+WORKDIR /sandbox
+
+# Same entrypoint as the root image — `sportsclaw` CLI. The launcher reads
+# its config from ~/.sportsclaw/operator/<jobId>.json; mount the config
+# into the sandbox via `openshell sandbox upload` or bind the path at
+# sandbox create time.
+ENTRYPOINT ["node", "/app/dist/index.js"]
+CMD ["operate", "--list"]

--- a/openshell/README.md
+++ b/openshell/README.md
@@ -1,0 +1,139 @@
+# SportsClaw × NVIDIA OpenShell
+
+Runbook for running a SportsClaw operator daemon inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with LLM calls routed through OpenShell's Privacy Router.
+
+OpenShell is **optional**. If you're not running on NVIDIA infra (or just don't want the sandbox layer), omit the `openshell` block from your job config and SportsClaw uses direct LLM calls exactly as before. Nothing in this directory is on the default code path.
+
+For the rationale, integration design, and risk register, see:
+- `../docs/openshell-research.md` — Phase 0 research findings.
+- `../docs/openshell-integration-plan.md` — Phase 1 design + decisions.
+
+---
+
+## What this gives you
+
+- LLM calls routed through OpenShell's Privacy Router (`https://inference.local`) instead of direct calls to Anthropic / OpenAI.
+- Sandboxed execution with declarative YAML policies for filesystem, network, and process layers.
+- Credential isolation — provider API keys live in the gateway, not in the sandbox.
+- Per-call routing visibility via `openshell logs <sandbox> --tail` plus `inferenceRoute` fields on every TickEvent.
+
+What this does **not** give you:
+- Multi-provider routing in a single tick. Per-gateway, OpenShell exposes one provider + one model. If your job needs Anthropic for narration *and* Nemotron for safety in the same tick, you need NemoClaw-style LiteLLM-on-host (not shipped here).
+- Gemini routing. The Privacy Router doesn't speak Google's `generativelanguage.googleapis.com` protocol. Pick `anthropic` or `openai` for an OpenShell-enabled job (validator enforces this).
+
+---
+
+## Prerequisites
+
+- A supported host: macOS (Apple Silicon), Linux, or Windows WSL 2.
+- A container runtime: Docker or Podman.
+- OpenShell installed:
+  ```bash
+  curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+  ```
+- A SportsClaw job config under `~/.sportsclaw/operator/<jobId>.json` (see `examples/operator-jobs/` in the repo root).
+
+---
+
+## Quickstart
+
+1. **Start an OpenShell gateway** (one-time per machine):
+   ```bash
+   openshell gateway add http://127.0.0.1:18080 --local --name local
+   openshell gateway select local
+   ```
+
+2. **Configure your inference provider.** Anthropic example:
+   ```bash
+   export ANTHROPIC_API_KEY=sk-ant-...
+   openshell provider create --name anthropic-prod --type anthropic --from-existing
+   openshell inference set --provider anthropic-prod --model claude-opus-4-6
+   ```
+   Long-thinking models can exceed the 60s default timeout — add `--timeout 300` if you see truncated responses. See `models.md` for provider/model picks.
+
+3. **Build the SportsClaw sandbox image:**
+   ```bash
+   docker build -t sportsclaw-openshell:latest -f openshell/Dockerfile .
+   ```
+
+4. **Add `openshell` block to your job config** (`~/.sportsclaw/operator/<jobId>.json`):
+   ```json
+   {
+     "jobId": "tv-operator",
+     "intervalMs": 60000,
+     "personaText": "...",
+     "provider": "anthropic",
+     "model": "claude-opus-4-6",
+     "openshell": {}
+   }
+   ```
+   An empty `openshell: {}` block enables the feature with provider-appropriate defaults (`baseUrl: "https://inference.local"` for Anthropic).
+
+5. **Launch the sandbox with the SportsClaw image and policy:**
+   ```bash
+   openshell sandbox create \
+       --from sportsclaw-openshell:latest \
+       --policy openshell/policy.yaml \
+       --name sportsclaw-tv
+   ```
+
+6. **Run a single tick to verify routing:**
+   ```bash
+   openshell sandbox exec -n sportsclaw-tv -- \
+       node dist/index.js operate --job tv-operator --once
+   ```
+   The startup banner should include `inference=openshell(https://inference.local)`. Every TickEvent emitted by the daemon carries an `inferenceRoute` field with `via: "openshell"`.
+
+7. **Watch routing in OpenShell's log:**
+   ```bash
+   openshell logs sportsclaw-tv --tail
+   ```
+   You should see `inference.local` requests with the policy decision and upstream model resolution.
+
+---
+
+## Policy customization
+
+`policy.yaml` in this directory is a starting point. It allows:
+- Read-only access to standard system paths.
+- Read/write to `/sandbox` and `/tmp`.
+- Outbound HTTPS to the configured tail-server, image-generation endpoints, and YouTube Live (commented placeholders — uncomment and edit).
+- Inference traffic routes through `inference.local` (handled separately by the Privacy Router, not by `network_policies`).
+
+To pull and edit the active policy on a running sandbox:
+```bash
+openshell policy get sportsclaw-tv -o yaml > current-policy.yaml
+# ... edit ...
+openshell policy set sportsclaw-tv --policy current-policy.yaml
+```
+
+`network_policies` is hot-reloadable (~5s). `filesystem_policy`, `landlock`, and `process` are static — changing them requires sandbox recreation.
+
+For policy field reference, see [OpenShell Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.mdx).
+
+---
+
+## Troubleshooting
+
+**`OpenShell mode: cannot resolve "inference.local"`** at startup — the launcher's DNS probe is reporting that you're not inside an OpenShell sandbox. Either run via `openshell sandbox exec` / `openshell sandbox connect`, or set `"openshell": {"enabled": false}` to disable.
+
+**`policy_denied` 403 from the gateway** — a network call is hitting a host that isn't in `network_policies`. Either add it to the policy or route inference via `inference.local` (`openshell inference set ...`).
+
+**LLM call returns 4xx like `unsupported_method`** — the Privacy Router only serves the routes its configured provider supports (Anthropic → `/v1/messages` only; OpenAI-compatible → `/v1/chat/completions` and friends). Confirm `cfg.provider` matches the gateway's configured provider.
+
+**Tick latency longer than 60s** — Privacy Router default per-call timeout is 60s. For long-thinking Nemotron or Claude with extended reasoning, raise it: `openshell inference set ... --timeout 300`.
+
+**`openshell sandbox create --from sportsclaw-openshell:latest` fails to find the image** — the build step (step 3 above) didn't run, or you're targeting a remote gateway. The CLI uses the local Docker daemon for `--from <image>`; remote gateways need a registry reference instead.
+
+---
+
+## Files in this directory
+
+| File | Purpose |
+|---|---|
+| `README.md` | This runbook. |
+| `Dockerfile` | Sandbox image, layered on the root `Dockerfile`. |
+| `policy.yaml` | Reference OpenShell policy (network + filesystem + process). |
+| `models.md` | Suggested provider/model pairings + Nemotron variant table. |
+
+Per [D4](../docs/openshell-integration-plan.md), this directory lives in the engine repo as static recipe files. It ships in the npm release but contributes nothing to the install path and is inert unless a job config opts in.

--- a/openshell/models.md
+++ b/openshell/models.md
@@ -1,0 +1,84 @@
+# Provider & Model Pairings for OpenShell Mode
+
+This is one supported configuration among several. The recipe in this directory works with any provider OpenShell's Privacy Router supports; the NVIDIA Nemotron + Anthropic pairing below is what the Machina Sports TV case study uses.
+
+Per gateway, the Privacy Router exposes **one provider and one model** at a time. To switch, run `openshell inference update --provider <name> --model <id>` — propagates to running sandboxes in ~5 seconds without recreation.
+
+## Anthropic (frontier narration)
+
+Recommended for SportsClaw jobs that need long-form broadcast text and tool-use chains.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+openshell provider create --name anthropic-prod --type anthropic --from-existing
+openshell inference set --provider anthropic-prod --model claude-opus-4-6
+```
+
+Supported Privacy Router route: `POST /v1/messages` only.
+
+Job config:
+```json
+{
+  "provider": "anthropic",
+  "model": "claude-opus-4-6",
+  "openshell": {}
+}
+```
+
+## NVIDIA Nemotron via NVIDIA API Catalog (frontier, GPU-backed)
+
+```bash
+export NVIDIA_API_KEY=nv-...
+openshell provider create --name nvidia-prod --type nvidia --from-existing
+openshell inference set \
+    --provider nvidia-prod \
+    --model nvidia/nemotron-3-super-120b \
+    --timeout 300
+```
+
+Supported route patterns: OpenAI-compatible (`/v1/chat/completions`, `/v1/responses`, `/v1/completions`, `/v1/models`).
+
+For long-thinking phases, set `--timeout 300` (or higher) — Nemotron's default extended reasoning can exceed the 60s Privacy Router default and truncate mid-stream.
+
+Job config:
+```json
+{
+  "provider": "openai",
+  "model": "nvidia/nemotron-3-super-120b",
+  "openshell": {}
+}
+```
+
+(`provider: "openai"` because OpenShell exposes Nemotron via the OpenAI-compatible API surface — the SDK is what matters, not the upstream vendor.)
+
+## Nemotron-local (on-device, requires NVIDIA GPU)
+
+For a self-hosted Nemotron via vLLM or similar:
+
+```bash
+openshell provider create \
+    --name nemotron-local \
+    --type openai \
+    --credential OPENAI_API_KEY=empty-if-not-required \
+    --config OPENAI_BASE_URL=http://host.openshell.internal:8000/v1
+openshell inference set --provider nemotron-local --model nemotron-3-nano-30b
+```
+
+`host.openshell.internal` resolves from inside the sandbox to the host machine running the inference server. Avoid `127.0.0.1` / `localhost` — the request originates from the gateway, not your shell.
+
+## Variant cheatsheet
+
+| Variant | Where it lives | Use when |
+|---|---|---|
+| `nvidia/nemotron-3-super-120b` | NVIDIA API Catalog | Cloud GPU, frontier reasoning |
+| `nvidia/nemotron-3-nano-30b-a3b` | NVIDIA API Catalog | Cheaper / lower latency cloud |
+| Local Nemotron (`--type openai` against vLLM) | On-device GPU | Air-gapped or full-data-locality scenarios |
+| `claude-opus-4-6` | Anthropic via Privacy Router | Long narration, tool chains |
+| `claude-sonnet-4-5-20250514` | Anthropic via Privacy Router | Faster, cheaper Claude |
+
+## What does NOT work in OpenShell mode
+
+- **Gemini.** The validator rejects `provider: "google"` when `openshell` is enabled. OpenShell's Privacy Router doesn't speak Google's `generativelanguage.googleapis.com` protocol. Either drop the `openshell` block (direct calls) or pick a different provider for OpenShell jobs.
+- **Multi-provider per tick.** Gateway-scoped one-provider-one-model. If a tick needs Nemotron for safety + Claude for narration, you need a host-side proxy (LiteLLM-style) that multiplexes upstreams — not shipped here.
+
+See `../docs/openshell-research.md` §a for the Privacy Router protocol details.

--- a/openshell/policy.yaml
+++ b/openshell/policy.yaml
@@ -1,0 +1,149 @@
+# =============================================================================
+# SportsClaw — Reference OpenShell Sandbox Policy
+#
+# A starting point for running `sportsclaw operate` inside an OpenShell
+# sandbox with LLM calls routed through the Privacy Router.
+#
+# Apply at sandbox creation:
+#   openshell sandbox create \
+#       --from sportsclaw-openshell:latest \
+#       --policy openshell/policy.yaml \
+#       --name sportsclaw-tv
+#
+# Or, hot-reload network rules on a running sandbox:
+#   openshell policy set sportsclaw-tv --policy openshell/policy.yaml
+#
+# Static sections (filesystem_policy, landlock, process) lock at creation
+# and require sandbox recreation to change. network_policies hot-reloads
+# in ~5 seconds.
+#
+# Edit the placeholder hostnames before deploying — uncomment what your
+# sink actually needs, drop what it doesn't. The defaults err on the
+# side of denying egress.
+# =============================================================================
+
+version: 1
+
+# ---------------------------------------------------------------------------
+# STATIC — Filesystem (Landlock LSM enforcement)
+# ---------------------------------------------------------------------------
+
+filesystem_policy:
+  # Read-only system paths the daemon needs to start.
+  # Baseline paths (/usr, /lib, /etc, /var/log) are added automatically.
+  read_only:
+    - /opt/venv          # Python venv used by sports-skills
+    - /app/dist          # Built JS
+    - /app/node_modules  # Resolved npm modules
+    - /app/skills-lock.json
+
+  # Read/write paths.
+  # /sandbox and /tmp are baseline. Add the daemon's persistence root.
+  read_write:
+    - /sandbox
+    - /tmp
+    - /app/.sportsclaw   # Daemon state, briefs, editorial memory
+
+landlock:
+  compatibility: best_effort
+
+# ---------------------------------------------------------------------------
+# STATIC — Process identity
+# ---------------------------------------------------------------------------
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# ---------------------------------------------------------------------------
+# DYNAMIC — Network egress
+#
+# Every outbound connection except `https://inference.local` is checked
+# against these blocks. Inference traffic to `inference.local` is handled
+# by the Privacy Router (configured via `openshell inference set ...`),
+# not by network_policies.
+#
+# Each block: name + endpoints (host/port/protocol) + allowed binaries.
+# Connections are denied if no block matches. Be specific.
+# ---------------------------------------------------------------------------
+
+network_policies:
+
+  # -------------------------------------------------------------------------
+  # Tail server — telemetry/event POSTs from sinks.
+  # Edit the host + port to match your `tailServer` config field.
+  # -------------------------------------------------------------------------
+  tail_server:
+    name: tail-server
+    endpoints:
+      - host: tail.example.internal
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
+    binaries:
+      - path: /usr/local/bin/node
+
+  # -------------------------------------------------------------------------
+  # Image generation — uncomment whichever provider your sink uses.
+  # OpenAI / Anthropic *text* calls should go via inference.local, but
+  # image-gen APIs aren't covered by the Privacy Router and need explicit
+  # egress here.
+  # -------------------------------------------------------------------------
+  # image_gen_openai:
+  #   name: image-gen-openai
+  #   endpoints:
+  #     - host: api.openai.com
+  #       port: 443
+  #       protocol: rest
+  #       enforcement: enforce
+  #       access: full
+  #   binaries:
+  #     - path: /usr/local/bin/node
+  #
+  # image_gen_google:
+  #   name: image-gen-google
+  #   endpoints:
+  #     - host: generativelanguage.googleapis.com
+  #       port: 443
+  #       protocol: rest
+  #       enforcement: enforce
+  #       access: full
+  #   binaries:
+  #     - path: /usr/local/bin/node
+
+  # -------------------------------------------------------------------------
+  # YouTube Live — broadcast sinks publishing to a live stream.
+  # Uncomment + edit if your sink talks to YouTube's Data API or RTMP.
+  # -------------------------------------------------------------------------
+  # youtube_live:
+  #   name: youtube-live
+  #   endpoints:
+  #     - host: www.googleapis.com
+  #       port: 443
+  #       protocol: rest
+  #       enforcement: enforce
+  #       access: full
+  #     - host: youtube.googleapis.com
+  #       port: 443
+  #       protocol: rest
+  #       enforcement: enforce
+  #       access: full
+  #   binaries:
+  #     - path: /usr/local/bin/node
+
+  # -------------------------------------------------------------------------
+  # MCP server — when SportsClaw resolves persona templates via MCP, it
+  # needs egress to the MCP server's HTTP endpoint. Most production
+  # deployments use a single Machina pod URL; edit to match.
+  # -------------------------------------------------------------------------
+  # mcp_server:
+  #   name: mcp-server
+  #   endpoints:
+  #     - host: mcp.example.internal
+  #       port: 443
+  #       protocol: rest
+  #       enforcement: enforce
+  #       access: full
+  #   binaries:
+  #     - path: /usr/local/bin/node

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -23,8 +23,8 @@ import path from "node:path";
 import { homedir } from "node:os";
 
 import { tool as defineTool, jsonSchema, type ToolSet } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { openai } from "@ai-sdk/openai";
+import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
+import { openai, createOpenAI } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
 
 import {
@@ -59,7 +59,7 @@ import {
   TICK_BRIEF_FRAGMENT_HEADER,
   TOOL_DISCIPLINE_FRAGMENT,
 } from "./prompts.js";
-import type { LLMProvider } from "./types.js";
+import type { InferenceRoute, LLMProvider, OpenShellConfig } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Public entry — wired into src/index.ts main dispatcher
@@ -387,11 +387,70 @@ async function resolvePersona(
 }
 
 // ---------------------------------------------------------------------------
-// Model resolution — small dup of engine's private helper; spec forbids
-// engine.ts changes, so we reproduce 3 lines rather than expose a getter.
+// Model resolution — small dup of engine's private helper. Extended here to
+// route through OpenShell's Privacy Router when the job opts in.
 // ---------------------------------------------------------------------------
 
-function resolveModel(provider: LLMProvider, modelId: string) {
+/**
+ * Provider-specific default base URLs for OpenShell's `inference.local`.
+ * Each SDK has its own path convention — Anthropic appends `/v1/messages`,
+ * OpenAI clients expect the `/v1` prefix already in the base URL.
+ */
+function defaultOpenShellBaseUrl(provider: LLMProvider): string {
+  switch (provider) {
+    case "anthropic":
+      return "https://inference.local";
+    case "openai":
+      return "https://inference.local/v1";
+    case "google":
+      throw new Error(
+        "OpenShell does not support Google's API protocol. Drop the openshell block or pick provider \"anthropic\" / \"openai\".",
+      );
+  }
+}
+
+interface ResolvedOpenShell {
+  enabled: boolean;
+  baseUrl: string;
+}
+
+function resolveOpenShell(
+  provider: LLMProvider,
+  openshell: OpenShellConfig | undefined,
+): ResolvedOpenShell | undefined {
+  if (!openshell) return undefined;
+  const enabled = openshell.enabled !== false; // default true when block present
+  if (!enabled) return { enabled: false, baseUrl: "" };
+  const baseUrl = openshell.baseUrl ?? defaultOpenShellBaseUrl(provider);
+  return { enabled: true, baseUrl };
+}
+
+function resolveModel(
+  provider: LLMProvider,
+  modelId: string,
+  openshell?: ResolvedOpenShell,
+) {
+  if (openshell?.enabled) {
+    // Privacy Router strips client credentials and injects backend ones,
+    // so the apiKey here is a placeholder that satisfies SDK validation.
+    switch (provider) {
+      case "anthropic":
+        return createAnthropic({
+          baseURL: openshell.baseUrl,
+          apiKey: "openshell-unused",
+        })(modelId);
+      case "openai":
+        return createOpenAI({
+          baseURL: openshell.baseUrl,
+          apiKey: "openshell-unused",
+        })(modelId);
+      case "google":
+        // Unreachable in practice — config validator rejects this combo.
+        throw new Error(
+          `OpenShell mode does not support provider "${provider}".`,
+        );
+    }
+  }
   switch (provider) {
     case "anthropic":
       return anthropic(modelId);
@@ -404,12 +463,37 @@ function resolveModel(provider: LLMProvider, modelId: string) {
   }
 }
 
+/**
+ * Set provider-specific base-URL env vars so any code path inside this
+ * process (e.g. engine.ts singletons used by sub-tools) also routes
+ * through `inference.local`. The factory call in resolveModel covers the
+ * daemon's own generateText path; this covers everything else.
+ */
+function applyOpenShellEnv(
+  provider: LLMProvider,
+  openshell: ResolvedOpenShell,
+): void {
+  switch (provider) {
+    case "anthropic":
+      process.env.ANTHROPIC_BASE_URL = openshell.baseUrl;
+      break;
+    case "openai":
+      process.env.OPENAI_BASE_URL = openshell.baseUrl;
+      break;
+    case "google":
+      // Never reached — config validator + resolveOpenShell both reject.
+      break;
+  }
+}
+
 interface ResolvedDaemonInputs {
   provider: LLMProvider;
   modelId: string;
   rootDir: string;
   personaText: string;
   extraFragments: string[];
+  openshell?: ResolvedOpenShell;
+  inferenceRoute: InferenceRoute;
 }
 
 async function resolveJobInputs(
@@ -429,7 +513,54 @@ async function resolveJobInputs(
   }
   const personaText = await resolvePersona(cfg, mcpManager);
   const extraFragments = resolveExtraFragments(cfg.extraFragments);
-  return { provider, modelId, rootDir, personaText, extraFragments };
+  const openshell = resolveOpenShell(provider, cfg.openshell);
+  if (openshell?.enabled) {
+    applyOpenShellEnv(provider, openshell);
+  }
+  const inferenceRoute: InferenceRoute = openshell?.enabled
+    ? { via: "openshell", baseUrl: openshell.baseUrl, provider, model: modelId }
+    : { via: "direct", provider, model: modelId };
+  return {
+    provider,
+    modelId,
+    rootDir,
+    personaText,
+    extraFragments,
+    openshell,
+    inferenceRoute,
+  };
+}
+
+/**
+ * Best-effort startup probe: when openshell is enabled, confirm
+ * `inference.local` (or the configured host) resolves before we hand
+ * control to the daemon. Fails fast with a clear error message rather
+ * than letting the first generateText surface an opaque DNS error.
+ * Mitigates Risk R4 in docs/openshell-integration-plan.md.
+ */
+async function probeOpenShellHost(baseUrl: string): Promise<void> {
+  let host: string;
+  try {
+    host = new URL(baseUrl).hostname;
+  } catch {
+    throw new Error(`OpenShell mode: invalid baseUrl ${JSON.stringify(baseUrl)}`);
+  }
+  const { promises: dnsp } = await import("node:dns");
+  try {
+    await Promise.race([
+      dnsp.lookup(host),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("dns lookup timeout (1.5s)")), 1500),
+      ),
+    ]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `OpenShell mode: cannot resolve "${host}" (${msg}). ` +
+        `Are you running inside an OpenShell sandbox? ` +
+        `Set openshell.enabled=false or remove the openshell block to disable.`,
+    );
+  }
 }
 
 function expandTilde(p: string): string {
@@ -486,6 +617,11 @@ async function runDryRun(jobId: string): Promise<void> {
     console.log(`rootDir:           ${inputs.rootDir}`);
     console.log(`sink:              ${sink.name}`);
     console.log(`memory writeback:  ${memoryToolsOn ? "enabled" : "disabled"}`);
+    if (inputs.openshell?.enabled) {
+      console.log(`inference:         openshell (${inputs.openshell.baseUrl})`);
+    } else {
+      console.log(`inference:         direct`);
+    }
   } finally {
     await tools.mcpManager.disconnectAll().catch(() => {});
   }
@@ -501,6 +637,9 @@ async function runOnce(jobId: string): Promise<void> {
   const tools = await buildOperatorTools(cfg, false, sink);
   try {
     const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
+    if (inputs.openshell?.enabled) {
+      await probeOpenShellHost(inputs.openshell.baseUrl);
+    }
     const ctx: SinkContext = {
       jobId: cfg.jobId,
       modelId: inputs.modelId,
@@ -512,13 +651,14 @@ async function runOnce(jobId: string): Promise<void> {
       jobId: cfg.jobId,
       jobLabel: cfg.label,
       intervalMs: cfg.intervalMs,
-      model: resolveModel(inputs.provider, inputs.modelId),
+      model: resolveModel(inputs.provider, inputs.modelId, inputs.openshell),
       role: inputs.personaText,
       tools: tools.toolSet,
       rootDir: inputs.rootDir,
       extraFragments: inputs.extraFragments,
       guardOptions: cfg.guardOptions,
       enableMemoryTools: cfg.enableMemoryTools,
+      inferenceRoute: inputs.inferenceRoute,
       onTickEvent: sink.onTickEvent
         ? async (evt) => { await sink.onTickEvent!(evt, ctx); }
         : undefined,
@@ -571,6 +711,9 @@ async function runForeground(jobId: string): Promise<void> {
   const sink = await resolveSink(cfg);
   const tools = await buildOperatorTools(cfg, false, sink);
   const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
+  if (inputs.openshell?.enabled) {
+    await probeOpenShellHost(inputs.openshell.baseUrl);
+  }
 
   const ctx: SinkContext = {
     jobId: cfg.jobId,
@@ -583,13 +726,14 @@ async function runForeground(jobId: string): Promise<void> {
     jobId: cfg.jobId,
     jobLabel: cfg.label,
     intervalMs: cfg.intervalMs,
-    model: resolveModel(inputs.provider, inputs.modelId),
+    model: resolveModel(inputs.provider, inputs.modelId, inputs.openshell),
     role: inputs.personaText,
     tools: tools.toolSet,
     rootDir: inputs.rootDir,
     extraFragments: inputs.extraFragments,
     guardOptions: cfg.guardOptions,
     enableMemoryTools: cfg.enableMemoryTools,
+    inferenceRoute: inputs.inferenceRoute,
     onTickEvent: sink.onTickEvent
       ? async (evt) => { await sink.onTickEvent!(evt, ctx); }
       : (evt) => console.log(JSON.stringify(evt)),
@@ -625,8 +769,11 @@ async function runForeground(jobId: string): Promise<void> {
   process.on("SIGINT", () => void shutdown("SIGINT"));
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
+  const inferenceTag = inputs.openshell?.enabled
+    ? ` inference=openshell(${inputs.openshell.baseUrl})`
+    : "";
   console.error(
-    `[operate] job=${cfg.jobId} interval=${cfg.intervalMs}ms provider=${inputs.provider} model=${inputs.modelId}`,
+    `[operate] job=${cfg.jobId} interval=${cfg.intervalMs}ms provider=${inputs.provider} model=${inputs.modelId}${inferenceTag}`,
   );
   daemon.start();
   // Keep the process alive without unref'd heartbeat timers exiting early.

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -15,7 +15,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
 
-import type { LLMProvider } from "./types.js";
+import type { LLMProvider, OpenShellConfig } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,6 +78,14 @@ export interface OperatorJobConfig {
    * — the current tick sees a frozen snapshot. Default: true.
    */
   enableMemoryTools?: boolean;
+  /**
+   * Opt in to routing LLM calls through NVIDIA OpenShell's Privacy Router.
+   * Absent block = default direct LLM calls; nothing changes. When present
+   * and enabled, the launcher constructs the AI SDK provider with a
+   * `baseURL` pointing at `inference.local` (or the configured `baseUrl`).
+   * See `openshell/README.md` for the deployment runbook.
+   */
+  openshell?: OpenShellConfig;
 }
 
 export interface ValidationIssue {
@@ -257,6 +265,47 @@ export function validateOperatorJobConfig(
     push("enableMemoryTools", "must be a boolean");
   }
 
+  // openshell — optional opt-in routing block
+  let parsedOpenShell: OpenShellConfig | undefined;
+  if (raw.openshell !== undefined) {
+    if (typeof raw.openshell !== "object" || raw.openshell === null || Array.isArray(raw.openshell)) {
+      push("openshell", "must be an object");
+    } else {
+      const os = raw.openshell as Record<string, unknown>;
+      if (os.enabled !== undefined && typeof os.enabled !== "boolean") {
+        push("openshell.enabled", "must be a boolean");
+      }
+      if (os.baseUrl !== undefined) {
+        if (typeof os.baseUrl !== "string") {
+          push("openshell.baseUrl", "must be a string URL");
+        } else {
+          try {
+            const url = new URL(os.baseUrl);
+            if (url.protocol !== "http:" && url.protocol !== "https:") {
+              push("openshell.baseUrl", "must be http(s)");
+            }
+          } catch {
+            push("openshell.baseUrl", `not a valid URL: ${JSON.stringify(os.baseUrl)}`);
+          }
+        }
+      }
+      // D1 — Gemini cannot route through the Privacy Router (Google's API
+      // shape is neither OpenAI-compatible nor Anthropic-compatible). Fail
+      // fast at config-load time rather than at the first generateText.
+      const openShellEnabled = os.enabled !== false; // default true when block present
+      if (openShellEnabled && raw.provider === "google") {
+        push(
+          "openshell",
+          "provider \"google\" is not supported under openshell — the Privacy Router doesn't speak Google's protocol. Drop the openshell block or pick provider \"anthropic\" / \"openai\".",
+        );
+      }
+      parsedOpenShell = {
+        enabled: os.enabled as boolean | undefined,
+        baseUrl: os.baseUrl as string | undefined,
+      };
+    }
+  }
+
   if (issues.length > 0) {
     return { valid: false, issues };
   }
@@ -279,6 +328,7 @@ export function validateOperatorJobConfig(
       guardOptions: raw.guardOptions as Record<string, unknown> | undefined,
       sinkRole: raw.sinkRole as string | undefined,
       enableMemoryTools: raw.enableMemoryTools as boolean | undefined,
+      openshell: parsedOpenShell,
     },
   };
 }

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -57,6 +57,7 @@ import {
   digestResult,
   type ToolGuardOptions,
 } from "./guardrails.js";
+import type { InferenceRoute } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -96,6 +97,12 @@ export interface TickEvent {
   toolCalls?: number;
   guardrailWarnings?: number;
   guardrailBlocks?: number;
+  /**
+   * Inference routing snapshot. Set when the launcher knows where the
+   * tick's LLM calls go (always populated in production; absent in some
+   * lightweight tests). Sinks unaware of this field can ignore it.
+   */
+  inferenceRoute?: InferenceRoute;
 }
 
 export interface OperatorDaemonConfig {
@@ -178,6 +185,12 @@ export interface OperatorDaemonConfig {
   heartbeat?: HeartbeatService;
   /** Inject a generateText impl (tests). Default: ai SDK's. */
   generateTextImpl?: typeof generateText;
+  /**
+   * Inference routing snapshot. The launcher passes this so every emitted
+   * TickEvent carries the routing decision (direct vs. openshell, base URL,
+   * provider, model). Omit to leave the field off TickEvents.
+   */
+  inferenceRoute?: InferenceRoute;
 }
 
 export interface OperatorDaemon {
@@ -264,6 +277,7 @@ export function createOperatorDaemon(
       jobId,
       tickId,
       timestamp,
+      inferenceRoute: cfg.inferenceRoute,
     });
 
     // 1. Frozen memory snapshot for this tick.
@@ -380,6 +394,7 @@ export function createOperatorDaemon(
         toolCalls: counts.calls,
         guardrailWarnings: counts.warnings,
         guardrailBlocks: counts.blocks,
+        inferenceRoute: cfg.inferenceRoute,
       };
       cfg.onTickEvent?.(event);
       return event;
@@ -397,6 +412,7 @@ export function createOperatorDaemon(
       toolCalls: counts.calls,
       guardrailWarnings: counts.warnings,
       guardrailBlocks: counts.blocks,
+      inferenceRoute: cfg.inferenceRoute,
     };
     cfg.onTickEvent?.(event);
     return event;
@@ -416,6 +432,7 @@ export function createOperatorDaemon(
         tickId,
         reason: event.result ?? "wake gate denied",
         timestamp: event.timestamp,
+        inferenceRoute: cfg.inferenceRoute,
       };
       cfg.onTickEvent?.(skip);
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,40 @@ import type { ModelMessage } from "ai";
 
 export type LLMProvider = "anthropic" | "openai" | "google";
 
+// ---------------------------------------------------------------------------
+// OpenShell — optional opt-in routing through NVIDIA OpenShell's Privacy
+// Router. Absent / disabled block = default direct LLM calls, unchanged.
+// See docs/openshell-integration-plan.md.
+// ---------------------------------------------------------------------------
+
+export interface OpenShellConfig {
+  /**
+   * Whether the launcher should route LLM calls through the Privacy Router.
+   * Default: `true` when the openshell block is present.
+   */
+  enabled?: boolean;
+  /**
+   * Base URL handed to the AI SDK provider. Only set when you need to point
+   * at something other than the default. Defaults are provider-specific
+   * (`https://inference.local` for Anthropic, `https://inference.local/v1`
+   * for OpenAI-compatible) and assume you are inside an OpenShell sandbox.
+   */
+  baseUrl?: string;
+}
+
+/**
+ * Snapshot of the inference routing decision, attached to every TickEvent
+ * so sinks can render or forward it. Optional + additive — sinks that
+ * don't know about this field ignore it.
+ */
+export interface InferenceRoute {
+  via: "direct" | "openshell";
+  /** Set when `via === "openshell"`. */
+  baseUrl?: string;
+  provider: LLMProvider;
+  model: string;
+}
+
 export interface ProviderModelOption {
   value: string;
   label: string;

--- a/test/operator-config.test.mjs
+++ b/test/operator-config.test.mjs
@@ -256,3 +256,118 @@ describe("validateOperatorJobConfig — optional fields", () => {
     assert.ok(fields.has("persona|personaText"));
   });
 });
+
+// ---------------------------------------------------------------------------
+// validateOperatorJobConfig — openshell block (Phase 2a)
+// ---------------------------------------------------------------------------
+
+describe("validateOperatorJobConfig — openshell block", () => {
+  const base = {
+    jobId: "openshell-job",
+    intervalMs: 60_000,
+    personaText: "You are an autonomous operator.",
+  };
+
+  it("accepts a config with no openshell block (default direct mode)", () => {
+    const r = validateOperatorJobConfig(base);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.config.openshell, undefined);
+  });
+
+  it("accepts an empty openshell block (defaults to enabled)", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      provider: "anthropic",
+      openshell: {},
+    });
+    assert.strictEqual(r.valid, true);
+    assert.deepStrictEqual(r.config.openshell, {
+      enabled: undefined,
+      baseUrl: undefined,
+    });
+  });
+
+  it("accepts openshell with explicit enabled=true", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      provider: "anthropic",
+      openshell: { enabled: true, baseUrl: "https://inference.local" },
+    });
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.config.openshell.enabled, true);
+    assert.strictEqual(r.config.openshell.baseUrl, "https://inference.local");
+  });
+
+  it("accepts openshell with enabled=false (block present but inert)", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      provider: "google",  // would normally fail D1, but disabled block is fine
+      openshell: { enabled: false },
+    });
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.config.openshell.enabled, false);
+  });
+
+  it("rejects non-object openshell", () => {
+    for (const bad of ["yes", 42, true, []]) {
+      const r = validateOperatorJobConfig({ ...base, openshell: bad });
+      assert.strictEqual(r.valid, false, `openshell=${JSON.stringify(bad)}`);
+      assert.ok(r.issues.find((i) => i.field === "openshell"));
+    }
+  });
+
+  it("rejects non-boolean openshell.enabled", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      openshell: { enabled: "true" },
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "openshell.enabled"));
+  });
+
+  it("rejects non-string openshell.baseUrl", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      openshell: { baseUrl: 42 },
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "openshell.baseUrl"));
+  });
+
+  it("rejects openshell.baseUrl that isn't a URL", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      openshell: { baseUrl: "not a url" },
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "openshell.baseUrl"));
+  });
+
+  it("rejects openshell.baseUrl with file:// scheme", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      openshell: { baseUrl: "file:///etc/passwd" },
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "openshell.baseUrl"));
+  });
+
+  it("rejects openshell + provider=google (D1)", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      provider: "google",
+      openshell: {},
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "openshell"));
+  });
+
+  it("rejects openshell + provider=google even with explicit enabled=true", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      provider: "google",
+      openshell: { enabled: true },
+    });
+    assert.strictEqual(r.valid, false);
+  });
+});

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -91,6 +91,63 @@ describe("tickOnce — published path", () => {
     assert.match(event.tickId, /^tick_/);
   });
 
+  it("omits inferenceRoute when the launcher doesn't pass one", async () => {
+    const events = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({ onTickEvent: (e) => events.push(e) }),
+    );
+    await daemon.tickOnce();
+    for (const e of events) {
+      assert.strictEqual(e.inferenceRoute, undefined, `event ${e.type}`);
+    }
+  });
+
+  it("propagates inferenceRoute to every TickEvent the daemon emits", async () => {
+    const route = {
+      via: "openshell",
+      baseUrl: "https://inference.local",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    };
+    const events = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        inferenceRoute: route,
+        onTickEvent: (e) => events.push(e),
+      }),
+    );
+    await daemon.tickOnce();
+    // We expect at least tick_started + tick_published, each carrying the route.
+    const types = events.map((e) => e.type);
+    assert.ok(types.includes("tick_started"));
+    assert.ok(types.includes("tick_published"));
+    for (const e of events) {
+      assert.deepStrictEqual(e.inferenceRoute, route, `event ${e.type}`);
+    }
+  });
+
+  it("propagates inferenceRoute even on tick_failed", async () => {
+    const route = {
+      via: "direct",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    };
+    const failing = async () => {
+      throw new Error("boom");
+    };
+    const events = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: failing,
+        inferenceRoute: route,
+        onTickEvent: (e) => events.push(e),
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_failed");
+    assert.deepStrictEqual(event.inferenceRoute, route);
+  });
+
   it("writes the brief to disk under <briefDir>/<jobId>/<tickId>.md", async () => {
     const daemon = createOperatorDaemon(baseConfig());
     const event = await daemon.tickOnce();


### PR DESCRIPTION
## Summary

- Opt-in integration with [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell)'s Privacy Router for sandboxed, policy-routed LLM calls. Direct calls remain the default — enabled only when a job config carries an `openshell` block.
- Engine seam is the AI SDK's `createAnthropic` / `createOpenAI` factories with `https://inference.local` as `baseURL`. `engine.ts` is untouched; sink plugin contract is unchanged; tenant config shape adds one optional field.
- Ships the recipe (Dockerfile, reference `policy.yaml`, runbook, model table) as the `openshell/` subdirectory per D4 — static files, no install-path impact.

## Phases (one commit each)

1. **Phase 0** (`docs/openshell-research.md`) — research findings on Privacy Router protocol, sandbox process model, policy authoring. Confirms env-var / factory seam is sufficient and NemoClaw is not a prerequisite.
2. **Phase 1** (`docs/openshell-integration-plan.md`) — integration design with five captured decisions (D1 drop Gemini for OpenShell jobs, D2 single-provider-per-job, D3 engine.ts policy relaxed, D4 subdirectory not separate repo, D5 additive `inferenceRoute` field) and eight enumerated risks.
3. **Phase 2** (`feat(openshell): opt-in privacy router routing + sandbox recipe`) — implementation, tests, recipe.

## What changed

**Engine** (~250 LOC across 4 files)
- `src/types.ts` — new `OpenShellConfig` and `InferenceRoute` interfaces.
- `src/operator-config.ts` — optional `openshell` field + validator (rejects bad URLs, the `openshell` + `provider: "google"` combination per D1).
- `src/operate.ts` — `resolveOpenShell` / `resolveModel(provider, modelId, openshell?)` / `applyOpenShellEnv` / `probeOpenShellHost`. Banner extended with `inference=openshell(…)`.
- `src/operator-daemon.ts` — optional `inferenceRoute` on `OperatorDaemonConfig` + every emitted `TickEvent` variant.

**Recipe** (`openshell/`)
- `README.md` runbook + troubleshooting.
- `policy.yaml` reference (hot-reloadable network blocks for tail-server / image-gen / MCP / YouTube Live, commented placeholders).
- `Dockerfile` thin downstream image layering a `sandbox` user on the root sportsclaw image.
- `models.md` Anthropic / Nemotron cloud / Nemotron local pairings.

**Tests** — 14 new (11 validator, 3 daemon). All operator suites green.

## Test plan

- [x] `npm run build` — clean tsc.
- [x] `npm run test:operator-config` — 39/39 (11 new).
- [x] `npm run test:operator-daemon` — 34/34 (3 new).
- [x] `npm run test:operate` — 26/26.
- [x] `npm run test:operator-sink` — 5/5.
- [ ] End-to-end smoke: run `openshell sandbox create --from sportsclaw-openshell:latest --policy openshell/policy.yaml`, then `openshell sandbox exec ... -- node dist/index.js operate --job <id> --once`, verify a tick publishes and `openshell logs --tail` shows `inference.local` traffic. (Requires real OpenShell install + provider creds.)
- [ ] Smoke a config without an `openshell` block to confirm zero behaviour change for direct-call users.

## Honored constraints

- `engine.ts` untouched (env-var seam plus factory call avoids it).
- Sink plugin contract unchanged — `inferenceRoute` is optional + additive; sinks ignore unknown fields.
- Tenant config shape preserved — only added the optional `openshell` field; nothing else reshaped.
- Default direct-call path is byte-identical for users without an `openshell` block.

## Decisions referenced

| ID | Decision | Where |
|----|---|---|
| D1 | Drop Gemini for OpenShell jobs | validator + plan |
| D2 | Single-provider-per-job for v1 | plan |
| D3 | Engine.ts policy relaxed | plan (no code change needed) |
| D4 | `openshell/` subdirectory | this PR |
| D5 | Additive `inferenceRoute` field | implementation |

Full discussion in `docs/openshell-integration-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)