### PR TITLE
feat(openshell): doctor + setup wizard CLI

### DIFF
--- a/openshell/README.md
+++ b/openshell/README.md
@@ -35,7 +35,18 @@ What this does **not** give you:
 
 ---
 
-## Quickstart
+## Easy path — bundled wizard
+
+```bash
+sportsclaw openshell doctor    # diagnose what's installed and what's missing
+sportsclaw openshell setup     # interactive: install, gateway, provider, image build, config scaffold
+```
+
+The wizard shells out to `openshell` and `docker` for each step and asks before doing anything destructive. It does **not** create the sandbox or run the daemon for you — those are still explicit OpenShell commands so the runtime stays the user's mental model. After `setup` finishes, jump to step 5 of the manual quickstart below.
+
+---
+
+## Manual quickstart
 
 1. **Start an OpenShell gateway** (one-time per machine):
    ```bash

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test:tool-call-part-guard": "npm run build && node --test test/tool-call-part-guard.test.mjs",
     "test:operator-sink": "npm run build && node --test test/operator-sink.test.mjs",
     "test:operator-sink-external": "npm run build && node --test test/operator-sink-external.test.mjs",
-    "test:operator-memory-tools": "npm run build && node --test test/operator-memory-tools.test.mjs"
+    "test:operator-memory-tools": "npm run build && node --test test/operator-memory-tools.test.mjs",
+    "test:openshell-cli": "npm run build && node --test test/openshell-cli.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ import {
   type DaemonPlatform,
 } from "./daemon.js";
 import { cmdOperate } from "./operate.js";
+import { cmdOpenshell } from "./openshell-cli.js";
 import { runSetup } from "./setup.js";
 import {
   loadMcpConfigs,
@@ -2293,6 +2294,8 @@ function printHelp(): void {
   console.log("  sportsclaw listen <platform>       Start a chat listener (discord, telegram)");
   console.log("  sportsclaw operate --job <jobId>   Run an autonomous operator daemon (foreground)");
   console.log("  sportsclaw operate --list          List configured operator jobs");
+  console.log("  sportsclaw openshell doctor        Diagnose OpenShell prereqs (optional integration)");
+  console.log("  sportsclaw openshell setup         Interactive wizard for OpenShell integration");
   console.log("  sportsclaw start <platform>        Start a listener as a background daemon");
   console.log("  sportsclaw start operator <jobId>  Start a supervised operator daemon");
   console.log("  sportsclaw stop <platform>         Stop a running daemon");
@@ -2510,6 +2513,8 @@ async function main(): Promise<void> {
       return cmdLogs(subArgs);
     case "operate":
       return cmdOperate(subArgs);
+    case "openshell":
+      return cmdOpenshell(subArgs);
     case "agents":
       return cmdAgents();
     case "analytics":

--- a/src/openshell-cli.ts
+++ b/src/openshell-cli.ts
@@ -1,0 +1,574 @@
+/**
+ * `sportsclaw openshell` — doctor + setup wizard for the optional
+ * NVIDIA OpenShell integration.
+ *
+ * Subcommands:
+ *   sportsclaw openshell doctor          diagnose prereqs, print remediation hints
+ *   sportsclaw openshell doctor --json   machine-readable output
+ *   sportsclaw openshell setup           guided interactive installer
+ *
+ * The wizard NEVER imports OpenShell as a library — it only shells out
+ * to the `openshell` CLI binary and `docker`. That keeps the engine's
+ * optional-at-install promise intact: nothing in this file runs unless
+ * the user explicitly invokes `sportsclaw openshell ...`.
+ */
+
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+
+import pc from "picocolors";
+
+import {
+  operatorConfigDir,
+  operatorConfigPath,
+} from "./operator-config.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CheckStatus = "ok" | "missing" | "warn";
+
+export interface CheckResult {
+  /** Stable id for the check (e.g. "openshell-cli"). */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  status: CheckStatus;
+  /** Free-text detail (version string, "not found", etc.). */
+  detail?: string;
+  /** Concrete command/action the user should take when status !== "ok". */
+  hint?: string;
+}
+
+export interface DoctorReport {
+  results: CheckResult[];
+  /** True when every check has status "ok". */
+  allOk: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Process probes (small, side-effect-free, no throws)
+// ---------------------------------------------------------------------------
+
+interface ProbeResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+function probe(cmd: string, args: string[], timeoutMs = 5_000): ProbeResult {
+  const out = spawnSync(cmd, args, {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    ok: out.status === 0,
+    stdout: out.stdout ?? "",
+    stderr: out.stderr ?? "",
+    exitCode: out.status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+function checkOpenshellCli(): CheckResult {
+  const r = probe("openshell", ["--version"]);
+  if (!r.ok) {
+    return {
+      id: "openshell-cli",
+      label: "OpenShell CLI",
+      status: "missing",
+      detail: "not on PATH",
+      hint: "curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh",
+    };
+  }
+  const version = r.stdout.trim() || "(version not reported)";
+  return { id: "openshell-cli", label: "OpenShell CLI", status: "ok", detail: version };
+}
+
+function checkContainerRuntime(): CheckResult {
+  const docker = probe("docker", ["info"]);
+  if (docker.ok) {
+    return {
+      id: "container-runtime",
+      label: "Container runtime",
+      status: "ok",
+      detail: "docker",
+    };
+  }
+  const podman = probe("podman", ["info"]);
+  if (podman.ok) {
+    return {
+      id: "container-runtime",
+      label: "Container runtime",
+      status: "ok",
+      detail: "podman",
+    };
+  }
+  return {
+    id: "container-runtime",
+    label: "Container runtime",
+    status: "missing",
+    detail: "neither docker nor podman responds",
+    hint: "Install Docker Desktop or start the daemon, then re-run this check.",
+  };
+}
+
+function checkGateway(): CheckResult {
+  const r = probe("openshell", ["gateway", "list", "-o", "json"]);
+  if (!r.ok) {
+    return {
+      id: "gateway",
+      label: "OpenShell gateway",
+      status: "missing",
+      detail: "no gateway registered",
+      hint: "openshell gateway add http://127.0.0.1:18080 --local --name local && openshell gateway select local",
+    };
+  }
+  // Parsing best-effort — output shape can change across versions.
+  const out = r.stdout.trim();
+  if (!out || out === "[]" || out === "null") {
+    return {
+      id: "gateway",
+      label: "OpenShell gateway",
+      status: "missing",
+      detail: "list is empty",
+      hint: "openshell gateway add http://127.0.0.1:18080 --local --name local && openshell gateway select local",
+    };
+  }
+  return { id: "gateway", label: "OpenShell gateway", status: "ok", detail: "registered" };
+}
+
+function checkProvider(): CheckResult {
+  const r = probe("openshell", ["provider", "list", "-o", "json"]);
+  if (!r.ok) {
+    return {
+      id: "provider",
+      label: "Inference provider",
+      status: "missing",
+      detail: "openshell provider list failed",
+      hint: "openshell provider create --name <name> --type <anthropic|openai|nvidia> --from-existing",
+    };
+  }
+  const out = r.stdout.trim();
+  if (!out || out === "[]" || out === "null") {
+    return {
+      id: "provider",
+      label: "Inference provider",
+      status: "missing",
+      detail: "no providers configured",
+      hint: "openshell provider create --name <name> --type <anthropic|openai|nvidia> --from-existing",
+    };
+  }
+  return {
+    id: "provider",
+    label: "Inference provider",
+    status: "ok",
+    detail: "at least one provider registered",
+  };
+}
+
+function checkInferenceRouting(): CheckResult {
+  const r = probe("openshell", ["inference", "get"]);
+  if (!r.ok || !/Provider:/i.test(r.stdout)) {
+    return {
+      id: "inference-routing",
+      label: "Inference routing",
+      status: "missing",
+      detail: "no provider/model pinned",
+      hint: "openshell inference set --provider <name> --model <model> --timeout 300",
+    };
+  }
+  // Extract Provider + Model lines, lightly tolerant of formatting.
+  const provider = /Provider:\s*(\S+)/i.exec(r.stdout)?.[1];
+  const model = /Model:\s*(\S+)/i.exec(r.stdout)?.[1];
+  return {
+    id: "inference-routing",
+    label: "Inference routing",
+    status: "ok",
+    detail: provider && model ? `${provider} / ${model}` : "configured",
+  };
+}
+
+function checkImage(image: string, id: string, label: string, buildHint: string): CheckResult {
+  const r = probe("docker", ["image", "inspect", image]);
+  if (!r.ok) {
+    return { id, label, status: "missing", detail: "not built", hint: buildHint };
+  }
+  return { id, label, status: "ok", detail: "present" };
+}
+
+function checkApiKey(): CheckResult {
+  const candidates = [
+    { name: "ANTHROPIC_API_KEY", prov: "anthropic" },
+    { name: "OPENAI_API_KEY", prov: "openai" },
+    { name: "NVIDIA_API_KEY", prov: "nvidia" },
+  ];
+  for (const c of candidates) {
+    if ((process.env[c.name] ?? "").trim().length > 0) {
+      return {
+        id: "api-key",
+        label: "Provider API key",
+        status: "ok",
+        detail: `${c.name} set (${c.prov})`,
+      };
+    }
+  }
+  return {
+    id: "api-key",
+    label: "Provider API key",
+    status: "warn",
+    detail: "none of ANTHROPIC_API_KEY / OPENAI_API_KEY / NVIDIA_API_KEY set",
+    hint: "Export one of those env vars before running `openshell provider create --from-existing`.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Doctor — public surface (exported for testing the formatter)
+// ---------------------------------------------------------------------------
+
+export function runChecks(): DoctorReport {
+  const results: CheckResult[] = [
+    checkOpenshellCli(),
+    checkContainerRuntime(),
+    checkGateway(),
+    checkProvider(),
+    checkInferenceRouting(),
+    checkImage(
+      "sportsclaw:latest",
+      "image-base",
+      "sportsclaw:latest image",
+      "docker build -t sportsclaw:latest .",
+    ),
+    checkImage(
+      "sportsclaw-openshell:latest",
+      "image-openshell",
+      "sportsclaw-openshell:latest image",
+      "docker build -t sportsclaw-openshell:latest -f openshell/Dockerfile .",
+    ),
+    checkApiKey(),
+  ];
+  const allOk = results.every((r) => r.status === "ok");
+  return { results, allOk };
+}
+
+const MARKERS: Record<CheckStatus, string> = {
+  ok: pc.green("✓"),
+  missing: pc.red("✗"),
+  warn: pc.yellow("!"),
+};
+
+/** Pretty-print a DoctorReport to stdout. */
+export function formatReport(report: DoctorReport): string {
+  const lines: string[] = [];
+  lines.push(pc.bold("sportsclaw openshell doctor"));
+  lines.push("");
+  const labelWidth = Math.max(...report.results.map((r) => r.label.length), 16);
+  for (const r of report.results) {
+    const marker = MARKERS[r.status];
+    const label = r.label.padEnd(labelWidth + 2);
+    const detail = r.detail ? pc.dim(r.detail) : "";
+    lines.push(`  ${marker} ${label}${detail}`);
+    if (r.status !== "ok" && r.hint) {
+      lines.push(`      ${pc.dim("→")} ${r.hint}`);
+    }
+  }
+  lines.push("");
+  if (report.allOk) {
+    lines.push(pc.green("All checks passed."));
+    lines.push(
+      pc.dim(
+        "Create a sandbox with: openshell sandbox create --from sportsclaw-openshell:latest --policy openshell/policy.yaml --name <name>",
+      ),
+    );
+  } else {
+    const failing = report.results.filter((r) => r.status !== "ok").length;
+    lines.push(
+      pc.yellow(`${failing} check${failing === 1 ? "" : "s"} need attention.`) +
+        " Run " +
+        pc.bold("sportsclaw openshell setup") +
+        " to fix interactively.",
+    );
+  }
+  return lines.join("\n");
+}
+
+async function runDoctor(opts: { json: boolean }): Promise<void> {
+  const report = runChecks();
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatReport(report));
+  }
+  process.exit(report.allOk ? 0 : 1);
+}
+
+// ---------------------------------------------------------------------------
+// Setup wizard
+// ---------------------------------------------------------------------------
+
+function shellOut(cmd: string, args: string[], opts: { allowFailure?: boolean } = {}): boolean {
+  console.log(pc.dim(`$ ${cmd} ${args.join(" ")}`));
+  const out = spawnSync(cmd, args, { stdio: "inherit" });
+  if (out.status !== 0 && !opts.allowFailure) {
+    console.error(pc.red(`Command failed: ${cmd} ${args.join(" ")} (exit ${out.status})`));
+    return false;
+  }
+  return out.status === 0;
+}
+
+async function confirm(rl: ReturnType<typeof createInterface>, prompt: string): Promise<boolean> {
+  const answer = (await rl.question(`${prompt} [Y/n] `)).trim().toLowerCase();
+  return answer === "" || answer === "y" || answer === "yes";
+}
+
+async function ask(rl: ReturnType<typeof createInterface>, prompt: string, def?: string): Promise<string> {
+  const suffix = def ? ` [${def}]` : "";
+  const v = (await rl.question(`${prompt}${suffix}: `)).trim();
+  return v || def || "";
+}
+
+async function fixOpenshellCli(rl: ReturnType<typeof createInterface>): Promise<boolean> {
+  console.log(pc.bold("\nOpenShell CLI is not installed."));
+  console.log(pc.dim("Source: https://github.com/NVIDIA/OpenShell"));
+  if (!(await confirm(rl, "Install it now via the official install.sh?"))) {
+    console.log(pc.yellow("Skipped — install manually before continuing."));
+    return false;
+  }
+  // The official one-liner pipes curl into sh. We replicate via spawn so
+  // the user sees the output.
+  return shellOut("sh", ["-c", "curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh"]);
+}
+
+async function fixGateway(rl: ReturnType<typeof createInterface>): Promise<boolean> {
+  console.log(pc.bold("\nNo OpenShell gateway registered."));
+  if (!(await confirm(rl, "Register a local gateway at http://127.0.0.1:18080?"))) {
+    return false;
+  }
+  if (!shellOut("openshell", ["gateway", "add", "http://127.0.0.1:18080", "--local", "--name", "local"])) {
+    return false;
+  }
+  return shellOut("openshell", ["gateway", "select", "local"]);
+}
+
+async function fixProvider(rl: ReturnType<typeof createInterface>): Promise<boolean> {
+  console.log(pc.bold("\nNo inference provider configured."));
+  console.log("Which provider?");
+  console.log("  1) anthropic  (uses ANTHROPIC_API_KEY)");
+  console.log("  2) openai     (uses OPENAI_API_KEY)");
+  console.log("  3) nvidia     (uses NVIDIA_API_KEY, NVIDIA API Catalog)");
+  const choice = await ask(rl, "Pick 1/2/3", "1");
+  const map: Record<string, { type: string; env: string; defaultModel: string }> = {
+    "1": { type: "anthropic", env: "ANTHROPIC_API_KEY", defaultModel: "claude-opus-4-6" },
+    "2": { type: "openai", env: "OPENAI_API_KEY", defaultModel: "gpt-4.1" },
+    "3": { type: "nvidia", env: "NVIDIA_API_KEY", defaultModel: "nvidia/nemotron-3-super-120b" },
+  };
+  const pick = map[choice];
+  if (!pick) {
+    console.log(pc.red(`Unknown choice ${JSON.stringify(choice)}.`));
+    return false;
+  }
+  if (!(process.env[pick.env] ?? "").trim()) {
+    console.log(
+      pc.yellow(
+        `${pick.env} is not set in your environment. Export it first, then re-run setup.`,
+      ),
+    );
+    return false;
+  }
+  const name = (await ask(rl, "Provider record name", `${pick.type}-prod`)).trim();
+  if (!shellOut("openshell", ["provider", "create", "--name", name, "--type", pick.type, "--from-existing"])) {
+    return false;
+  }
+  const model = await ask(rl, "Model to pin", pick.defaultModel);
+  return shellOut("openshell", [
+    "inference", "set", "--provider", name, "--model", model, "--timeout", "300",
+  ]);
+}
+
+async function fixBaseImage(rl: ReturnType<typeof createInterface>): Promise<boolean> {
+  console.log(pc.bold("\nsportsclaw:latest image not built."));
+  console.log(pc.dim("This builds the root sportsclaw image. Takes several minutes."));
+  if (!(await confirm(rl, "Build it now?"))) return false;
+  return shellOut("docker", ["build", "-t", "sportsclaw:latest", "."]);
+}
+
+async function fixOpenshellImage(rl: ReturnType<typeof createInterface>): Promise<boolean> {
+  console.log(pc.bold("\nsportsclaw-openshell:latest image not built."));
+  console.log(pc.dim("Thin downstream image layering a sandbox user onto sportsclaw:latest."));
+  if (!(await confirm(rl, "Build it now?"))) return false;
+  return shellOut("docker", ["build", "-t", "sportsclaw-openshell:latest", "-f", "openshell/Dockerfile", "."]);
+}
+
+interface ScaffoldOpts {
+  jobId: string;
+  personaText: string;
+  provider: "anthropic" | "openai";
+  model: string;
+  intervalMs: number;
+}
+
+/** Build the JSON content for a scaffolded openshell-enabled job config. */
+export function buildScaffoldConfig(opts: ScaffoldOpts): string {
+  const cfg = {
+    jobId: opts.jobId,
+    label: `${opts.jobId} (OpenShell)`,
+    intervalMs: opts.intervalMs,
+    personaText: opts.personaText,
+    provider: opts.provider,
+    model: opts.model,
+    openshell: {},
+  };
+  return JSON.stringify(cfg, null, 2) + "\n";
+}
+
+async function offerScaffold(rl: ReturnType<typeof createInterface>): Promise<void> {
+  console.log(pc.bold("\nScaffold a starter job config?"));
+  if (!(await confirm(rl, "Create a sample openshell-enabled job in ~/.sportsclaw/operator/?"))) {
+    return;
+  }
+  const jobId = (await ask(rl, "Job id (filename basename)", "openshell-tv")).trim();
+  if (!/^[A-Za-z0-9._-]+$/.test(jobId)) {
+    console.log(pc.red(`Invalid jobId ${JSON.stringify(jobId)}.`));
+    return;
+  }
+  const filePath = operatorConfigPath(jobId);
+  if (fs.existsSync(filePath)) {
+    console.log(pc.yellow(`${filePath} already exists — not overwriting.`));
+    return;
+  }
+  fs.mkdirSync(operatorConfigDir(), { recursive: true });
+  const provider = ((await ask(rl, "Provider (anthropic/openai)", "anthropic")).trim() as "anthropic" | "openai");
+  const defaultModel = provider === "openai" ? "gpt-4.1" : "claude-opus-4-6";
+  const model = (await ask(rl, "Model id", defaultModel)).trim();
+  const personaText =
+    (await ask(rl, "Persona (one-line, will be embedded in the system prompt)",
+      "You are SportsClaw, an autonomous broadcast editor.")).trim();
+  const content = buildScaffoldConfig({
+    jobId,
+    personaText,
+    provider: provider === "openai" ? "openai" : "anthropic",
+    model,
+    intervalMs: 60_000,
+  });
+  fs.writeFileSync(filePath, content, "utf8");
+  console.log(pc.green(`Wrote ${filePath}`));
+  console.log(
+    pc.dim("Validate with: sportsclaw operate --validate " + jobId),
+  );
+}
+
+async function runSetup(): Promise<void> {
+  console.log(pc.bold("sportsclaw openshell setup"));
+  console.log("");
+  let report = runChecks();
+  console.log(formatReport(report));
+  console.log("");
+  if (report.allOk) {
+    console.log(pc.green("Nothing to fix."));
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      await offerScaffold(rl);
+    } finally {
+      rl.close();
+    }
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    // Sequential dependency: CLI → runtime → gateway → provider → inference → image.
+    // We re-check after each fix because earlier fixes can unblock later ones.
+    const fixers: Array<{ id: string; fn: () => Promise<boolean> }> = [
+      { id: "openshell-cli", fn: () => fixOpenshellCli(rl) },
+      {
+        id: "container-runtime",
+        fn: async () => {
+          console.log(pc.yellow("Docker / Podman must be started manually — install Docker Desktop or run `sudo systemctl start docker`, then re-run this wizard."));
+          return false;
+        },
+      },
+      { id: "gateway", fn: () => fixGateway(rl) },
+      { id: "provider", fn: () => fixProvider(rl) },
+      { id: "image-base", fn: () => fixBaseImage(rl) },
+      { id: "image-openshell", fn: () => fixOpenshellImage(rl) },
+    ];
+
+    for (const fx of fixers) {
+      report = runChecks();
+      const failing = report.results.find((r) => r.id === fx.id && r.status !== "ok");
+      if (!failing) continue;
+      const ok = await fx.fn();
+      if (!ok) {
+        console.log(pc.yellow(`Skipping remaining steps — fix \"${fx.id}\" first, then re-run.`));
+        return;
+      }
+    }
+
+    report = runChecks();
+    console.log("");
+    console.log(formatReport(report));
+    console.log("");
+    if (report.allOk) {
+      await offerScaffold(rl);
+      console.log("");
+      console.log(pc.green("Setup complete."));
+      console.log(pc.dim("Next: openshell sandbox create --from sportsclaw-openshell:latest --policy openshell/policy.yaml --name <name>"));
+      console.log(pc.dim("Then:  openshell sandbox upload <name> ~/.sportsclaw/operator/<jobId>.json /sandbox/.sportsclaw/operator/<jobId>.json"));
+      console.log(pc.dim("And:   openshell sandbox exec -n <name> -- node /app/dist/index.js operate --job <jobId> --once"));
+    } else {
+      console.log(pc.yellow("Some checks still fail. Re-run the wizard after fixing them manually."));
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+function printOpenshellHelp(): void {
+  console.log([
+    "sportsclaw openshell — optional NVIDIA OpenShell helpers",
+    "",
+    "Usage:",
+    "  sportsclaw openshell doctor          Diagnose prereqs, print remediation hints",
+    "  sportsclaw openshell doctor --json   Machine-readable doctor output",
+    "  sportsclaw openshell setup           Interactive wizard: install, gateway, provider, image, scaffold",
+    "",
+    "Both subcommands shell out to the `openshell` binary and `docker`; nothing is",
+    "imported as a library. OpenShell remains optional at install for everyone else.",
+    "",
+    "Background: openshell/README.md  |  docs/openshell-integration-plan.md",
+  ].join("\n"));
+}
+
+// ---------------------------------------------------------------------------
+// Public entry — dispatcher
+// ---------------------------------------------------------------------------
+
+export async function cmdOpenshell(args: string[]): Promise<void> {
+  const sub = args[0];
+  const rest = args.slice(1);
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    printOpenshellHelp();
+    return;
+  }
+  switch (sub) {
+    case "doctor":
+      return runDoctor({ json: rest.includes("--json") });
+    case "setup":
+      return runSetup();
+    default:
+      console.error(`Unknown openshell subcommand: ${sub}`);
+      printOpenshellHelp();
+      process.exit(2);
+  }
+}

--- a/test/openshell-cli.test.mjs
+++ b/test/openshell-cli.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * `sportsclaw openshell` CLI — focused tests on the pure helpers.
+ *
+ * The doctor's individual probes shell out to `openshell` and `docker`,
+ * which would make any test depend on host state. We test the
+ * formatter and the scaffold builder directly with synthetic inputs.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildScaffoldConfig,
+  formatReport,
+} from "../dist/openshell-cli.js";
+
+// ---------------------------------------------------------------------------
+// formatReport
+// ---------------------------------------------------------------------------
+
+describe("formatReport", () => {
+  it("includes a marker, label, and detail per result", () => {
+    const out = formatReport({
+      results: [
+        { id: "a", label: "Item A", status: "ok", detail: "v1.2.3" },
+        { id: "b", label: "Item B", status: "missing", detail: "not found", hint: "do X" },
+      ],
+      allOk: false,
+    });
+    assert.match(out, /Item A/);
+    assert.match(out, /v1\.2\.3/);
+    assert.match(out, /Item B/);
+    assert.match(out, /not found/);
+    assert.match(out, /→ do X/);
+  });
+
+  it("prints the all-ok banner when every check passes", () => {
+    const out = formatReport({
+      results: [{ id: "a", label: "Item A", status: "ok", detail: "" }],
+      allOk: true,
+    });
+    assert.match(out, /All checks passed/);
+    assert.match(out, /openshell sandbox create/);
+  });
+
+  it("prints a remediation hint pointing at `setup` when any check fails", () => {
+    const out = formatReport({
+      results: [
+        { id: "a", label: "Item A", status: "ok" },
+        { id: "b", label: "Item B", status: "missing", hint: "do X" },
+      ],
+      allOk: false,
+    });
+    assert.match(out, /sportsclaw openshell setup/);
+  });
+
+  it("renders a `warn` status with its hint", () => {
+    const out = formatReport({
+      results: [
+        { id: "k", label: "API key", status: "warn", detail: "not set", hint: "export X" },
+      ],
+      allOk: false,
+    });
+    assert.match(out, /API key/);
+    assert.match(out, /not set/);
+    assert.match(out, /→ export X/);
+  });
+
+  it("does not print a remediation arrow for OK rows", () => {
+    const out = formatReport({
+      results: [{ id: "a", label: "Item A", status: "ok", detail: "fine", hint: "ignored" }],
+      allOk: true,
+    });
+    assert.doesNotMatch(out, /→ ignored/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildScaffoldConfig
+// ---------------------------------------------------------------------------
+
+describe("buildScaffoldConfig", () => {
+  it("produces valid JSON with the openshell block enabled by default", () => {
+    const raw = buildScaffoldConfig({
+      jobId: "tv-op",
+      personaText: "You are an operator.",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      intervalMs: 60000,
+    });
+    const cfg = JSON.parse(raw);
+    assert.strictEqual(cfg.jobId, "tv-op");
+    assert.strictEqual(cfg.provider, "anthropic");
+    assert.strictEqual(cfg.model, "claude-opus-4-6");
+    assert.strictEqual(cfg.intervalMs, 60000);
+    assert.strictEqual(cfg.personaText, "You are an operator.");
+    assert.deepStrictEqual(cfg.openshell, {});
+  });
+
+  it("ends with a trailing newline (POSIX file convention)", () => {
+    const raw = buildScaffoldConfig({
+      jobId: "x",
+      personaText: "...",
+      provider: "openai",
+      model: "gpt-4.1",
+      intervalMs: 30000,
+    });
+    assert.ok(raw.endsWith("\n"));
+  });
+
+  it("survives the operator-config validator", async () => {
+    const { validateOperatorJobConfig } = await import("../dist/operator-config.js");
+    const raw = buildScaffoldConfig({
+      jobId: "scaffold-test",
+      personaText: "You are SportsClaw.",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      intervalMs: 60000,
+    });
+    const parsed = JSON.parse(raw);
+    const result = validateOperatorJobConfig(parsed);
+    assert.strictEqual(result.valid, true, JSON.stringify(result.issues));
+    assert.deepStrictEqual(result.config.openshell, {
+      enabled: undefined,
+      baseUrl: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `sportsclaw openshell doctor` — diagnoses prereqs (OpenShell CLI, Docker, gateway, provider, inference routing, base + sandbox images, API keys) and prints a remediation command for each missing item. Exits non-zero when anything fails; `--json` for scripts/CI.
- `sportsclaw openshell setup` — interactive wizard that walks through fixing each failing check (install OpenShell, register gateway, create provider, set inference routing, build both Docker images, scaffold an `openshell`-enabled starter job config).
- New runbook section in `openshell/README.md` flags the wizard as the easy path; the existing manual quickstart stays for power users.

## Why

The current manual flow is ~12 commands across `openshell`, `docker`, and `sportsclaw`. New users were unlikely to get there without hand-holding. Doctor closes the diagnostic gap; setup closes the install gap.

## Optional-at-install preserved

- The wizard only **shells out** to `openshell` and `docker`. It never imports OpenShell as a library.
- No new `package.json` dependencies. The npm install path is unchanged for tenants who don't use OpenShell.
- Engine code paths added by PR #60 remain inert unless a job config opts in via an `openshell` block — the wizard just makes opting in easier.

## What changed

| File | Δ |
|---|---|
| `src/openshell-cli.ts` | **new** — doctor + setup dispatcher, individual probe functions, `formatReport`, `buildScaffoldConfig`. |
| `src/index.ts` | `case "openshell"` + help line. |
| `test/openshell-cli.test.mjs` | **new** — 8 tests for the pure helpers. |
| `package.json` | new `test:openshell-cli` script. |
| `openshell/README.md` | runbook now leads with the wizard. |

Net: ~700 LOC (most of it the wizard module + tests).

## Dependency

This PR targets **`feat/openshell-integration`** (PR #60), not `main`. Merge order: #60 first, then this. If #60 changes substantially during review, this branch may need a rebase.

## Test plan

- [x] `npm run build` — clean tsc.
- [x] `npm run test:openshell-cli` — 8/8 (formatter + scaffold).
- [x] `npm run test:operator-config` — 39/39 (regression).
- [x] `npm run test:operator-daemon` — 34/34.
- [x] `npm run test:operate` — 26/26.
- [x] `npm run test:operator-sink` — 5/5.
- [x] `npm run test:ci-smoke` — PASSED.
- [x] Manual: `sportsclaw openshell doctor` on a host with no OpenShell — correctly reports all 8 checks as missing with remediation hints, exits 1.
- [x] Manual: `sportsclaw openshell doctor --json` — emits structured `DoctorReport`.
- [x] Manual: `sportsclaw openshell help` and bare `sportsclaw openshell` — both print the subcommand help.
- [ ] Manual: end-to-end `sportsclaw openshell setup` on a host with no OpenShell installed (requires destructive install steps; reviewer's call whether to verify locally).

## Design notes

- Help via `sportsclaw openshell help` rather than `--help` because the top-level dispatcher catches `--help` everywhere in argv before subcommand dispatch. Not worth refactoring the top-level for this.
- Setup is sequential — earlier fixes can unblock later checks (e.g. installing OpenShell makes the gateway check meaningful). We re-run `runChecks()` after each fix.
- Docker / Podman startup is **not** automated; the wizard tells the user to start it manually. Auto-starting Docker is too platform-specific and too easy to get wrong.
- The scaffolded config uses `"openshell": {}` (empty block = enabled with defaults) and explicit provider + model fields per Phase 1's D2 single-provider-per-job constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)