### PR TITLE
fix(formatters): render tables as labelled cards on Telegram and Discord

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "test:operator-safety": "npm run build && node --test test/operator-safety.test.mjs",
     "test:operator-ledger-pod": "npm run build && node --test test/operator-ledger-pod.test.mjs",
     "test:operator-context-chaining": "npm run build && node --test test/operator-context-chaining.test.mjs",
-    "test:openshell-cli": "npm run build && node --test test/openshell-cli.test.mjs"
+    "test:openshell-cli": "npm run build && node --test test/openshell-cli.test.mjs",
+    "test:formatters-telegram": "npm run build && node --test test/formatters-telegram.test.mjs",
+    "test:formatters-discord": "npm run build && node --test test/formatters-discord.test.mjs"
   },
   "keywords": [
     "sports",

--- a/src/formatters/discord.ts
+++ b/src/formatters/discord.ts
@@ -2,18 +2,17 @@
  * sportsclaw — Discord Renderer
  *
  * Converts a ParsedResponse into a DiscordEmbed object.
- * Tables → code blocks, headers → embed fields, source → footer.
- * Also exports formatTextForDiscord() for rendering LLM responses
- * as Discord-friendly plain text (comparison tables → code blocks).
+ * Headers → embed fields, source → footer, tables → labelled multi-line cards.
+ *
+ * Tables get a Discord-native treatment: each data row becomes a card
+ * (bold first cell as heading, remaining cells as `• **Header:** value`
+ * bullets). Code-block-wrapped tables wrap awkwardly on mobile Discord
+ * and read like CSV; the labelled-card format keeps the data without the
+ * spreadsheet metaphor.
  */
 
-import {
-  parseBlocks,
-  isComparisonTable,
-  renderComparisonText,
-  renderTableAligned,
-} from "./parser.js";
-import type { ParsedResponse } from "./parser.js";
+import { parseBlocks, stripBold } from "./parser.js";
+import type { ParsedResponse, ParsedBlock } from "./parser.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -101,9 +100,8 @@ export function renderDiscord(parsed: ParsedResponse): DiscordEmbed {
 
 /**
  * Parses an LLM response and re-renders it for Discord:
- * - Comparison tables (3 columns) → center-aligned code block
- * - Other tables → padded code block
- * - Everything else preserved as-is (bold, italic, etc.)
+ * - Tables → labelled multi-line cards (one card per data row)
+ * - Everything else preserved as-is (bold, italic, code blocks, etc.)
  */
 export function formatTextForDiscord(response: string): string {
   const parsed = parseBlocks(response);
@@ -128,17 +126,8 @@ function renderBlockForDiscord(block: ParsedResponse["blocks"][number]): string 
     case "header":
       return `**${block.text}**`;
 
-    case "table": {
-      if (isComparisonTable(block.rows)) {
-        return (
-          "```\n" +
-          renderComparisonText(block.rows, block.headerIndex) +
-          "\n```"
-        );
-      }
-      // All other tables: column-padded alignment in a code block
-      return "```\n" + renderTableAligned(block.rows, block.headerIndex) + "\n```";
-    }
+    case "table":
+      return renderTableAsCards(block);
 
     case "code":
       return "```" + block.language + "\n" + block.lines.join("\n") + "\n```";
@@ -146,4 +135,52 @@ function renderBlockForDiscord(block: ParsedResponse["blocks"][number]): string 
     case "text":
       return block.lines.join("\n");
   }
+}
+
+/**
+ * Render a table as Discord markdown, one labelled card per data row.
+ *
+ * Layout per row:
+ *   **{first-cell}**
+ *   • **{header[1]}:** {cell[1]}
+ *   • **{header[2]}:** {cell[2]}
+ *   ...
+ *
+ * Mirrors the Telegram renderer's labelled-card format using Discord's
+ * markdown bold (`**`) instead of HTML `<b>`. No HTML escaping — Discord
+ * isn't HTML; the parser already strips `**` from cells via stripBold so
+ * stray markdown inside values doesn't double-bold.
+ */
+function renderTableAsCards(block: ParsedBlock & { type: "table" }): string {
+  const rows = block.rows.map((row) => row.map((c) => stripBold(c)));
+  const headerIdx = block.headerIndex >= 0 ? block.headerIndex : 0;
+  const headerRow = rows[headerIdx] ?? [];
+  const dataRows = rows.filter((_, i) => i !== headerIdx);
+
+  if (dataRows.length === 0) {
+    return `**${headerRow.join(" · ")}**`;
+  }
+
+  const cards: string[] = [];
+  for (const row of dataRows) {
+    const lines: string[] = [];
+    const heading = (row[0] ?? "").trim();
+    if (heading) {
+      lines.push(`**${heading}**`);
+    }
+    for (let c = 1; c < row.length; c++) {
+      const val = (row[c] ?? "").trim();
+      if (val.length === 0) continue;
+      const label = (headerRow[c] ?? `Col ${c + 1}`).trim();
+      if (label.length === 0) {
+        lines.push(`• ${val}`);
+      } else {
+        lines.push(`• **${label}:** ${val}`);
+      }
+    }
+    if (lines.length > 0) {
+      cards.push(lines.join("\n"));
+    }
+  }
+  return cards.join("\n\n");
 }

--- a/src/formatters/telegram.ts
+++ b/src/formatters/telegram.ts
@@ -2,20 +2,16 @@
  * sportsclaw — Telegram Renderer
  *
  * Converts a ParsedResponse into an HTML string for Telegram's HTML parse mode.
- * Headers → <b>, tables → inline text (no <pre> codeblocks), code → <pre>,
- * bold → <b>, inline code → <code>.
+ * Headers → <b>, code → <pre>, bold → <b>, inline code → <code>.
  *
- * Tables are rendered as formatted text lines with mid-dot separators so they
- * flow naturally in Telegram without the monospace codeblock treatment.
+ * Tables get a Telegram-native treatment: each data row becomes a labelled
+ * multi-line item (bold first cell as heading, remaining cells as bulleted
+ * "Header: value" lines). Telegram has no native table support and `<pre>`
+ * table renderings wrap awkwardly on phone screens, so we drop the
+ * spreadsheet metaphor entirely.
  */
 
-import {
-  stripBold,
-  isComparisonTable,
-  renderComparisonText,
-  renderTableAligned,
-  columnWidths,
-} from "./parser.js";
+import { stripBold } from "./parser.js";
 import type { ParsedResponse, ParsedBlock } from "./parser.js";
 
 // ---------------------------------------------------------------------------
@@ -69,53 +65,64 @@ export function renderTelegram(parsed: ParsedResponse): string {
 }
 
 // ---------------------------------------------------------------------------
-// renderTableAsText — render tables as monospace-aligned <pre> blocks
+// renderTableAsText — Telegram-native labelled multi-line rendering
 // ---------------------------------------------------------------------------
 
 /**
- * Render a table as Telegram HTML.
+ * Render a table as Telegram HTML, one labelled "card" per data row.
  *
- * - Comparison tables (3 cols): center-aligned in <pre> for readable match stats
- * - Compact tables (≤6 cols, ≤15 data rows): column-padded in <pre>
- * - Wide tables (>6 cols): flowing text with bold first column and | separators
+ * Layout per row:
+ *   <b>{first-cell}</b>
+ *   • <b>{header[1]}:</b> {cell[1]}
+ *   • <b>{header[2]}:</b> {cell[2]}
+ *   ...
+ *
+ * Why: Telegram has no native tables. `<pre>`-wrapped grids wrap awkwardly
+ * on narrow screens and pipe-separated flowing text reads like CSV. The
+ * labelled-card format keeps the data without the spreadsheet metaphor.
+ *
+ * Edge cases:
+ *   - 1-column tables: just bold the value (no labels to attach).
+ *   - Empty cells: skipped (no "Label:" line emitted for blank values).
+ *   - Header has fewer cells than a data row: extra cells fall back to "Col N".
+ *   - No data rows: the header itself is bolded with ` · ` separators.
  */
 function renderTableAsText(block: ParsedBlock & { type: "table" }): string {
   const rows = block.rows.map((row) => row.map((c) => stripBold(c)));
   const headerIdx = block.headerIndex >= 0 ? block.headerIndex : 0;
-  const headerRow = rows[headerIdx];
+  const headerRow = rows[headerIdx] ?? [];
   const dataRows = rows.filter((_, i) => i !== headerIdx);
 
   if (dataRows.length === 0) {
-    return `<b>${escapeHtml(headerRow.join("  "))}</b>`;
+    return `<b>${escapeHtml(headerRow.join(" · "))}</b>`;
   }
 
-  // Comparison tables (3 columns): center-aligned in <pre>
-  if (isComparisonTable(rows)) {
-    return `<pre>${escapeHtml(renderComparisonText(rows, block.headerIndex))}</pre>`;
-  }
-
-  const numCols = Math.max(...rows.map((r) => r.length));
-
-  // Compact tables: column-padded in <pre> for proper alignment.
-  // Telegram <pre> blocks scroll horizontally, so an aligned table that
-  // scrolls is far better than an unaligned one that doesn't.
-  const widths = columnWidths(rows);
-  const totalWidth = widths.reduce((s, w) => s + w, 0) + Math.max(0, numCols - 1) * 3;
-  if (numCols <= 6 && dataRows.length <= 15 && totalWidth <= 64) {
-    return `<pre>${escapeHtml(renderTableAligned(rows, block.headerIndex))}</pre>`;
-  }
-
-  // Wide tables: flowing text with bold first column
-  const lines: string[] = [];
+  const cards: string[] = [];
   for (const row of dataRows) {
-    const parts: string[] = [];
-    for (let c = 0; c < row.length; c++) {
-      const val = row[c] || "";
-      parts.push(c === 0 ? `<b>${escapeHtml(val)}</b>` : escapeHtml(val));
+    const lines: string[] = [];
+    // First cell is the row heading (bold).
+    const heading = (row[0] ?? "").trim();
+    if (heading) {
+      lines.push(`<b>${escapeHtml(heading)}</b>`);
     }
-    lines.push(parts.join(" | "));
+    // Remaining cells become labelled bullets keyed by the header.
+    for (let c = 1; c < row.length; c++) {
+      const val = (row[c] ?? "").trim();
+      if (val.length === 0) continue;
+      const label = (headerRow[c] ?? `Col ${c + 1}`).trim();
+      // 1-column tables (no header label) — just dump the value bolded above.
+      // (Shouldn't normally hit since c >= 1 implies a second column exists.)
+      if (label.length === 0) {
+        lines.push(`• ${escapeHtml(val)}`);
+      } else {
+        lines.push(`• <b>${escapeHtml(label)}:</b> ${escapeHtml(val)}`);
+      }
+    }
+    if (lines.length > 0) {
+      cards.push(lines.join("\n"));
+    }
   }
-  return lines.join("\n");
+  return cards.join("\n\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/formatters-discord.test.mjs
+++ b/test/formatters-discord.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * Discord renderer — tests for renderDiscord + table → labelled-card rendering.
+ *
+ * Tables get labelled-card treatment on Discord (mirrors the Telegram fix):
+ * each data row becomes a bold-headed mini-block with `• **Label:** value`
+ * bullets. Tests pin that behaviour for both the embed and plain-text paths.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseBlocks } from "../dist/formatters/parser.js";
+import {
+  renderDiscord,
+  formatTextForDiscord,
+} from "../dist/formatters/discord.js";
+
+// ---------------------------------------------------------------------------
+// formatTextForDiscord — table rendering
+// ---------------------------------------------------------------------------
+
+describe("formatTextForDiscord — tables", () => {
+  it("renders a fenced multi-column table as labelled cards", () => {
+    const input =
+      "```\n" +
+      "Data | Adversário | Estádio\n" +
+      "13/06/2026 | Marrocos | MetLife Stadium\n" +
+      "20/06/2026 | Haiti | Lincoln Financial Field\n" +
+      "```";
+    const out = formatTextForDiscord(input);
+
+    assert.match(out, /\*\*13\/06\/2026\*\*/);
+    assert.match(out, /• \*\*Adversário:\*\* Marrocos/);
+    assert.match(out, /• \*\*Estádio:\*\* MetLife Stadium/);
+    assert.match(out, /\n\n\*\*20\/06\/2026\*\*/);
+    assert.ok(!out.includes("```\nData"), "table must not be wrapped in a code block");
+    assert.ok(!/Data \| Adversário/.test(out), "pipe row must not appear in output");
+  });
+
+  it("renders a proper markdown table the same way", () => {
+    const input =
+      "| Data | Adversário | Estádio |\n" +
+      "| --- | --- | --- |\n" +
+      "| 13/06/2026 | Marrocos | MetLife |\n" +
+      "| 20/06/2026 | Haiti | Lincoln |";
+    const out = formatTextForDiscord(input);
+
+    assert.match(out, /\*\*13\/06\/2026\*\*/);
+    assert.match(out, /• \*\*Adversário:\*\* Marrocos/);
+    assert.match(out, /• \*\*Estádio:\*\* Lincoln/);
+    assert.ok(!out.includes("```"), "no code block on the table path");
+  });
+
+  it("skips blank cells without emitting a 'Label:' line", () => {
+    const input =
+      "```\n" +
+      "Team | W | L\n" +
+      "Lakers | 11 | \n" +
+      "```";
+    const out = formatTextForDiscord(input);
+
+    assert.match(out, /\*\*Lakers\*\*/);
+    assert.match(out, /• \*\*W:\*\* 11/);
+    assert.ok(!/• \*\*L:\*\*/.test(out));
+  });
+
+  it("falls back to 'Col N' when a row is wider than the header", () => {
+    const input =
+      "```\n" +
+      "Stat | Value\n" +
+      "Possession | 58% | extra-cell\n" +
+      "```";
+    const out = formatTextForDiscord(input);
+
+    assert.match(out, /\*\*Possession\*\*/);
+    assert.match(out, /• \*\*Value:\*\* 58%/);
+    assert.match(out, /• \*\*Col 3:\*\* extra-cell/);
+  });
+
+  it("preserves real code blocks (no embedded table) as ```", () => {
+    const out = formatTextForDiscord(
+      "```javascript\nconst x = 1;\nconsole.log(x);\n```",
+    );
+    assert.match(out, /```javascript\nconst x = 1;\nconsole\.log\(x\);\n```/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderDiscord — embed shape with table content
+// ---------------------------------------------------------------------------
+
+describe("renderDiscord — embed with table", () => {
+  it("puts the labelled-card content in the embed description (no headers)", () => {
+    const input =
+      "```\n" +
+      "Data | Adversário\n" +
+      "13/06/2026 | Marrocos\n" +
+      "20/06/2026 | Haiti\n" +
+      "```";
+    const embed = renderDiscord(parseBlocks(input));
+
+    assert.ok(embed.description);
+    assert.match(embed.description, /\*\*13\/06\/2026\*\*/);
+    assert.match(embed.description, /• \*\*Adversário:\*\* Marrocos/);
+    assert.ok(!embed.description.includes("```"));
+  });
+
+  it("groups a table beneath a header into a field value", () => {
+    const input =
+      "## Agenda da Seleção\n" +
+      "```\n" +
+      "Data | Adversário\n" +
+      "13/06/2026 | Marrocos\n" +
+      "```";
+    const embed = renderDiscord(parseBlocks(input));
+
+    assert.ok(embed.fields && embed.fields.length === 1);
+    assert.strictEqual(embed.fields[0].name, "Agenda da Seleção");
+    assert.match(embed.fields[0].value, /\*\*13\/06\/2026\*\*/);
+    assert.match(embed.fields[0].value, /• \*\*Adversário:\*\* Marrocos/);
+  });
+});

--- a/test/formatters-telegram.test.mjs
+++ b/test/formatters-telegram.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * Telegram renderer — tests for renderTelegram + table → labelled-card rendering.
+ *
+ * Telegram has no native table support; this renderer drops the spreadsheet
+ * metaphor in favour of per-row labelled cards. Tests pin that behaviour and
+ * cover the surrounding block types (headers, code, text, source footer).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseBlocks } from "../dist/formatters/parser.js";
+import { renderTelegram } from "../dist/formatters/telegram.js";
+
+// ---------------------------------------------------------------------------
+// table rendering
+// ---------------------------------------------------------------------------
+
+describe("renderTelegram — tables", () => {
+  it("renders a multi-column fenced-table as one labelled card per data row", () => {
+    const input =
+      "```\n" +
+      "Data | Adversário | Estádio\n" +
+      "13/06/2026 | Marrocos | MetLife Stadium\n" +
+      "20/06/2026 | Haiti | Lincoln Financial Field\n" +
+      "```";
+    const out = renderTelegram(parseBlocks(input));
+
+    assert.match(out, /<b>13\/06\/2026<\/b>/);
+    assert.match(out, /• <b>Adversário:<\/b> Marrocos/);
+    assert.match(out, /• <b>Estádio:<\/b> MetLife Stadium/);
+    assert.match(out, /<b>20\/06\/2026<\/b>/);
+    assert.match(out, /• <b>Adversário:<\/b> Haiti/);
+    // Cards separated by a blank line.
+    assert.match(out, /\n\n<b>20\/06\/2026<\/b>/);
+    // No <pre> wrapping, no flowing-pipe text.
+    assert.ok(!out.includes("<pre>"), "table must not emit a <pre> block");
+    assert.ok(!out.includes(" | "), "table must not emit pipe-separated rows");
+  });
+
+  it("renders a proper markdown table (with separator) the same way", () => {
+    const input =
+      "| Data | Adversário | Estádio |\n" +
+      "| --- | --- | --- |\n" +
+      "| 13/06/2026 | Marrocos | MetLife |\n" +
+      "| 20/06/2026 | Haiti | Lincoln |";
+    const out = renderTelegram(parseBlocks(input));
+
+    assert.match(out, /<b>13\/06\/2026<\/b>/);
+    assert.match(out, /• <b>Adversário:<\/b> Marrocos/);
+    assert.match(out, /• <b>Estádio:<\/b> Lincoln/);
+    assert.ok(!out.includes("<pre>"));
+  });
+
+  it("skips blank cells without emitting a 'Label:' line", () => {
+    const input =
+      "```\n" +
+      "Team | W | L\n" +
+      "Lakers | 11 | \n" +
+      "```";
+    const out = renderTelegram(parseBlocks(input));
+
+    assert.match(out, /<b>Lakers<\/b>/);
+    assert.match(out, /• <b>W:<\/b> 11/);
+    // No "• L:" line because the value was blank.
+    assert.ok(!/• <b>L:<\/b>/.test(out), "blank cells must not emit a bullet");
+  });
+
+  it("falls back to 'Col N' when a row is wider than the header", () => {
+    const input =
+      "```\n" +
+      "Stat | Value\n" +
+      "Possession | 58% | extra-cell\n" +
+      "```";
+    const out = renderTelegram(parseBlocks(input));
+
+    assert.match(out, /<b>Possession<\/b>/);
+    assert.match(out, /• <b>Value:<\/b> 58%/);
+    assert.match(out, /• <b>Col 3:<\/b> extra-cell/);
+  });
+
+  it("escapes HTML-sensitive characters inside cells and headers", () => {
+    const input =
+      "```\n" +
+      "Team & Notes | Comment\n" +
+      "<Lakers> | a <b>fake bold</b> tag\n" +
+      "```";
+    const out = renderTelegram(parseBlocks(input));
+
+    assert.match(out, /<b>&lt;Lakers&gt;<\/b>/);
+    assert.match(out, /• <b>Comment:<\/b> a &lt;b&gt;fake bold&lt;\/b&gt; tag/);
+    // The literal "<b>fake bold</b>" must be escaped, not interpreted.
+    assert.ok(!out.includes("<b>fake bold</b>"));
+  });
+
+  it("renders a header-only table as a single bolded line with · separators", () => {
+    // A "table" with no data rows — unusual but possible after filtering.
+    const input =
+      "```\n" +
+      "Col A | Col B | Col C\n" +
+      "```";
+    // parseBlocks with a single pipe-line inside a fence falls through to code
+    // (not table — needs at least 2 rows to trigger parsePipeLines). Skip if so.
+    const blocks = parseBlocks(input).blocks;
+    if (blocks[0]?.type !== "table") return; // not the path we're testing
+    const out = renderTelegram({ blocks, meta: {} });
+    assert.match(out, /<b>Col A · Col B · Col C<\/b>/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// surrounding block types — sanity coverage
+// ---------------------------------------------------------------------------
+
+describe("renderTelegram — other blocks", () => {
+  it("wraps headers in <b>", () => {
+    const out = renderTelegram(parseBlocks("## Match Report"));
+    assert.match(out, /<b>Match Report<\/b>/);
+  });
+
+  it("emits real code blocks (no embedded table) as <pre>", () => {
+    const out = renderTelegram(
+      parseBlocks("```javascript\nconst x = 1;\nconsole.log(x);\n```"),
+    );
+    assert.match(out, /<pre>const x = 1;\nconsole\.log\(x\);<\/pre>/);
+  });
+
+  it("converts **bold** and `inline code` markers in flowing text", () => {
+    const out = renderTelegram(
+      parseBlocks("Tonight: **Lakers** vs `Warriors`."),
+    );
+    assert.match(out, /<b>Lakers<\/b>/);
+    assert.match(out, /<code>Warriors<\/code>/);
+  });
+
+  it("converts a leading - or * into a • bullet", () => {
+    const out = renderTelegram(parseBlocks("- first\n- second"));
+    assert.match(out, /^• first$/m);
+    assert.match(out, /^• second$/m);
+  });
+});


### PR DESCRIPTION
## Summary

Markdown tables looked ugly on both Telegram and Discord — Telegram wide tables ended up as pipe-separated flowing text (CSV-style), and Discord tables always went into \`\`\` code blocks that wrap awkwardly on mobile. Both reads like a spreadsheet dump, not a chat message.

Replace both with a "labelled card" format. Each data row becomes a mini-block: the first cell is a bold heading, the rest become \`• **Header:** value\` bullets.

### Before (Telegram)
\`\`\`html
<b>13/06/2026</b> | Marrocos | MetLife Stadium (East Rutherford, NJ) | A grande estreia contra a fortíssima geração marroquina.
<b>20/06/2026</b> | Haiti | Lincoln Financial Field (Philly, PA) | Obrigação absoluta de vitória...
\`\`\`

### After (Telegram)
\`\`\`html
<b>13/06/2026</b>
• <b>Adversário:</b> Marrocos
• <b>Estádio (Cidade):</b> MetLife Stadium (East Rutherford, NJ)
• <b>Cenário do Confronto:</b> A grande estreia contra a fortíssima geração marroquina.

<b>20/06/2026</b>
• <b>Adversário:</b> Haiti
• <b>Estádio (Cidade):</b> Lincoln Financial Field (Philly, PA)
• <b>Cenário do Confronto:</b> Obrigação absoluta de vitória...
\`\`\`

(Discord output uses \`**bold**\` markdown instead of \`<b>\` HTML, otherwise identical.)

## Changes
- **`src/formatters/telegram.ts`** — replace `renderTableAsText` with the labelled-card layout. Drops the comparison-table (3-col centered) and compact-table (column-padded `<pre>`) special cases in favour of a single uniform format. Removes the `isComparisonTable` / `renderComparisonText` / `renderTableAligned` / `columnWidths` imports (now only used by the CLI renderer).
- **`src/formatters/discord.ts`** — same treatment for the `formatTextForDiscord` and `renderDiscord` (embed) paths. Replaces the always-code-block table rendering with `renderTableAsCards`.
- **New `test/formatters-telegram.test.mjs`** — 10 tests covering the new card format, blank cells, header-narrower-than-row fallback, HTML escaping, and the surrounding block types (headers, code, bold/inline-code in text, leading-`-` bullets).
- **New `test/formatters-discord.test.mjs`** — 7 tests covering the card format for both plain-text and embed paths.

## Edge cases handled
- Blank cells skip their `• Label:` bullet entirely.
- Rows wider than the header fall back to `Col N` labels.
- Header-only tables (no data rows) render as a single bolded line with ` · ` separators.
- HTML-sensitive characters in cells/headers are escaped on the Telegram side; Discord uses markdown so no escaping needed.

## Test plan
- [x] `npm run build` clean
- [x] `test:formatters-telegram` — 10 pass
- [x] `test:formatters-discord` — 7 pass
- [x] Operator-related suites unaffected: `operator-daemon` (45), `operator-config` (50), `operator-safety` (4), `operator-context-chaining` (5), `operator-ledger-pod` (7), `last-tick-brief` (29), `operate` (26) — all pass