### PR TITLE
feat(tools): sanitize bare year inputs to fully qualified ESPN slugs

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -225,6 +225,72 @@ function validateIdentifier(value: string, label: string): string | null {
   return null;
 }
 
+/**
+ * Sanitize bare year values to fully qualified ESPN / League slugs
+ * (e.g., season_id="2026" -> "espn.mlb.2026")
+ */
+export function sanitizeToolInput(toolName: string, input: ToolCallInput): void {
+  let sport = "";
+  let targetObj = input;
+
+  if (toolName === "sports_query" && typeof input.sport === "string") {
+    sport = input.sport.toLowerCase();
+    if (input.args && typeof input.args === "object" && !Array.isArray(input.args)) {
+      targetObj = input.args as Record<string, unknown>;
+    }
+  } else {
+    const sportMatch = toolName.match(/^([a-z0-9_-]+?)_/i);
+    if (!sportMatch) return;
+    sport = sportMatch[1].toLowerCase();
+  }
+
+  const seasonKeys = ["season", "season_id", "season_year"];
+  for (const key of seasonKeys) {
+    if (targetObj[key] !== undefined && targetObj[key] !== null) {
+      const originalValue = String(targetObj[key]).trim();
+      
+      const isBareYear = /^\d{4}$/.test(originalValue) || /^\d{4}-\d{2,4}$/.test(originalValue);
+      if (isBareYear) {
+        let mappedValue: string | null = null;
+        
+        switch (sport) {
+          case "mlb":
+            mappedValue = `espn.mlb.${originalValue}`;
+            break;
+          case "nfl":
+            mappedValue = `espn.nfl.${originalValue}`;
+            break;
+          case "nba":
+            mappedValue = `espn.nba.${originalValue}`;
+            break;
+          case "nhl":
+            mappedValue = `espn.nhl.${originalValue}`;
+            break;
+          case "wnba":
+            mappedValue = `espn.wnba.${originalValue}`;
+            break;
+          case "cfb":
+            mappedValue = `espn.cfb.${originalValue}`;
+            break;
+          case "cbb":
+            mappedValue = `espn.cbb.${originalValue}`;
+            break;
+          case "football":
+            if (/^\d{4}$/.test(originalValue)) {
+              mappedValue = `premier-league-${originalValue}`;
+            }
+            break;
+        }
+
+        if (mappedValue) {
+          console.error(`[sportsclaw] Sanitized bare year for ${toolName}: ${key}="${originalValue}" -> "${mappedValue}"`);
+          targetObj[key] = mappedValue;
+        }
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tool dispatch types
 // ---------------------------------------------------------------------------
@@ -468,6 +534,9 @@ export class ToolRegistry {
     input: ToolCallInput,
     config?: Partial<sportsclawConfig>
   ): Promise<ToolCallResult> {
+    // Sanitize input bare years
+    sanitizeToolInput(toolName, input);
+
     // Security: Check blocklist FIRST, before any other processing
     const blockReason = isBlockedTool(toolName, config?.allowTrading);
     if (blockReason) {

--- a/test/tool-sanitizer.test.mjs
+++ b/test/tool-sanitizer.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { sanitizeToolInput } from "../dist/tools.js";
+
+describe("sanitizeToolInput — bare year sanitization", () => {
+  it("sanitizes bare year for MLB standings", () => {
+    const input = { season: "2026" };
+    sanitizeToolInput("mlb_get_standings", input);
+    assert.equal(input.season, "espn.mlb.2026");
+  });
+
+  it("sanitizes bare year with hyphen for NFL team schedule", () => {
+    const input = { season: "2025-2026" };
+    sanitizeToolInput("nfl_get_team_schedule", input);
+    assert.equal(input.season, "espn.nfl.2025-2026");
+  });
+
+  it("sanitizes bare year for football/soccer standings", () => {
+    const input = { season_id: "2026" };
+    sanitizeToolInput("football_get_season_standings", input);
+    assert.equal(input.season_id, "premier-league-2026");
+  });
+
+  it("sanitizes bare year in sports_query nested args for MLB", () => {
+    const input = {
+      sport: "mlb",
+      command: "get_standings",
+      args: { season: "2026" }
+    };
+    sanitizeToolInput("sports_query", input);
+    assert.equal(input.args.season, "espn.mlb.2026");
+  });
+
+  it("does not affect already fully qualified slugs", () => {
+    const input = { season: "espn.mlb.2026" };
+    sanitizeToolInput("mlb_get_standings", input);
+    assert.equal(input.season, "espn.mlb.2026");
+  });
+
+  it("does not affect human names or non-year strings", () => {
+    const input = { season: "summer" };
+    sanitizeToolInput("mlb_get_standings", input);
+    assert.equal(input.season, "summer");
+  });
+});


### PR DESCRIPTION
## Summary

Models occasionally call sports tools with `season=\"2026\"` or `season_id=\"2025-2026\"`, but the underlying ESPN / data-provider endpoints expect fully qualified slugs like `espn.mlb.2026` or `premier-league-2026`. The mismatch produces 404s with no salvage path inside the tick.

- New exported `sanitizeToolInput(toolName, input)` detects the sport from the tool name prefix (e.g. `mlb_get_standings` → `mlb`) or from the `sport` field for the generic `sports_query` dispatcher, then rewrites bare-year season fields (`season` / `season_id` / `season_year`) into fully qualified slugs.
- Sports covered: mlb / nfl / nba / nhl / wnba / cfb / cbb → `espn.<sport>.<year>`; football → `premier-league-<year>`.
- Wired into `ToolRegistry.dispatch` so every tool call goes through it.
- Already-qualified slugs and non-year strings pass through untouched.

## Test plan

- [x] `npm run build` — clean
- [x] New `test/tool-sanitizer.test.mjs` — 6/6 pass (MLB, NFL with hyphenated year, football, sports_query nested args, already-qualified pass-through, non-year pass-through)
- [x] Full openshell + operator suite — 121/121, no regressions

## Known limitations (not blockers)

- Football mapping is hardcoded to `premier-league-<year>`. La Liga, Bundesliga, etc. callers need to pass the explicit slug.
- Sanitization logs via `console.error` on every rewrite — useful for tracing model behavior, can be quieted later if it gets noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)