### PR TITLE
feat(operator): opt-in structured output via sink.getOutputSchema + cfg.skills toolset filter

### DIFF
--- a/src/operate.ts
+++ b/src/operate.ts
@@ -591,6 +591,7 @@ async function runOnce(jobId: string): Promise<void> {
       mcpManager: tools.mcpManager,
       cfg,
     };
+    const outputSchema = sink.getOutputSchema?.({ cfg });
     const daemon = createOperatorDaemon({
       jobId: cfg.jobId,
       jobLabel: cfg.label,
@@ -603,6 +604,7 @@ async function runOnce(jobId: string): Promise<void> {
       guardOptions: cfg.guardOptions,
       enableMemoryTools: cfg.enableMemoryTools,
       inferenceRoute: inputs.inferenceRoute,
+      ...(outputSchema ? { outputSchema } : {}),
       onTickEvent: sink.onTickEvent
         ? async (evt) => { await sink.onTickEvent!(evt, ctx); }
         : undefined,
@@ -666,6 +668,7 @@ async function runForeground(jobId: string): Promise<void> {
     mcpManager: tools.mcpManager,
     cfg,
   };
+  const outputSchema = sink.getOutputSchema?.({ cfg });
   const daemon = createOperatorDaemon({
     jobId: cfg.jobId,
     jobLabel: cfg.label,
@@ -678,6 +681,7 @@ async function runForeground(jobId: string): Promise<void> {
     guardOptions: cfg.guardOptions,
     enableMemoryTools: cfg.enableMemoryTools,
     inferenceRoute: inputs.inferenceRoute,
+    ...(outputSchema ? { outputSchema } : {}),
     onTickEvent: sink.onTickEvent
       ? async (evt) => { await sink.onTickEvent!(evt, ctx); }
       : (evt) => console.log(JSON.stringify(evt)),

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -260,6 +260,16 @@ async function buildOperatorTools(
   verbose: boolean,
   sink?: OperatorSinkPlugin,
 ): Promise<OperatorTools> {
+  // Apply the per-job skill filter BEFORE loadAllSchemas reads
+  // process.env.SPORTSCLAW_SKILLS. Lets focused jobs (e.g. a World Cup
+  // channel that only needs football + news + prediction markets) trim
+  // the ~300-tool default to a tight subset — smaller prompts, faster
+  // ticks, and the toolset fits within Gemini's responseSchema +
+  // function-calling complexity envelope. If the env var is already set
+  // by the caller (e.g. integration tests), respect that — don't override.
+  if (cfg.skills && cfg.skills.length > 0 && !process.env.SPORTSCLAW_SKILLS) {
+    process.env.SPORTSCLAW_SKILLS = cfg.skills.join(",");
+  }
   const registry = new ToolRegistry();
   for (const schema of loadAllSchemas()) {
     registry.injectSchema(schema, false);

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -59,6 +59,27 @@ export interface OperatorJobConfig {
    * BROADCAST_DIRECTIVE_FRAGMENT) and used as inline text otherwise.
    */
   extraFragments?: string[];
+  /**
+   * Sport-skill schemas to load for this job. When set, the launcher applies
+   * the list as `SPORTSCLAW_SKILLS` for this process before `loadAllSchemas()`
+   * is invoked — only the named skills' tools become available to the LLM.
+   *
+   * Why: the default behaviour loads every installed schema (~14 sports +
+   * markets + metadata + betting → ~300 tool surfaces in a typical install).
+   * For a focused job (e.g. a World Cup channel that only needs football +
+   * news + prediction markets) this is wasteful in two ways: every tool
+   * description goes into the system prompt, and the combination of the
+   * full toolset with structured output (`OperatorSinkPlugin.getOutputSchema`)
+   * trips a Gemini `responseSchema` complexity limit. Setting a tight
+   * `skills` list fixes both.
+   *
+   * Strings should match schema filenames in `~/.sportsclaw/schemas/`
+   * (without the `.json` suffix), e.g.
+   * `["football","kalshi","polymarket","news","markets","metadata","betting"]`.
+   *
+   * Omit to keep the legacy "load everything" behaviour.
+   */
+  skills?: string[];
   /** Tool guardrail overrides — passed through to ToolGuardController. */
   guardOptions?: Record<string, unknown>;
   /**
@@ -252,6 +273,19 @@ export function validateOperatorJobConfig(
     }
   }
 
+  // skills — sport-skill filter applied as SPORTSCLAW_SKILLS by the launcher
+  if (raw.skills !== undefined) {
+    if (!Array.isArray(raw.skills)) {
+      push("skills", "must be an array of strings");
+    } else {
+      for (let i = 0; i < raw.skills.length; i++) {
+        if (typeof raw.skills[i] !== "string") {
+          push(`skills[${i}]`, "must be a string");
+        }
+      }
+    }
+  }
+
   // guardOptions
   if (
     raw.guardOptions !== undefined &&
@@ -325,6 +359,7 @@ export function validateOperatorJobConfig(
       tailServer: raw.tailServer as string | undefined,
       sink: raw.sink as string | undefined,
       extraFragments: raw.extraFragments as string[] | undefined,
+      skills: raw.skills as string[] | undefined,
       guardOptions: raw.guardOptions as Record<string, unknown> | undefined,
       sinkRole: raw.sinkRole as string | undefined,
       enableMemoryTools: raw.enableMemoryTools as boolean | undefined,

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -406,7 +406,15 @@ export function createOperatorDaemon(
         system,
         prompt: tickPrompt,
         ...(wrappedTools ? { tools: wrappedTools } : {}),
-        maxOutputTokens: cfg.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+        // Structured-output mode emits the full schema payload (narrative +
+        // arrays) plus tool-call reasoning in one budget. 2048 is fine for
+        // free-text ticks; tight for structured ones. Bump the default when
+        // `cfg.outputSchema` is set so the model has headroom to finish.
+        maxOutputTokens:
+          cfg.maxOutputTokens ??
+          (useStructuredOutput
+            ? DEFAULT_MAX_OUTPUT_TOKENS * 2
+            : DEFAULT_MAX_OUTPUT_TOKENS),
         // Allow the model multiple steps so it can call tools and THEN
         // produce a final synthesis text. Without stopWhen, generateText
         // takes a single step and ends with empty text whenever the
@@ -481,12 +489,16 @@ export function createOperatorDaemon(
     // Silent decision:
     //   - structured-output mode: trust the schema's `silent` field. If the
     //     object never came back (SDK couldn't produce a valid match), also
-    //     treat as silent rather than crashing.
+    //     treat as silent rather than crashing. Do NOT also gate on
+    //     `text.length === 0` — a schema-validated payload with silent=false
+    //     but an empty narrative is *malformed*, not silent; the sink decides
+    //     whether to suppress the overlay card (it has malformedBroadcast
+    //     checks that emit nothing to viewers but still keep the trace).
     //   - free-text mode: keep the [SILENT] sentinel match on text.
     let silent: boolean;
     if (useStructuredOutput) {
       const obj = structuredOutput as { silent?: unknown } | undefined;
-      silent = !obj || obj.silent === true || text.length === 0;
+      silent = !obj || obj.silent === true;
     } else {
       silent = LastTickBrief.isSilent(text);
     }

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -36,6 +36,8 @@
 import path from "node:path";
 import {
   generateText,
+  jsonSchema,
+  Output,
   stepCountIs,
   type LanguageModel,
   type ToolSet,
@@ -89,6 +91,16 @@ export interface TickEvent {
   tickId: string;
   /** Final assistant text, if any. Omitted when silent or failed. */
   text?: string;
+  /**
+   * Structured output validated against `cfg.outputSchema`. Populated only
+   * when the daemon ran in structured-output mode (i.e. cfg.outputSchema
+   * was provided) and the model emitted a valid object. When this is set,
+   * `text` is populated with the schema's `narrative` field (if any) for
+   * backwards compatibility with text-consuming sinks. Sinks aware of
+   * structured output should prefer `output` over re-parsing `text` —
+   * the SDK already validated the shape and there's no envelope-leak risk.
+   */
+  output?: unknown;
   /** Reason string for skipped, error message for failed. */
   reason?: string;
   /** ISO 8601 timestamp. */
@@ -180,6 +192,30 @@ export interface OperatorDaemonConfig {
     tickId: string;
     timestamp: string;
   }) => Promise<string | null | undefined> | string | null | undefined;
+
+  /**
+   * Optional structured output spec. When provided, the daemon configures
+   * the LLM call with Vercel AI SDK's `experimental_output: Output.object()`
+   * — the model is forced to emit a JSON object validated against `schema`.
+   *
+   * The shape is the same one returned by `OperatorSinkPlugin.getOutputSchema`:
+   *   { schema: <JSON Schema object>, name?: string, description?: string }
+   *
+   * Two consequences when set:
+   *   1. The `silentSentinel: true` system-prompt fragment is suppressed —
+   *      the model expresses "skip" via the schema's `silent` field
+   *      (sinks that want silent capability should include it in their schema).
+   *   2. The emitted `TickEvent.output` carries the parsed object; `text`
+   *      gets the object's `narrative` field if present (for backwards
+   *      compat with sinks that still read text).
+   *
+   * Omit to keep the legacy free-text path (with `[SILENT]` sentinel parsing).
+   */
+  outputSchema?: {
+    schema: unknown;
+    name?: string;
+    description?: string;
+  };
 
   /** Inject a HeartbeatService (tests). Default: a fresh instance. */
   heartbeat?: HeartbeatService;
@@ -289,12 +325,16 @@ export function createOperatorDaemon(
       perJobLimit: recentBriefLimit,
     });
 
-    // 3. System prompt composition.
+    // 3. System prompt composition. When structured output is in play, the
+    // `[SILENT]` sentinel mechanism is replaced by a `silent` field on the
+    // schema — suppress the prompt fragment so the model doesn't get two
+    // conflicting instructions for the same "skip this tick" intent.
+    const useStructuredOutput = !!cfg.outputSchema;
     const system = buildSystemPrompt({
       role: cfg.role,
       isCron: true,
       toolDiscipline: true,
-      silentSentinel: true,
+      silentSentinel: !useStructuredOutput,
       editorialMemorySnapshot: memorySnapshot,
       recentTickBrief,
       extras: cfg.extraFragments,
@@ -341,9 +381,25 @@ export function createOperatorDaemon(
       .replace("{tickId}", tickId)
       .replace("{timestamp}", timestamp);
 
-    // 5. LLM pass.
+    // 5. LLM pass. Two flavours:
+    //   - Free-text mode (legacy): result.text holds the raw model output;
+    //     `[SILENT]` is matched downstream.
+    //   - Structured mode: `experimental_output: Output.object({schema})`
+    //     constrains + validates the model's final answer; result.experimental_output
+    //     holds the parsed object. text is set to the object's narrative (when
+    //     present) for backwards-compat with text-consuming sinks.
     let text = "";
+    let structuredOutput: unknown;
     let failureReason: string | undefined;
+    const experimental_output = useStructuredOutput
+      ? Output.object({
+          schema: jsonSchema(cfg.outputSchema!.schema as object),
+          ...(cfg.outputSchema!.name ? { name: cfg.outputSchema!.name } : {}),
+          ...(cfg.outputSchema!.description
+            ? { description: cfg.outputSchema!.description }
+            : {}),
+        })
+      : undefined;
     try {
       const result = await generateImpl({
         model: cfg.model,
@@ -356,8 +412,28 @@ export function createOperatorDaemon(
         // takes a single step and ends with empty text whenever the
         // model chose to call tools first.
         stopWhen: stepCountIs(cfg.maxSteps ?? DEFAULT_MAX_STEPS),
+        ...(experimental_output ? { experimental_output } : {}),
       });
-      text = (result.text ?? "").trim();
+      if (useStructuredOutput) {
+        // SDK populates result.experimental_output with the validated object.
+        // If the SDK couldn't produce a valid match (rare, since it retries),
+        // experimental_output is undefined — treat as silent rather than
+        // failing the tick.
+        structuredOutput = (result as { experimental_output?: unknown })
+          .experimental_output;
+        const narrative =
+          structuredOutput &&
+          typeof structuredOutput === "object" &&
+          typeof (structuredOutput as { narrative?: unknown }).narrative ===
+            "string"
+            ? ((structuredOutput as { narrative: string }).narrative).trim()
+            : "";
+        // text is the synthesised narrative (for back-compat) when the
+        // object has one; otherwise empty.
+        text = narrative;
+      } else {
+        text = (result.text ?? "").trim();
+      }
     } catch (err) {
       failureReason = err instanceof Error ? err.message : String(err);
     }
@@ -402,12 +478,26 @@ export function createOperatorDaemon(
 
     await heartbeat.markJobSucceeded(jobId).catch(() => {});
 
-    const silent = LastTickBrief.isSilent(text);
+    // Silent decision:
+    //   - structured-output mode: trust the schema's `silent` field. If the
+    //     object never came back (SDK couldn't produce a valid match), also
+    //     treat as silent rather than crashing.
+    //   - free-text mode: keep the [SILENT] sentinel match on text.
+    let silent: boolean;
+    if (useStructuredOutput) {
+      const obj = structuredOutput as { silent?: unknown } | undefined;
+      silent = !obj || obj.silent === true || text.length === 0;
+    } else {
+      silent = LastTickBrief.isSilent(text);
+    }
     const event: TickEvent = {
       type: silent ? "tick_silent" : "tick_published",
       jobId,
       tickId,
       text: silent ? undefined : text,
+      // Carry structured output even on silent ticks so downstream tools can
+      // observe what the model chose to skip (debugging / metrics).
+      ...(structuredOutput !== undefined ? { output: structuredOutput } : {}),
       timestamp,
       toolCalls: counts.calls,
       guardrailWarnings: counts.warnings,

--- a/src/operator-sink.ts
+++ b/src/operator-sink.ts
@@ -128,6 +128,33 @@ export interface OperatorSinkPlugin {
   }): Promise<string | null | undefined> | string | null | undefined;
 
   /**
+   * Optional structured-output spec the daemon enforces via Vercel AI SDK's
+   * `experimental_output: Output.object({schema})`. When this returns a
+   * value, the daemon:
+   *   - validates every model response against the schema (with SDK-side
+   *     retries on mismatch)
+   *   - suppresses the legacy `[SILENT]` sentinel fragment (the schema is
+   *     expected to carry a `silent` field if the sink wants to support
+   *     "skip this tick")
+   *   - populates `TickEvent.output` with the parsed object, so sinks can
+   *     consume the structured result without any text parsing
+   *
+   * Return `undefined` to keep the legacy free-text path (no SDK validation;
+   * sink owns any envelope parsing). Built-in sinks that don't model a
+   * structured contract should leave this unimplemented.
+   *
+   * Shape:
+   *   { schema: <JSON Schema object>, name?: string, description?: string }
+   *
+   * `name` and `description` are forwarded to `Output.object` — they're hints
+   * that some providers expose to the model (e.g. via the tool/schema name).
+   * Use them; they materially improve adherence on smaller models.
+   */
+  getOutputSchema?(args: { cfg: OperatorJobConfig }):
+    | { schema: unknown; name?: string; description?: string }
+    | undefined;
+
+  /**
    * Per-tick event handler. Called once per `tick_started` / `tick_published`
    * / `tick_silent` / `tick_failed` / `tick_skipped` emission. Sinks may
    * `await` the call — the daemon awaits it before the next tick can fire.

--- a/test/operator-config.test.mjs
+++ b/test/operator-config.test.mjs
@@ -162,6 +162,38 @@ describe("validateOperatorJobConfig — optional fields", () => {
     assert.ok(r.issues.find((i) => i.field === "extraFragments[1]"));
   });
 
+  it("accepts a skills list of strings", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      skills: ["football", "kalshi", "polymarket"],
+    });
+    assert.strictEqual(r.valid, true);
+    assert.deepStrictEqual(r.config.skills, ["football", "kalshi", "polymarket"]);
+  });
+
+  it("accepts an empty skills array (caller's choice — launcher won't set the env var)", () => {
+    const r = validateOperatorJobConfig({ ...base, skills: [] });
+    assert.strictEqual(r.valid, true);
+    assert.deepStrictEqual(r.config.skills, []);
+  });
+
+  it("rejects a non-array skills value", () => {
+    for (const bad of ["football", 42, { football: true }]) {
+      const r = validateOperatorJobConfig({ ...base, skills: bad });
+      assert.strictEqual(r.valid, false, `skills=${JSON.stringify(bad)}`);
+      assert.ok(r.issues.find((i) => i.field === "skills"));
+    }
+  });
+
+  it("rejects a skills entry that is not a string", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      skills: ["football", 42, "polymarket"],
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "skills[1]"));
+  });
+
   it("rejects a tailServer that isn't a URL", () => {
     const r = validateOperatorJobConfig({ ...base, tailServer: "not a url" });
     assert.strictEqual(r.valid, false);

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -755,6 +755,208 @@ describe("editorial-memory tools (daemon wiring)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Structured output — cfg.outputSchema path
+// ---------------------------------------------------------------------------
+
+describe("tickOnce — structured output", () => {
+  const minimalSchema = {
+    type: "object",
+    properties: {
+      silent: { type: "boolean" },
+      narrative: { type: "string" },
+    },
+    required: ["silent"],
+    additionalProperties: false,
+  };
+
+  /**
+   * generateText stub that records its args and returns a fixed result.
+   * `result` is what the daemon will see — for structured mode it must set
+   * `experimental_output` to the validated object.
+   */
+  function makeGenWithResult(result) {
+    const calls = [];
+    const impl = async (args) => {
+      calls.push(args);
+      return result;
+    };
+    impl.calls = calls;
+    return impl;
+  }
+
+  it("passes experimental_output to generateText when outputSchema is set", async () => {
+    const gen = makeGenWithResult({
+      experimental_output: { silent: false, narrative: "Tip-off in 5." },
+    });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema, name: "Broadcast" },
+      }),
+    );
+    await daemon.tickOnce();
+    assert.strictEqual(gen.calls.length, 1);
+    assert.ok(
+      gen.calls[0].experimental_output !== undefined,
+      "expected experimental_output in generateText args",
+    );
+  });
+
+  it("does NOT pass experimental_output when outputSchema is unset (legacy path)", async () => {
+    const gen = makeGenWithResult({ text: "free-text tick" });
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen }),
+    );
+    await daemon.tickOnce();
+    assert.strictEqual(gen.calls.length, 1);
+    assert.strictEqual(gen.calls[0].experimental_output, undefined);
+  });
+
+  it("suppresses the [SILENT] sentinel fragment in the system prompt", async () => {
+    const gen = makeGenWithResult({
+      experimental_output: { silent: false, narrative: "x" },
+    });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+      }),
+    );
+    await daemon.tickOnce();
+    const sys = gen.calls[0].system;
+    assert.doesNotMatch(
+      sys,
+      /\[SILENT\] sentinel/,
+      "schema's silent field replaces the sentinel; both = conflicting instructions",
+    );
+  });
+
+  it("keeps the [SILENT] sentinel fragment when outputSchema is unset", async () => {
+    const gen = makeGenWithResult({ text: "free-text" });
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen }),
+    );
+    await daemon.tickOnce();
+    assert.match(gen.calls[0].system, /\[SILENT\] sentinel/);
+  });
+
+  it("doubles maxOutputTokens default (2048 → 4096) when outputSchema is set", async () => {
+    const gen = makeGenWithResult({
+      experimental_output: { silent: false, narrative: "x" },
+    });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+      }),
+    );
+    await daemon.tickOnce();
+    assert.strictEqual(gen.calls[0].maxOutputTokens, 4096);
+  });
+
+  it("respects explicit cfg.maxOutputTokens override even with outputSchema", async () => {
+    const gen = makeGenWithResult({
+      experimental_output: { silent: false, narrative: "x" },
+    });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+        maxOutputTokens: 1024,
+      }),
+    );
+    await daemon.tickOnce();
+    assert.strictEqual(gen.calls[0].maxOutputTokens, 1024);
+  });
+
+  it("populates TickEvent.output with the validated object and text with .narrative", async () => {
+    const obj = { silent: false, narrative: "Lakers up 102-99 with 2:14 left." };
+    const gen = makeGenWithResult({ experimental_output: obj });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_published");
+    assert.deepStrictEqual(event.output, obj);
+    assert.strictEqual(event.text, obj.narrative);
+  });
+
+  it("treats output.silent=true as tick_silent but still carries output for observability", async () => {
+    const obj = { silent: true, narrative: "" };
+    const gen = makeGenWithResult({ experimental_output: obj });
+    const events = [];
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+        onTickEvent: (e) => events.push(e),
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_silent");
+    assert.strictEqual(event.text, undefined);
+    assert.deepStrictEqual(event.output, obj);
+  });
+
+  it("treats silent=false with empty narrative as tick_published (sink decides what to do)", async () => {
+    // The PR comment explicitly says: a schema-validated payload with
+    // silent=false but an empty narrative is *malformed*, not silent — the
+    // sink is responsible for suppressing/handling it.
+    const obj = { silent: false, narrative: "" };
+    const gen = makeGenWithResult({ experimental_output: obj });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_published");
+    assert.strictEqual(event.text, "");
+    assert.deepStrictEqual(event.output, obj);
+  });
+
+  it("treats missing experimental_output as tick_silent (SDK couldn't produce a match)", async () => {
+    const gen = makeGenWithResult({ text: "ignored in structured mode" });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: { schema: minimalSchema },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_silent");
+    assert.strictEqual(event.text, undefined);
+    assert.strictEqual(event.output, undefined);
+  });
+
+  it("forwards name/description on outputSchema (preserves them through Output.object)", async () => {
+    // We can't introspect Output.object's internals from here; the best we
+    // can do is confirm the daemon still emits experimental_output when
+    // name+description are present (i.e. didn't accidentally crash).
+    const gen = makeGenWithResult({
+      experimental_output: { silent: false, narrative: "ok" },
+    });
+    const daemon = createOperatorDaemon(
+      baseConfig({
+        generateTextImpl: gen,
+        outputSchema: {
+          schema: minimalSchema,
+          name: "Broadcast",
+          description: "TV broadcast tick payload",
+        },
+      }),
+    );
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_published");
+    assert.ok(gen.calls[0].experimental_output !== undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Public entry re-exports
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds opt-in structured-output support to the operator daemon — when a sink returns a JSON schema from `getOutputSchema(cfg)`, the daemon constrains the LLM via Vercel AI SDK's `experimental_output: Output.object({schema})`, validates the response, and populates a new `TickEvent.output` field on success. Falls back to the legacy free-text + `[SILENT]` sentinel path when no schema is returned, so existing sinks keep working unchanged.

Also adds `cfg.skills?: string[]` — a per-job sport-skill filter that's applied as `SPORTSCLAW_SKILLS` before `loadAllSchemas()`. This lets focused operators (e.g. a World Cup channel) trim the default ~300-tool surface down to the subset they actually use, which is both an efficiency win (smaller prompts → faster ticks → cheaper) and the workaround for Gemini's `responseSchema + many-tools` complexity limit.

Verified end-to-end on a Gemini 3.5 Flash channel: structured payloads validate cleanly, the consuming sink (`@machina-sports/tv-operator-sink`) reads `evt.output` directly without envelope parsing.

## Changes

- **`OperatorDaemonConfig.outputSchema?: { schema, name?, description? }`** — when set, daemon passes `experimental_output` to `generateText` AND suppresses the `silentSentinel: true` system-prompt fragment (the `silent` field on the schema replaces it).
- **`TickEvent.output?: unknown`** — populated with the validated object on `tick_published`. `text` is also populated with the object's `narrative` field for back-compat with text-consuming sinks.
- **`OperatorSinkPlugin.getOutputSchema?({cfg})`** — optional hook sinks implement to declare their schema. Returning `undefined` keeps the legacy path.
- **`OperatorJobConfig.skills?: string[]`** — applied as `SPORTSCLAW_SKILLS` in `buildOperatorTools` before `loadAllSchemas()` runs. Filters the loaded sport-skill schemas to the named subset (matches filenames in `~/.sportsclaw/schemas/`).
- **Token budget bump** — when `cfg.outputSchema` is set, default `maxOutputTokens` doubles to 4096. The full structured payload (narrative + arrays + tool reasoning) regularly tripped MAX_TOKENS at 2048.
- **Silent decision** — in structured mode, trust the schema's `silent` field. Removed the `text.length === 0` short-circuit that mis-classified malformed payloads as silent (sinks have their own malformed-broadcast detection that handles overlay surfaces correctly).

## Compatibility

- Sinks that don't implement `getOutputSchema` keep the legacy `generateText + [SILENT]` behaviour byte-for-byte.
- Existing operator job configs without `skills` keep the "load everything" behaviour.
- Existing TickEvent consumers reading `text` keep working — the new `output` field is purely additive.
- Tested with `gemini-3.5-flash` + tools + structured output. Older Gemini models (`gemini-2.5-flash`) don't support tools + `responseMimeType: application/json` combined — those will surface as provider errors via the existing daemon error path. See [Vercel AI #11947](https://github.com/vercel/ai/issues/11947) for the upstream tracking.

## Gemini limits I hit (and the fix)

First end-to-end attempt with a full broadcast schema + the operator's default ~300-tool surface returned HTTP 400 \"Request contains an invalid argument\" from Gemini 3.5 Flash. Reproducibly:

| Schema | Tools | Result |
|---|---|---|
| Full broadcast schema | 0 tools | ✅ |
| Full broadcast schema | 1 tool | ✅ |
| Full broadcast schema | 301 tools | ❌ |
| 2-field schema | 301 tools | ✅ |

The official docs' guidance is exactly this case: *\"The API may reject very large or deeply nested schemas. If you encounter errors, try simplifying your schema by shortening property names, reducing nesting, or limiting the number of constraints.\"* Trimming the toolset (the new `cfg.skills` filter) is the same family of fix and the right thing to do regardless — a focused operator doesn't need 14 sports' worth of tool descriptions in every prompt.

## Test plan

- [x] `npm run build` clean
- [x] Live tick on Gemini 3.5 Flash with full schema + `cfg.skills` = 7 entries (~80 tools) — structured output validated, sink consumed `evt.output` directly
- [x] Existing free-text sinks (no `getOutputSchema`) — daemon path unchanged
- [ ] Add unit tests for the new `outputSchema` config path in `operator-daemon.test.mjs` (follow-up if reviewer wants belt-and-braces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)