### PR TITLE
fix(operator): post-merge hardening — payload cap, ledger visibility, drop TV fallback default

### DIFF
--- a/src/last-tick-brief.ts
+++ b/src/last-tick-brief.ts
@@ -50,6 +50,18 @@ export interface TickBrief {
 
 export const SILENT_SENTINEL = "[SILENT]";
 
+/**
+ * Max bytes a chained payload may occupy in a brief's serialized form before
+ * we elide it. The chained payload is re-injected into every subsequent
+ * tick's system prompt via `contextFrom` + `renderJobSection`, so an
+ * unbounded payload would compound across ticks and blow the prompt budget.
+ *
+ * 4 KB lets a typical "next-tick state" (cue id, remaining duration, channel
+ * meta) through while clipping multi-block manifests that belong on the
+ * sink's structured-output channel, not the chained brief context.
+ */
+export const MAX_PAYLOAD_BYTES = 4096;
+
 export interface ContextFromOptions {
   /** How many briefs per job to pull. Default 1 (the most recent). */
   perJobLimit?: number;
@@ -191,7 +203,22 @@ export function serializeBrief(brief: TickBrief): string {
     `silent: ${brief.silent ? "true" : "false"}`,
   ];
   if (brief.payload !== undefined) {
-    fm.push(`payload: ${JSON.stringify(brief.payload)}`);
+    const serialized = JSON.stringify(brief.payload);
+    // Elide oversized payloads. A truncated JSON string in the frontmatter
+    // would be unparseable and would also corrupt every downstream prompt
+    // that re-renders it via renderJobSection. Replace with a marker the
+    // next tick can recognise and reason about ("there was state, but it
+    // was too big to chain — fetch fresh via tools if you need it").
+    if (serialized.length > MAX_PAYLOAD_BYTES) {
+      const marker = JSON.stringify({
+        _elided: true,
+        reason: "payload exceeded MAX_PAYLOAD_BYTES",
+        approxBytes: serialized.length,
+      });
+      fm.push(`payload: ${marker}`);
+    } else {
+      fm.push(`payload: ${serialized}`);
+    }
   }
   fm.push(FRONTMATTER_DELIM);
   return `${fm.join("\n")}\n\n${brief.body}\n`;

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -110,10 +110,18 @@ export interface OperatorJobConfig {
   /**
    * Broadcast-safety validation gate. When `enabled` is true and the daemon
    * is in structured-output mode, the validated payload is passed through
-   * `validateManifestCoverage(structuredOutput, options)`. If validation
-   * fails, the daemon emits `fallbackManifest` (or a default emergency-slate
-   * manifest) in place of the model's output and records the original on
-   * `TickEvent.safetyValidation.originalOutput` for the trace.
+   * `validateManifestCoverage(structuredOutput, options)`.
+   *
+   * On validation failure:
+   *   - If `fallbackManifest` is configured, the daemon emits it in place
+   *     of the model's output. The tick is `tick_published` with
+   *     `safetyValidation.fallbackTriggered = true` and the original on
+   *     `safetyValidation.originalOutput`.
+   *   - If `fallbackManifest` is NOT configured, the tick escalates to
+   *     `tick_failed`. The daemon refuses to invent broadcast content —
+   *     supplying the fallback shape is the sink's responsibility, not the
+   *     daemon's. The original output is still preserved on
+   *     `safetyValidation.originalOutput` for trace.
    *
    * The gate only fires when both `outputSchema` and `broadcastSafety` are
    * set — sinks that don't model a broadcast manifest can ignore this.

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -490,7 +490,12 @@ export function createOperatorDaemon(
       failureReason = err instanceof Error ? err.message : String(err);
     }
 
-    // Broadcast Safety Validation Gate (PR 2)
+    // Broadcast Safety Validation Gate.
+    // The fallback must be supplied by the caller — the daemon refuses to
+    // invent broadcast content. Without a configured `fallbackManifest`,
+    // a failed safety check turns into a `tick_failed` event so the sink
+    // can apply its own emergency-slate logic rather than viewers seeing
+    // a daemon-shaped fake.
     let safetyValidation: TickEvent["safetyValidation"] = undefined;
     if (!failureReason && cfg.broadcastSafety?.enabled && useStructuredOutput && structuredOutput) {
       const validationOpts = cfg.broadcastSafety.options ?? {};
@@ -502,33 +507,30 @@ export function createOperatorDaemon(
 
       if (!validationResult.ok) {
         const originalOutput = structuredOutput;
-        const fallbackManifest = cfg.broadcastSafety.fallbackManifest ?? {
-          id: `fallback-${tickId}`,
-          channelId: jobId,
-          blocks: [
-            {
-              id: `fallback-evergreen-${tickId}`,
-              title: "Emergency Backup Playout (Evergreen)",
-              durationSec: 300,
-              freshness: "EVERGREEN",
-              fallback: {
-                blockId: "emergency-slate",
-                reason: `Broadcast safety gate fallback triggered: ${validationResult.error}`
-              }
-            }
-          ],
-          createdAt: timestamp
-        };
+        const fallbackManifest = cfg.broadcastSafety.fallbackManifest;
 
-        structuredOutput = fallbackManifest;
-        text = `Emergency fallback active: output failed broadcast safety checks. Error: ${validationResult.error}`;
-        
-        safetyValidation = {
-          passed: false,
-          error: validationResult.error,
-          fallbackTriggered: true,
-          originalOutput,
-        };
+        if (fallbackManifest === undefined) {
+          // No fallback supplied → escalate to tick_failed. The original
+          // output is preserved on safetyValidation so the sink can still
+          // observe what the model produced.
+          failureReason =
+            `Broadcast safety check failed and no fallbackManifest configured: ${validationResult.error}`;
+          safetyValidation = {
+            passed: false,
+            error: validationResult.error,
+            fallbackTriggered: false,
+            originalOutput,
+          };
+        } else {
+          structuredOutput = fallbackManifest;
+          text = `Emergency fallback active: output failed broadcast safety checks. Error: ${validationResult.error}`;
+          safetyValidation = {
+            passed: false,
+            error: validationResult.error,
+            fallbackTriggered: true,
+            originalOutput,
+          };
+        }
       } else {
         safetyValidation = {
           passed: true,
@@ -705,6 +707,9 @@ export function createOperatorDaemon(
         guardrailWarnings: counts.warnings,
         guardrailBlocks: counts.blocks,
         inferenceRoute: cfg.inferenceRoute,
+        // When the failure comes from the safety gate (no fallback configured),
+        // safetyValidation carries the original output and validator error.
+        ...(safetyValidation !== undefined ? { safetyValidation } : {}),
       };
       cfg.onTickEvent?.(event);
       const ledgerSync = await recordLedger(failureReason).catch(() => undefined);

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -129,6 +129,28 @@ export interface TickEvent {
     fallbackTriggered: boolean;
     originalOutput?: unknown;
   };
+  /**
+   * Outcome of the per-tick ledger sync (local JSONL + optional Pod MCP).
+   * Populated whenever the daemon's audit ledger code ran for this tick.
+   * Lets downstream observers detect Pod-sync drift (the local trail wrote
+   * fine but the Pod copy never landed) instead of relying on stderr scrapes.
+   *
+   *   localRun     — `ok` | `failed` | `skipped` (no writer configured)
+   *   podRun       — `ok` | `failed` | `skipped` (no MCP server)
+   *   localIncident, podIncident — present only when an incident was raised
+   *
+   * Errors are surfaced as short strings; full traces still go to stderr.
+   */
+  ledgerSync?: {
+    localRun: "ok" | "failed" | "skipped";
+    localRunError?: string;
+    podRun: "ok" | "failed" | "skipped";
+    podRunError?: string;
+    localIncident?: "ok" | "failed";
+    localIncidentError?: string;
+    podIncident?: "ok" | "failed" | "skipped";
+    podIncidentError?: string;
+  };
 }
 
 export interface OperatorDaemonConfig {
@@ -536,7 +558,10 @@ export function createOperatorDaemon(
       );
     }
 
-    const recordLedger = async (errorReason?: string, isSilent: boolean = false): Promise<void> => {
+    const recordLedger = async (
+      errorReason?: string,
+      isSilent: boolean = false,
+    ): Promise<NonNullable<TickEvent["ledgerSync"]>> => {
       const endedAt = new Date().toISOString();
       const decisions: DecisionRecord[] = [];
 
@@ -584,11 +609,21 @@ export function createOperatorDaemon(
         status: errorReason ? "failed" : "completed",
       };
 
+      const sync: NonNullable<TickEvent["ledgerSync"]> = {
+        localRun: "skipped",
+        podRun: "skipped",
+      };
+      const errMsg = (err: unknown): string =>
+        err instanceof Error ? err.message : String(err);
+
       // 1. Write local run ledger
       try {
         const localRunLedger = new FileAgentRunLedger(path.join(cfg.rootDir, "operator-runs.jsonl"));
         await localRunLedger.append(runRecord);
+        sync.localRun = "ok";
       } catch (err) {
+        sync.localRun = "failed";
+        sync.localRunError = errMsg(err);
         console.error(`[operator-daemon] Failed to write local agent run ledger: ${err}`);
       }
 
@@ -608,18 +643,25 @@ export function createOperatorDaemon(
         try {
           const localIncidentLedger = new FileIncidentLedger(path.join(cfg.rootDir, "incidents.jsonl"));
           await localIncidentLedger.append(incident);
+          sync.localIncident = "ok";
         } catch (err) {
+          sync.localIncident = "failed";
+          sync.localIncidentError = errMsg(err);
           console.error(`[operator-daemon] Failed to write local incident ledger: ${err}`);
         }
 
         // Write MCP Incident Ledger if available
+        sync.podIncident = "skipped";
         if (cfg.mcpManager) {
           const serverName = cfg.mcpManager.getMachinaServerName();
           if (serverName) {
             try {
               const podIncidentLedger = new PodIncidentLedger(cfg.mcpManager, serverName);
               await podIncidentLedger.append(incident);
+              sync.podIncident = "ok";
             } catch (err) {
+              sync.podIncident = "failed";
+              sync.podIncidentError = errMsg(err);
               console.error(`[operator-daemon] Failed to sync incident to Pod: ${err}`);
             }
           }
@@ -633,18 +675,24 @@ export function createOperatorDaemon(
           try {
             const podRunLedger = new PodOperatorRunsLedger(cfg.mcpManager, serverName);
             await podRunLedger.append(runRecord);
+            sync.podRun = "ok";
           } catch (err) {
+            sync.podRun = "failed";
+            sync.podRunError = errMsg(err);
             console.error(`[operator-daemon] Failed to sync agent run ledger to Pod: ${err}`);
           }
         }
       }
+      return sync;
     };
 
     // 7. Heartbeat status + telemetry.
     // Event emission goes BEFORE recordLedger so sinks (Discord, Telegram,
     // broadcast surfaces) react at the speed of local I/O rather than the
-    // speed of the Pod MCP round-trip. tickOnce still awaits the ledger
-    // before returning so tests can observe ledger state via `await tickOnce`.
+    // speed of the Pod MCP round-trip. The ledger sync result is mutated
+    // onto the same event object after the await — sinks that observed the
+    // event synchronously won't see `ledgerSync`, but callers that await
+    // `tickOnce()` (tests, batch consumers) read the final populated form.
     if (failureReason) {
       await heartbeat.markJobFailed(jobId, failureReason).catch(() => {});
       const event: TickEvent = {
@@ -659,7 +707,8 @@ export function createOperatorDaemon(
         inferenceRoute: cfg.inferenceRoute,
       };
       cfg.onTickEvent?.(event);
-      await recordLedger(failureReason).catch(() => {});
+      const ledgerSync = await recordLedger(failureReason).catch(() => undefined);
+      if (ledgerSync) event.ledgerSync = ledgerSync;
       return event;
     }
 
@@ -697,7 +746,8 @@ export function createOperatorDaemon(
       ...(safetyValidation !== undefined ? { safetyValidation } : {}),
     };
     cfg.onTickEvent?.(event);
-    await recordLedger(undefined, silent).catch(() => {});
+    const ledgerSync = await recordLedger(undefined, silent).catch(() => undefined);
+    if (ledgerSync) event.ledgerSync = ledgerSync;
     return event;
   }
 

--- a/test/last-tick-brief.test.mjs
+++ b/test/last-tick-brief.test.mjs
@@ -15,6 +15,7 @@ import os from "node:os";
 import {
   LastTickBrief,
   SILENT_SENTINEL,
+  MAX_PAYLOAD_BYTES,
   serializeBrief,
   parseBrief,
   newTickId,
@@ -244,6 +245,63 @@ describe("serializeBrief / parseBrief", () => {
 
   it("rejects missing required frontmatter fields", () => {
     assert.throws(() => parseBrief("---\ntickId: t\n---\n\nbody"));
+  });
+
+  it("round-trips a small payload verbatim", () => {
+    const brief = {
+      tickId: "tick_pl",
+      jobId: "tv-channel-1",
+      timestamp: "2026-05-22T12:00:00.000Z",
+      body: "Playing live feed.",
+      silent: false,
+      payload: { remainingPlayoutSec: 420, cue: "midroll_1" },
+    };
+    const text = serializeBrief(brief);
+    const parsed = parseBrief(text);
+    assert.deepStrictEqual(parsed.payload, brief.payload);
+  });
+
+  it("elides a payload that exceeds MAX_PAYLOAD_BYTES with an _elided marker", () => {
+    // Build a payload guaranteed to exceed the cap.
+    const big = { junk: "x".repeat(MAX_PAYLOAD_BYTES + 100) };
+    const brief = {
+      tickId: "tick_big",
+      jobId: "tv-channel-1",
+      timestamp: "2026-05-22T12:01:00.000Z",
+      body: "Tick with oversized payload.",
+      silent: false,
+      payload: big,
+    };
+    const text = serializeBrief(brief);
+
+    // The serialized form must NOT contain the original junk string.
+    assert.ok(
+      !text.includes(big.junk),
+      "oversized payload content must not be persisted",
+    );
+
+    // The frontmatter must carry an elision marker that re-parses cleanly.
+    const parsed = parseBrief(text);
+    assert.ok(parsed.payload && typeof parsed.payload === "object");
+    assert.strictEqual(parsed.payload._elided, true);
+    assert.strictEqual(typeof parsed.payload.approxBytes, "number");
+    assert.ok(parsed.payload.approxBytes > MAX_PAYLOAD_BYTES);
+  });
+
+  it("does not elide a payload exactly at the cap", () => {
+    // A payload whose JSON length is below the cap survives intact.
+    // Build one carefully: { "s": "<chars>" } — overhead of `{"s":""}` is 8 bytes.
+    const filler = "y".repeat(MAX_PAYLOAD_BYTES - 16);
+    const brief = {
+      tickId: "tick_edge",
+      jobId: "tv-channel-1",
+      timestamp: "2026-05-22T12:02:00.000Z",
+      body: "Edge case.",
+      silent: false,
+      payload: { s: filler },
+    };
+    const parsed = parseBrief(serializeBrief(brief));
+    assert.deepStrictEqual(parsed.payload, brief.payload);
   });
 });
 

--- a/test/operator-ledger-pod.test.mjs
+++ b/test/operator-ledger-pod.test.mjs
@@ -192,4 +192,67 @@ describe("Operator Daemon — Ledgers & Pod Sync", () => {
     assert.strictEqual(incidentRecord.level, "error");
     assert.strictEqual(incidentRecord.component, "safety-gate");
   });
+
+  // -------------------------------------------------------------------------
+  // TickEvent.ledgerSync — visibility for downstream observers
+  // -------------------------------------------------------------------------
+
+  it("populates TickEvent.ledgerSync with local=ok / pod=skipped when MCP is absent", async () => {
+    const gen = makeGenWithResult({ text: "Standard published broadcast" });
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen }),
+    );
+
+    const event = await daemon.tickOnce();
+    assert.ok(event.ledgerSync, "ledgerSync should be populated on tick_published");
+    assert.strictEqual(event.ledgerSync.localRun, "ok");
+    assert.strictEqual(event.ledgerSync.podRun, "skipped");
+  });
+
+  it("populates ledgerSync with podRun=ok when MCP succeeds", async () => {
+    const mcpManager = new MockMcpManager();
+    const gen = makeGenWithResult({ text: "Standard published broadcast" });
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen, mcpManager }),
+    );
+
+    const event = await daemon.tickOnce();
+    assert.ok(event.ledgerSync);
+    assert.strictEqual(event.ledgerSync.localRun, "ok");
+    assert.strictEqual(event.ledgerSync.podRun, "ok");
+  });
+
+  it("surfaces podRun=failed with an error string when the Pod sync throws", async () => {
+    // MockMcpManager that throws on every callToolDirect.
+    const flakyMcp = {
+      getMachinaServerName() { return "mock-machina-server"; },
+      async callToolDirect() { throw new Error("ECONNRESET"); },
+    };
+    const gen = makeGenWithResult({ text: "Standard published broadcast" });
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen, mcpManager: flakyMcp }),
+    );
+
+    const event = await daemon.tickOnce();
+    assert.ok(event.ledgerSync);
+    assert.strictEqual(event.ledgerSync.localRun, "ok", "local ledger is independent");
+    assert.strictEqual(event.ledgerSync.podRun, "failed");
+    assert.match(event.ledgerSync.podRunError ?? "", /ECONNRESET/);
+  });
+
+  it("populates ledgerSync on tick_failed (carrying the incident sync outcome too)", async () => {
+    const mcpManager = new MockMcpManager();
+    const gen = async () => { throw new Error("Inference Timeout Error"); };
+    const daemon = createOperatorDaemon(
+      baseConfig({ generateTextImpl: gen, mcpManager }),
+    );
+
+    const event = await daemon.tickOnce();
+    assert.strictEqual(event.type, "tick_failed");
+    assert.ok(event.ledgerSync);
+    assert.strictEqual(event.ledgerSync.localRun, "ok");
+    assert.strictEqual(event.ledgerSync.localIncident, "ok");
+    assert.strictEqual(event.ledgerSync.podRun, "ok");
+    assert.strictEqual(event.ledgerSync.podIncident, "ok");
+  });
 });

--- a/test/operator-ledger-pod.test.mjs
+++ b/test/operator-ledger-pod.test.mjs
@@ -152,6 +152,22 @@ describe("Operator Daemon — Ledgers & Pod Sync", () => {
       createdAt: new Date().toISOString(),
     };
 
+    // Caller must supply the fallback — the daemon no longer invents content.
+    const sinkFallback = {
+      id: "test-fallback",
+      channelId: "test-ledger-job",
+      blocks: [
+        {
+          id: "evergreen-1",
+          title: "Evergreen",
+          durationSec: 300,
+          freshness: "EVERGREEN",
+          fallback: { blockId: "evergreen", reason: "test fallback" },
+        },
+      ],
+      createdAt: new Date().toISOString(),
+    };
+
     const mcpManager = new MockMcpManager();
     const gen = makeGenWithResult({ experimental_output: invalidManifest });
 
@@ -166,6 +182,7 @@ describe("Operator Daemon — Ledgers & Pod Sync", () => {
         },
         broadcastSafety: {
           enabled: true,
+          fallbackManifest: sinkFallback,
         },
         mcpManager,
       }),

--- a/test/operator-safety.test.mjs
+++ b/test/operator-safety.test.mjs
@@ -92,7 +92,10 @@ describe("Operator Daemon — Broadcast Safety & Fallback Gates", () => {
     assert.strictEqual(event.safetyValidation.fallbackTriggered, false);
   });
 
-  it("triggers fallback gate and replaces manifest when validation fails (missing fallback policy)", async () => {
+  it("escalates to tick_failed when validation fails and no fallbackManifest is configured", async () => {
+    // Per the new contract, the daemon refuses to invent broadcast content.
+    // Without a sink-supplied fallback, a failed safety check is a hard
+    // failure — the sink decides what viewers see, not the daemon.
     const invalidManifest = {
       id: "manifest-bad",
       channelId: "test-safety-job",
@@ -120,18 +123,12 @@ describe("Operator Daemon — Broadcast Safety & Fallback Gates", () => {
     );
 
     const event = await daemon.tickOnce();
-    assert.strictEqual(event.type, "tick_published");
+    assert.strictEqual(event.type, "tick_failed");
+    assert.match(event.reason, /Broadcast safety check failed and no fallbackManifest configured/);
     assert.ok(event.safetyValidation);
     assert.strictEqual(event.safetyValidation.passed, false);
-    assert.strictEqual(event.safetyValidation.fallbackTriggered, true);
-    assert.match(event.safetyValidation.error, /Block must have a fallback policy/);
+    assert.strictEqual(event.safetyValidation.fallbackTriggered, false);
     assert.deepEqual(event.safetyValidation.originalOutput, invalidManifest);
-
-    // Output is replaced by fallback manifest
-    assert.ok(event.output);
-    assert.strictEqual(event.output.channelId, "test-safety-job");
-    assert.strictEqual(event.output.blocks[0].id.startsWith("fallback-evergreen-"), true);
-    assert.match(event.text, /Emergency fallback active/);
   });
 
   it("respects custom fallbackManifest when fallback gate is triggered", async () => {
@@ -177,7 +174,7 @@ describe("Operator Daemon — Broadcast Safety & Fallback Gates", () => {
     assert.deepEqual(event.output, customFallback);
   });
 
-  it("checks freshness and triggers fallback gate for stale LIVE blocks", async () => {
+  it("checks freshness and triggers fallback gate for stale LIVE blocks (with configured fallback)", async () => {
     const staleTimestamp = new Date(Date.now() - 30000).toISOString(); // 30s ago
     const staleManifest = {
       id: "manifest-stale",
@@ -196,6 +193,21 @@ describe("Operator Daemon — Broadcast Safety & Fallback Gates", () => {
       createdAt: new Date().toISOString(),
     };
 
+    const sinkFallback = {
+      id: "sink-emergency",
+      channelId: "test-safety-job",
+      blocks: [
+        {
+          id: "sink-evergreen",
+          title: "Sink-supplied evergreen",
+          durationSec: 300,
+          freshness: "EVERGREEN",
+          fallback: { blockId: "evergreen", reason: "sink fallback" },
+        },
+      ],
+      createdAt: new Date().toISOString(),
+    };
+
     const gen = makeGenWithResult({ experimental_output: staleManifest });
     const daemon = createOperatorDaemon(
       baseConfig({
@@ -207,6 +219,7 @@ describe("Operator Daemon — Broadcast Safety & Fallback Gates", () => {
             requireFreshnessForLiveBlocks: true,
             maxLiveAgeMs: 10000, // 10s maximum age
           },
+          fallbackManifest: sinkFallback,
         },
       }),
     );
@@ -217,5 +230,6 @@ describe("Operator Daemon — Broadcast Safety & Fallback Gates", () => {
     assert.strictEqual(event.safetyValidation.passed, false);
     assert.strictEqual(event.safetyValidation.fallbackTriggered, true);
     assert.match(event.safetyValidation.error, /freshness is stale/);
+    assert.deepEqual(event.output, sinkFallback);
   });
 });


### PR DESCRIPTION
## Summary

Three follow-ups to the operator changes merged in #66 and #67. One PR, three commits, each independently revertable.

### Commit 1 — Cap chained-payload byte size in serializeBrief
A brief's `payload` is re-injected into every subsequent tick's system prompt via `renderJobSection`. Without a per-payload cap, a large structured output (e.g. a manifest with 50 blocks) compounds across ticks and blows the prompt budget — and the existing `maxChars` guard in `contextFrom` slices mid-JSON, leaving an unparseable fragment in the prompt.

Cap at 4 KB by default (`MAX_PAYLOAD_BYTES`). Oversized payloads are replaced with a marker `{ _elided: true, approxBytes }` that the next tick can still parse and reason about ("there was state, but it was too big to chain — fetch fresh via tools if you need it").

### Commit 2 — Surface ledger-sync outcome on TickEvent
Pod-sync failures were silent — logged to stderr and nowhere else. Downstream observers had no way to detect drift between the local audit trail and the Pod copy.

Add `TickEvent.ledgerSync` with per-target outcomes (`localRun`, `podRun`, optional `localIncident` / `podIncident`). Each `"failed"` carries a short `*Error` string; full traces still hit stderr.

Wiring: `recordLedger` now returns the outcome; `tickOnce` mutates the returned event with `event.ledgerSync = await recordLedger(...)` **after** the synchronous `cfg.onTickEvent` fire. Sinks reading the event during the callback see `ledgerSync` as undefined (consistent with "sync hasn't happened yet"); callers that await `tickOnce` read the final populated form.

### Commit 3 — Drop hardcoded TV fallback default; escalate to tick_failed
The operator daemon was inventing broadcast content when the safety gate fired without a configured fallback — a default `{ id, channelId, blocks: [{title: "Emergency Backup Playout (Evergreen)", ...}], createdAt }` was baked into the daemon. That coupled the generic daemon to a specific TV manifest shape and let a daemon-shaped fake reach viewers.

New contract: if `broadcastSafety.fallbackManifest` is not configured and validation fails, the tick escalates to `tick_failed`. The original model output is preserved on `safetyValidation.originalOutput` so the sink can still observe what was produced and apply its own emergency-slate logic.

This is the **minimal** version of the layering fix — `validateManifestCoverage` still lives in the daemon (the feature is honestly TV-shaped). A maximal version would move the validator behind a generic `onValidateOutput` hook and relocate TV-specifics entirely. Deferred until there's a second consumer asking for it.

## Test plan
- [x] `npm run build` clean
- [x] `test:last-tick-brief` — 29 pass (3 new: small/edge/oversized payload round-trip)
- [x] `test:operator-ledger-pod` — 7 pass (4 new: local-only / MCP-success / MCP-failure / failure-path with incident)
- [x] `test:operator-safety` — 4 pass (one renamed to assert escalation, one updated to supply explicit fallback)
- [x] Full sweep: 302 tests across 16 operator-related suites, 0 failures