### PR TITLE
feat(openshell): doctor --probe, e2e routing fixes, supervisor compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@
 
 FROM node:20-slim AS base
 
-# Install Python 3 and pip into the same image
+# Install Python 3 and pip, plus iproute2 (the OpenShell supervisor's
+# network-namespace setup requires `ip` from iproute2).
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv iproute2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/openshell/README.md
+++ b/openshell/README.md
@@ -126,7 +126,7 @@ For policy field reference, see [OpenShell Policy Schema](https://github.com/NVI
 
 ## Troubleshooting
 
-**`OpenShell mode: cannot resolve "inference.local"`** at startup — the launcher's DNS probe is reporting that you're not inside an OpenShell sandbox. Either run via `openshell sandbox exec` / `openshell sandbox connect`, or set `"openshell": {"enabled": false}` to disable.
+**`OpenShell mode: cannot resolve "inference.local" ... and OPENSHELL_SANDBOX is not set`** at startup — the launcher's probe looked for the `OPENSHELL_SANDBOX=1` env var (which the supervisor exports inside every sandbox container) and then fell back to a DNS lookup. Both failed, so you're almost certainly not inside an OpenShell sandbox. Either run via `openshell sandbox exec` / `openshell sandbox connect`, or set `"openshell": {"enabled": false}` to disable.
 
 **`policy_denied` 403 from the gateway** — a network call is hitting a host that isn't in `network_policies`. Either add it to the policy or route inference via `inference.local` (`openshell inference set ...`).
 
@@ -135,6 +135,28 @@ For policy field reference, see [OpenShell Policy Schema](https://github.com/NVI
 **Tick latency longer than 60s** — Privacy Router default per-call timeout is 60s. For long-thinking Nemotron or Claude with extended reasoning, raise it: `openshell inference set ... --timeout 300`.
 
 **`openshell sandbox create --from sportsclaw-openshell:latest` fails to find the image** — the build step (step 3 above) didn't run, or you're targeting a remote gateway. The CLI uses the local Docker daemon for `--from <image>`; remote gateways need a registry reference instead.
+
+---
+
+## Known upstream issues
+
+### macOS Homebrew install: gateway can't mint sandbox JWTs ([NVIDIA/OpenShell#1523](https://github.com/NVIDIA/OpenShell/issues/1523))
+
+Fresh OpenShell 0.0.47 Homebrew installs on macOS leave sandboxes stuck in `Provisioning` for 300 seconds before timing out with `DependenciesNotReady: ... waiting for supervisor relay`. The root cause is that the Homebrew service wrapper mirrors only the TLS material into the runtime path (`~/.local/state/openshell/homebrew/tls/`) and skips the `jwt/` subdirectory, so the gateway can't mint sandbox JWTs and the supervisor's gRPC policy-fetch is rejected at the application layer.
+
+`sportsclaw openshell doctor --probe` will detect this with the message `sandbox provisioning hangs — no compute driver`.
+
+**Workaround until the upstream fix lands:**
+
+```bash
+cp -R /opt/homebrew/var/openshell/tls/jwt ~/.local/state/openshell/homebrew/tls/
+chmod -R go-rwx ~/.local/state/openshell/homebrew/tls/jwt
+brew services restart openshell
+```
+
+You should then see `gateway-minted sandbox JWT enabled gateway_id=openshell ttl_secs=3600` in `/opt/homebrew/var/log/openshell/openshell-gateway.out.log`. A fresh `sportsclaw openshell doctor --probe` should report `Compute driver ✓ sandbox provisions` in under 5 seconds.
+
+Related upstream issue: [NVIDIA/OpenShell#1372](https://github.com/NVIDIA/OpenShell/issues/1372) — broader macOS Homebrew configuration bootstrap. Affects Podman/Kubernetes drivers (not Docker), but the same packaging gap.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0",
     "picocolors": "^1.1.1",
-    "proper-lockfile": "^4.1.2"
+    "proper-lockfile": "^4.1.2",
+    "undici": "^6.25.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "marked-terminal": "^7.3.0",
     "picocolors": "^1.1.1",
     "proper-lockfile": "^4.1.2",
-    "undici": "^6.25.0"
+    "undici": "^6.6.0"
   }
 }

--- a/src/llm-providers.ts
+++ b/src/llm-providers.ts
@@ -67,10 +67,16 @@ export function resolveModel(
           apiKey: "openshell-unused",
         })(modelId);
       case "openai":
+        // .chat (not the default factory) targets POST /v1/chat/completions.
+        // The default uses /v1/responses, which the OpenShell Privacy Router
+        // proxies through to the upstream — but most OpenAI-compatible
+        // upstreams (NVIDIA API Catalog, Nemotron-on-vLLM, etc.) only serve
+        // /v1/chat/completions and 404 on /v1/responses. Forcing chat keeps
+        // OpenShell mode working across every supported provider.
         return createOpenAI({
           baseURL: openshell.baseUrl,
           apiKey: "openshell-unused",
-        })(modelId);
+        }).chat(modelId);
       case "google":
         throw new Error(
           `OpenShell mode does not support provider "${provider}".`,

--- a/src/openshell-cli.ts
+++ b/src/openshell-cli.ts
@@ -52,11 +52,15 @@ export interface DoctorReport {
 // Process probes (small, side-effect-free, no throws)
 // ---------------------------------------------------------------------------
 
-interface ProbeResult {
+export interface ProbeResult {
   ok: boolean;
   stdout: string;
   stderr: string;
   exitCode: number | null;
+  /** True when spawnSync killed the process because the timeout elapsed.
+   *  For the sandbox-creation probe this is the actual signal we want:
+   *  a healthy driver finishes in seconds, so any timeout is a hang. */
+  timedOut: boolean;
 }
 
 function probe(cmd: string, args: string[], timeoutMs = 5_000): ProbeResult {
@@ -65,11 +69,16 @@ function probe(cmd: string, args: string[], timeoutMs = 5_000): ProbeResult {
     timeout: timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  // spawnSync kills the child with SIGTERM on timeout — status becomes null
+  // and signal is set. We don't get a distinct error code, so use signal
+  // presence as the timeout discriminator.
+  const timedOut = out.status === null && out.signal != null;
   return {
     ok: out.status === 0,
     stdout: out.stdout ?? "",
     stderr: out.stderr ?? "",
     exitCode: out.status,
+    timedOut,
   };
 }
 
@@ -145,8 +154,45 @@ function checkGateway(): CheckResult {
   return { id: "gateway", label: "OpenShell gateway", status: "ok", detail: "registered" };
 }
 
+// OpenShell 0.0.47 prints colorized output that wraps fields like
+// "Provider:" in ANSI escape sequences. Strip them before regex matching,
+// otherwise `\S+` captures `\033[0m` as the "value".
+const ANSI_REGEX = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_REGEX, "");
+}
+
+/** Parse the human-readable `openshell provider list` table. v0.0.47 has
+ *  no `-o json` flag on this subcommand, so we count non-blank lines:
+ *  header alone → no providers; header + ≥1 data row → providers exist. */
+export function parseProviderListOutput(stdout: string): { hasProviders: boolean } {
+  const lines = stripAnsi(stdout)
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  return { hasProviders: lines.length >= 2 };
+}
+
+/** Parse `openshell inference get` output. Looks at the first section
+ *  (Gateway inference) since that's the one the Privacy Router uses to
+ *  route inference.local traffic. Returns empty fields when neither a
+ *  Provider nor Model line appears — "Not configured" sections naturally
+ *  produce that result without a special case. */
+export function parseInferenceGetOutput(stdout: string): {
+  provider?: string;
+  model?: string;
+} {
+  // Scope to the Gateway inference section so a "Not configured" System
+  // inference block doesn't accidentally satisfy the regex.
+  const clean = stripAnsi(stdout);
+  const gatewaySection = clean.split(/^\s*System inference:/im)[0];
+  const provider = /Provider:\s*(\S+)/.exec(gatewaySection)?.[1];
+  const model = /Model:\s*(\S+)/.exec(gatewaySection)?.[1];
+  return { provider, model };
+}
+
 function checkProvider(): CheckResult {
-  const r = probe("openshell", ["provider", "list", "-o", "json"]);
+  const r = probe("openshell", ["provider", "list"]);
   if (!r.ok) {
     return {
       id: "provider",
@@ -156,8 +202,8 @@ function checkProvider(): CheckResult {
       hint: "openshell provider create --name <name> --type <anthropic|openai|nvidia> --from-existing",
     };
   }
-  const out = r.stdout.trim();
-  if (!out || out === "[]" || out === "null") {
+  const { hasProviders } = parseProviderListOutput(r.stdout);
+  if (!hasProviders) {
     return {
       id: "provider",
       label: "Inference provider",
@@ -176,7 +222,17 @@ function checkProvider(): CheckResult {
 
 function checkInferenceRouting(): CheckResult {
   const r = probe("openshell", ["inference", "get"]);
-  if (!r.ok || !/Provider:/i.test(r.stdout)) {
+  if (!r.ok) {
+    return {
+      id: "inference-routing",
+      label: "Inference routing",
+      status: "missing",
+      detail: "openshell inference get failed",
+      hint: "openshell inference set --provider <name> --model <model> --timeout 300",
+    };
+  }
+  const { provider, model } = parseInferenceGetOutput(r.stdout);
+  if (!provider || !model) {
     return {
       id: "inference-routing",
       label: "Inference routing",
@@ -185,14 +241,11 @@ function checkInferenceRouting(): CheckResult {
       hint: "openshell inference set --provider <name> --model <model> --timeout 300",
     };
   }
-  // Extract Provider + Model lines, lightly tolerant of formatting.
-  const provider = /Provider:\s*(\S+)/i.exec(r.stdout)?.[1];
-  const model = /Model:\s*(\S+)/i.exec(r.stdout)?.[1];
   return {
     id: "inference-routing",
     label: "Inference routing",
     status: "ok",
-    detail: provider && model ? `${provider} / ${model}` : "configured",
+    detail: `${provider} / ${model}`,
   };
 }
 
@@ -202,6 +255,72 @@ function checkImage(image: string, id: string, label: string, buildHint: string)
     return { id, label, status: "missing", detail: "not built", hint: buildHint };
   }
   return { id, label, status: "ok", detail: "present" };
+}
+
+/** Interpret the result of a sandbox-creation probe. The OpenShell CLI
+ *  exits 0 even when provisioning times out, so we look at output content
+ *  rather than just the exit code. Catches the case where the gateway is
+ *  up but no compute driver is registered — the symptom we hit in e2e
+ *  testing on 2026-05-23. */
+export function interpretSandboxProbeResult(result: ProbeResult): CheckResult {
+  const combined = `${result.stdout}\n${result.stderr}`;
+  // Driver-missing manifests as either:
+  //  (a) the CLI printing its own "supervisor relay" timeout after ~300s
+  //  (b) our 45s probe killing the CLI before it gets a chance to print
+  // Both mean the same thing: no compute driver picked up the request.
+  if (
+    result.timedOut ||
+    /supervisor relay|DependenciesNotReady|provisioning timed out/i.test(combined)
+  ) {
+    return {
+      id: "compute-driver",
+      label: "Compute driver",
+      status: "missing",
+      detail: "sandbox provisioning hangs — no compute driver",
+      hint: "Restart the OpenShell service: `brew services restart nvidia/openshell/openshell`. If sandboxes still hang, the openshell-driver-vm may need separate setup — see https://github.com/NVIDIA/OpenShell.",
+    };
+  }
+  if (result.ok) {
+    return {
+      id: "compute-driver",
+      label: "Compute driver",
+      status: "ok",
+      detail: "sandbox provisions",
+    };
+  }
+  const firstError =
+    combined
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => /^(error|✗)/i.test(l)) ?? "";
+  return {
+    id: "compute-driver",
+    label: "Compute driver",
+    status: "missing",
+    detail: firstError.slice(0, 120) || `sandbox create failed (exit ${result.exitCode ?? "?"})`,
+    hint: "Run `openshell sandbox create --from sportsclaw:latest --name probe --no-keep -- true` to see the full error.",
+  };
+}
+
+function checkComputeDriver(): CheckResult {
+  // Random name so concurrent doctor runs don't collide.
+  const name = `sc-doctor-${Math.random().toString(36).slice(2, 10)}`;
+  // `--no-keep` auto-deletes after the command exits cleanly, but if
+  // provisioning hangs we never reach that exit and the sandbox lingers in
+  // Provisioning forever. 45s probe timeout: longer than typical provisioning,
+  // shorter than the gateway's 300s patience.
+  const result = probe(
+    "openshell",
+    ["sandbox", "create", "--no-keep", "--name", name, "--from", "sportsclaw:latest", "--", "true"],
+    45_000,
+  );
+  // Best-effort cleanup. Always run — even on success, just in case --no-keep
+  // didn't fire. spawnSync ignores its own non-zero exits via stdio: ignore.
+  spawnSync("openshell", ["sandbox", "delete", name], {
+    timeout: 10_000,
+    stdio: "ignore",
+  });
+  return interpretSandboxProbeResult(result);
 }
 
 function checkApiKey(): CheckResult {
@@ -233,7 +352,7 @@ function checkApiKey(): CheckResult {
 // Doctor — public surface (exported for testing the formatter)
 // ---------------------------------------------------------------------------
 
-export function runChecks(): DoctorReport {
+export function runChecks(opts: { probe?: boolean } = {}): DoctorReport {
   const results: CheckResult[] = [
     checkOpenshellCli(),
     checkContainerRuntime(),
@@ -254,6 +373,12 @@ export function runChecks(): DoctorReport {
     ),
     checkApiKey(),
   ];
+  // Active probe is opt-in: it creates a real (short-lived) sandbox and adds
+  // up to 45s to doctor runtime. The other checks are passive and finish
+  // in well under a second.
+  if (opts.probe) {
+    results.push(checkComputeDriver());
+  }
   const allOk = results.every((r) => r.status === "ok");
   return { results, allOk };
 }
@@ -299,8 +424,8 @@ export function formatReport(report: DoctorReport): string {
   return lines.join("\n");
 }
 
-async function runDoctor(opts: { json: boolean }): Promise<void> {
-  const report = runChecks();
+async function runDoctor(opts: { json: boolean; probe: boolean }): Promise<void> {
+  const report = runChecks({ probe: opts.probe });
   if (opts.json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
@@ -539,9 +664,10 @@ function printOpenshellHelp(): void {
     "sportsclaw openshell — optional NVIDIA OpenShell helpers",
     "",
     "Usage:",
-    "  sportsclaw openshell doctor          Diagnose prereqs, print remediation hints",
-    "  sportsclaw openshell doctor --json   Machine-readable doctor output",
-    "  sportsclaw openshell setup           Interactive wizard: install, gateway, provider, image, scaffold",
+    "  sportsclaw openshell doctor           Diagnose prereqs, print remediation hints",
+    "  sportsclaw openshell doctor --probe   Add a live sandbox-provisioning probe (~45s)",
+    "  sportsclaw openshell doctor --json    Machine-readable doctor output",
+    "  sportsclaw openshell setup            Interactive wizard: install, gateway, provider, image, scaffold",
     "",
     "Both subcommands shell out to the `openshell` binary and `docker`; nothing is",
     "imported as a library. OpenShell remains optional at install for everyone else.",
@@ -563,7 +689,10 @@ export async function cmdOpenshell(args: string[]): Promise<void> {
   }
   switch (sub) {
     case "doctor":
-      return runDoctor({ json: rest.includes("--json") });
+      return runDoctor({
+        json: rest.includes("--json"),
+        probe: rest.includes("--probe"),
+      });
     case "setup":
       return runSetup();
     default:

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -440,6 +440,41 @@ function applyOpenShellEnv(
   }
 }
 
+// Track installation so we don't replace the dispatcher on repeat
+// invocations (each `operate --once` instantiates resolveJobInputs).
+let openShellProxyDispatcherInstalled = false;
+
+/**
+ * Route all outbound fetch() through the supervisor's egress proxy when
+ * the sandbox sets HTTPS_PROXY (10.200.0.1:3128). Node 20 ships undici 5,
+ * which ignores proxy env vars by default; AI SDK and OpenAI SDK both
+ * fall through to Node's global fetch, so without this they'd try to
+ * resolve `inference.local` via real DNS and fail with EAI_AGAIN.
+ *
+ * Dynamic import + try/catch so a missing/older undici degrades to a
+ * warning rather than crashing the engine. Idempotent across ticks.
+ */
+async function installOpenShellProxyDispatcher(): Promise<void> {
+  if (openShellProxyDispatcherInstalled) return;
+  const proxyUrl =
+    process.env.HTTPS_PROXY ??
+    process.env.HTTP_PROXY ??
+    process.env.https_proxy ??
+    process.env.http_proxy;
+  if (!proxyUrl) return;
+  try {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    openShellProxyDispatcherInstalled = true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[openshell] failed to install proxy dispatcher (${msg}); ` +
+        `LLM calls to inference.local will fail with EAI_AGAIN until this is fixed.`,
+    );
+  }
+}
+
 interface ResolvedDaemonInputs {
   provider: LLMProvider;
   modelId: string;
@@ -470,6 +505,7 @@ async function resolveJobInputs(
   const openshell = resolveOpenShell(provider, cfg.openshell);
   if (openshell?.enabled) {
     applyOpenShellEnv(provider, openshell);
+    await installOpenShellProxyDispatcher();
   }
   const inferenceRoute: InferenceRoute = openshell?.enabled
     ? { via: "openshell", baseUrl: openshell.baseUrl, provider, model: modelId }
@@ -486,13 +522,20 @@ async function resolveJobInputs(
 }
 
 /**
- * Best-effort startup probe: when openshell is enabled, confirm
- * `inference.local` (or the configured host) resolves before we hand
- * control to the daemon. Fails fast with a clear error message rather
- * than letting the first generateText surface an opaque DNS error.
- * Mitigates Risk R4 in docs/openshell-integration-plan.md.
+ * Best-effort startup probe: confirm we're really inside an OpenShell
+ * sandbox before handing control to the daemon. Fails fast with a clear
+ * error rather than letting the first generateText surface something
+ * opaque. Mitigates Risk R4 in docs/openshell-integration-plan.md.
+ *
+ * The supervisor exports OPENSHELL_SANDBOX=1 inside every container it
+ * manages — that's the authoritative signal. Real DNS lookups for
+ * `inference.local` don't work because the supervisor intercepts that
+ * traffic at the HTTPS_PROXY layer (10.200.0.1:3128) rather than via
+ * /etc/hosts. DNS is kept as a fallback only for unusual setups where
+ * the env var isn't present.
  */
 async function probeOpenShellHost(baseUrl: string): Promise<void> {
+  if (process.env.OPENSHELL_SANDBOX === "1") return;
   let host: string;
   try {
     host = new URL(baseUrl).hostname;
@@ -510,7 +553,7 @@ async function probeOpenShellHost(baseUrl: string): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `OpenShell mode: cannot resolve "${host}" (${msg}). ` +
+      `OpenShell mode: cannot resolve "${host}" (${msg}) and OPENSHELL_SANDBOX is not set. ` +
         `Are you running inside an OpenShell sandbox? ` +
         `Set openshell.enabled=false or remove the openshell block to disable.`,
     );

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -487,7 +487,27 @@ export function createOperatorDaemon(
         text = (result.text ?? "").trim();
       }
     } catch (err) {
-      failureReason = err instanceof Error ? err.message : String(err);
+      // AI_APICallError shapes its message as "Unknown" when the upstream
+      // returns a non-JSON body the SDK can't parse into a structured error
+      // (e.g. plain-text "404 page not found"). Pull statusCode + a body
+      // excerpt so the failureReason is actionable instead of opaque.
+      if (err instanceof Error) {
+        const apiErr = err as Error & {
+          statusCode?: number;
+          url?: string;
+          responseBody?: string;
+        };
+        const parts: string[] = [err.message || err.name];
+        if (apiErr.statusCode !== undefined) parts.push(`status=${apiErr.statusCode}`);
+        if (apiErr.url) parts.push(`url=${apiErr.url}`);
+        if (apiErr.responseBody) {
+          const body = String(apiErr.responseBody).trim().slice(0, 200);
+          if (body) parts.push(`body=${JSON.stringify(body)}`);
+        }
+        failureReason = parts.join(" ");
+      } else {
+        failureReason = String(err);
+      }
     }
 
     // Broadcast Safety Validation Gate.

--- a/test/openshell-cli.test.mjs
+++ b/test/openshell-cli.test.mjs
@@ -12,6 +12,9 @@ import { describe, it } from "node:test";
 import {
   buildScaffoldConfig,
   formatReport,
+  interpretSandboxProbeResult,
+  parseInferenceGetOutput,
+  parseProviderListOutput,
 } from "../dist/openshell-cli.js";
 
 function stripAnsi(text) {
@@ -76,6 +79,179 @@ describe("formatReport", () => {
       allOk: true,
     });
     assert.doesNotMatch(out, /→ ignored/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseProviderListOutput — `openshell provider list` table parser
+// ---------------------------------------------------------------------------
+
+describe("parseProviderListOutput", () => {
+  // Captured verbatim from `openshell provider list` against OpenShell 0.0.47
+  // with one provider (`nvidia-prod`). Header is wrapped in `\x1B[1m...\x1B[0m`.
+  const WITH_PROVIDERS =
+    "\x1B[1mNAME       \x1B[0m  \x1B[1mTYPE  \x1B[0m  \x1B[1mCREDENTIAL_KEYS \x1B[0m  \x1B[1mCONFIG_KEYS\x1B[0m\n" +
+    "nvidia-prod  nvidia  1                 0\n";
+
+  it("returns hasProviders=true when a data row follows the header", () => {
+    assert.deepStrictEqual(parseProviderListOutput(WITH_PROVIDERS), {
+      hasProviders: true,
+    });
+  });
+
+  it("returns hasProviders=false when only the header is present", () => {
+    const headerOnly =
+      "\x1B[1mNAME       \x1B[0m  \x1B[1mTYPE  \x1B[0m  \x1B[1mCREDENTIAL_KEYS \x1B[0m  \x1B[1mCONFIG_KEYS\x1B[0m\n";
+    assert.deepStrictEqual(parseProviderListOutput(headerOnly), {
+      hasProviders: false,
+    });
+  });
+
+  it("returns hasProviders=false for empty output", () => {
+    assert.deepStrictEqual(parseProviderListOutput(""), {
+      hasProviders: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseInferenceGetOutput — `openshell inference get` parser
+// ---------------------------------------------------------------------------
+
+describe("parseInferenceGetOutput", () => {
+  // Captured verbatim from `openshell inference get` against OpenShell 0.0.47
+  // with nvidia-prod / nvidia/nemotron-3-nano-30b-a3b pinned. Labels are
+  // wrapped in `\x1B[2m...\x1B[0m` — the old `/Provider:\s*(\S+)/` regex
+  // would capture `\x1B[0m` instead of the actual provider name.
+  const CONFIGURED =
+    "\x1B[1m\x1B[36mGateway inference:\x1B[39m\x1B[0m\n\n" +
+    "  \x1B[2mProvider:\x1B[0m nvidia-prod\n" +
+    "  \x1B[2mModel:\x1B[0m nvidia/nemotron-3-nano-30b-a3b\n" +
+    "  \x1B[2mVersion:\x1B[0m 1\n" +
+    "  \x1B[2mTimeout:\x1B[0m 300s\n";
+
+  const NOT_CONFIGURED =
+    "\x1B[1m\x1B[36mGateway inference:\x1B[39m\x1B[0m\n\n" +
+    "  \x1B[2mNot configured\x1B[0m\n\n" +
+    "\x1B[1m\x1B[36mSystem inference:\x1B[39m\x1B[0m\n\n" +
+    "  \x1B[2mNot configured\x1B[0m\n";
+
+  it("extracts provider and model through ANSI-wrapped labels", () => {
+    assert.deepStrictEqual(parseInferenceGetOutput(CONFIGURED), {
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-nano-30b-a3b",
+    });
+  });
+
+  it("returns empty provider/model when both sections report 'Not configured'", () => {
+    assert.deepStrictEqual(parseInferenceGetOutput(NOT_CONFIGURED), {
+      provider: undefined,
+      model: undefined,
+    });
+  });
+
+  it("returns Gateway inference values even when System inference is 'Not configured'", () => {
+    // Real observed case: gateway routing pinned, but system-level default
+    // still unset. We care about gateway routing — that's what `inference.local`
+    // resolves through.
+    const MIXED =
+      "\x1B[1m\x1B[36mGateway inference:\x1B[39m\x1B[0m\n\n" +
+      "  \x1B[2mProvider:\x1B[0m nvidia-prod\n" +
+      "  \x1B[2mModel:\x1B[0m nvidia/nemotron-3-nano-30b-a3b\n" +
+      "  \x1B[2mVersion:\x1B[0m 1\n" +
+      "  \x1B[2mTimeout:\x1B[0m 300s\n\n" +
+      "\x1B[1m\x1B[36mSystem inference:\x1B[39m\x1B[0m\n\n" +
+      "  \x1B[2mNot configured\x1B[0m\n";
+    assert.deepStrictEqual(parseInferenceGetOutput(MIXED), {
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-nano-30b-a3b",
+    });
+  });
+
+  it("returns empty when output is unrecognizable", () => {
+    assert.deepStrictEqual(parseInferenceGetOutput("unexpected garbage\n"), {
+      provider: undefined,
+      model: undefined,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// interpretSandboxProbeResult — `openshell sandbox create` probe interpreter
+// ---------------------------------------------------------------------------
+
+describe("interpretSandboxProbeResult", () => {
+  it("returns 'ok' when sandbox provisions cleanly", () => {
+    const r = interpretSandboxProbeResult({
+      ok: true,
+      stdout: "Created sandbox: sc-doctor-abc123\n  [0.3s] Running...\n  [0.4s] Completed\n",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    });
+    assert.strictEqual(r.id, "compute-driver");
+    assert.strictEqual(r.status, "ok");
+  });
+
+  it("flags the supervisor-relay symptom with a service-restart hint", () => {
+    // Verbatim from `openshell sandbox create` on 2026-05-23 when only the
+    // gateway was running and no compute driver was registered. CLI exit was
+    // 0 despite the timeout — we must look at the error text, not just exit.
+    const r = interpretSandboxProbeResult({
+      ok: true,
+      stdout:
+        "Created sandbox: sportsclaw-test\n\n  [0.0s] Requesting compute...\n\n" +
+        "Error:   × sandbox provisioning timed out after 300s. Last reported status:\n" +
+        "  │ DependenciesNotReady: Container is running; waiting for supervisor relay\n",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    });
+    assert.strictEqual(r.status, "missing");
+    assert.match(r.detail, /no compute driver/i);
+    assert.match(r.hint, /brew services restart/i);
+  });
+
+  it("flags the same symptom when our probe times out before the CLI prints", () => {
+    // Real observed case: our 45s probe killed the CLI before its own 300s
+    // wait completed, so no "supervisor relay" text was emitted. timedOut
+    // must still produce the driver-bringup hint.
+    const r = interpretSandboxProbeResult({
+      ok: false,
+      stdout: "Created sandbox: sc-doctor-xyz\n\n  [0.0s] Requesting compute...\n",
+      stderr: "",
+      exitCode: null,
+      timedOut: true,
+    });
+    assert.strictEqual(r.status, "missing");
+    assert.match(r.detail, /no compute driver/i);
+    assert.match(r.hint, /brew services restart/i);
+  });
+
+  it("surfaces the first error line for unrelated failures", () => {
+    const r = interpretSandboxProbeResult({
+      ok: false,
+      stdout: "",
+      stderr:
+        "Error:   × status: Internal, message: \"create sandbox failed: pull Docker image failed: denied\\ndenied\"\n",
+      exitCode: 1,
+      timedOut: false,
+    });
+    assert.strictEqual(r.status, "missing");
+    assert.match(r.detail, /pull Docker image failed|denied/i);
+    assert.doesNotMatch(r.hint ?? "", /brew services restart/i);
+  });
+
+  it("falls back to a generic detail when no error line is recognizable", () => {
+    const r = interpretSandboxProbeResult({
+      ok: false,
+      stdout: "",
+      stderr: "",
+      exitCode: 137,
+      timedOut: false,
+    });
+    assert.strictEqual(r.status, "missing");
+    assert.match(r.detail, /exit 137/);
   });
 });
 


### PR DESCRIPTION
## Summary

End-to-end testing on macOS Homebrew OpenShell 0.0.47 surfaced four issues that were silently blocking the engine from running inside a real sandbox. With these landed, a live `operate --once` tick inside an OpenShell sandbox now emits `inferenceRoute.via: \"openshell\"` and the proxy routes 200 OK to upstream NVIDIA Nemotron.

- **`src/openshell-cli.ts`** — two doctor accuracy bugs (provider check used a flag that doesn't exist in OpenShell 0.0.47; inference-routing regex captured ANSI escape codes as the value) + new opt-in `doctor --probe` that creates a real throwaway sandbox to verify end-to-end provisioning works. Probe interpretation is unit-tested with byte-exact fixtures from the live runtime.
- **`src/operate.ts`** — `probeOpenShellHost` now checks `OPENSHELL_SANDBOX=1` first (the supervisor exports it inside every sandbox container) before falling back to DNS. `inference.local` is intercepted at the `HTTPS_PROXY` layer, not via `/etc/hosts`, so DNS was always failing inside otherwise-healthy sandboxes. New `installOpenShellProxyDispatcher` wires undici's `EnvHttpProxyAgent` as the global dispatcher when OpenShell mode is active — Node 20's default fetch ignores `HTTPS_PROXY`, so without this the AI SDK couldn't actually reach `inference.local`.
- **`Dockerfile`** — added `iproute2` so the supervisor's `ip netns add` step succeeds (node:20-slim doesn't include it; without it sandboxes enter Error phase immediately with \"trusted ip helper not found\").
- **`openshell/README.md`** — new \"Known upstream issues\" section documenting the `cp -R jwt/` workaround for [NVIDIA/OpenShell#1523](https://github.com/NVIDIA/OpenShell/issues/1523), which prevents the Homebrew install from minting sandbox JWTs and is the single biggest e2e blocker on macOS today.

## Test plan

- [x] `npm run build` — clean TypeScript build
- [x] 115/115 unit tests pass (`node --test test/openshell-cli.test.mjs test/operator-config.test.mjs test/operator-daemon.test.mjs`)
- [x] `sportsclaw openshell doctor` against a live broken-driver state correctly shows \`✓\` for provider/routing rows that were previously \`✗\` due to parsing bugs
- [x] `sportsclaw openshell doctor --probe` against the same broken-driver state surfaces the underlying issue with an actionable hint in ~45s instead of letting users wait 5 minutes
- [x] After applying the documented JWT workaround, a real sandbox provisions in 2s and `operate --once` emits a TickEvent with `inferenceRoute.via: \"openshell\"`
- [x] Direct LLM calls via the supervisor's proxy return 200 OK from upstream Nemotron

## Out of scope (follow-ups)

Nemotron reasoning-model response format (`content: null` with output in `reasoning_content`) trips up the AI SDK's text extraction, causing a `tick_failed` reason: \"Unknown\". The routing layer is correct; this is a separate model-compatibility issue tracked locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)