### PR TITLE
feat(nim): self-hosted Nemotron + Qwen-Image NIM support

### DIFF
--- a/src/image-gen.ts
+++ b/src/image-gen.ts
@@ -7,7 +7,10 @@
  *
  * Provider routing matches engine's prior behavior:
  *   - google  → Gemini image generation (gemini-3.1-flash-image-preview)
- *   - openai  → DALL-E 3
+ *   - openai  → DALL-E 3 (direct), OR an OpenAI-compat local image NIM
+ *               (Qwen-Image-2512 on the brev H200) when
+ *               NIM_IMAGE_BASE_URL is set. This is the path used in the
+ *               NVIDIA case-study deployment.
  *   - anthropic → unsupported (tool returns a friendly error string)
  */
 
@@ -76,14 +79,22 @@ export async function generateImageGoogle(
 }
 
 export async function generateImageOpenAI(prompt: string, size?: string): Promise<GeneratedImage> {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error("OPENAI_API_KEY is not set.");
+  // When NIM_IMAGE_BASE_URL is set, route to a self-hosted OpenAI-compat
+  // image NIM (Qwen-Image-2512 on the brev H200) instead of DALL-E.
+  // The NIM's served-model-name comes from NIM_IMAGE_MODEL.
+  const nimBase = process.env.NIM_IMAGE_BASE_URL;
+  const nimModel = process.env.NIM_IMAGE_MODEL;
+  const useNim = !!nimBase;
+  const baseUrl = useNim ? nimBase : "https://api.openai.com";
+  const model = useNim ? (nimModel ?? "qwen/qwen-image-2512") : "dall-e-3";
+  const apiKey = useNim ? "nim-unused" : process.env.OPENAI_API_KEY;
+  if (!useNim && !apiKey) throw new Error("OPENAI_API_KEY is not set.");
 
-  const res = await fetch("https://api.openai.com/v1/images/generations", {
+  const res = await fetch(`${baseUrl}/v1/images/generations`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
     body: JSON.stringify({
-      model: "dall-e-3",
+      model,
       prompt,
       n: 1,
       size: size || "1024x1024",
@@ -93,12 +104,12 @@ export async function generateImageOpenAI(prompt: string, size?: string): Promis
 
   if (!res.ok) {
     const errBody = await res.text();
-    throw new Error(`OpenAI image generation failed (${res.status}): ${errBody}`);
+    throw new Error(`${useNim ? "NIM" : "OpenAI"} image generation failed (${res.status}): ${errBody}`);
   }
 
   const data = (await res.json()) as any;
   const imageData = data.data?.[0]?.b64_json;
-  if (!imageData) throw new Error("OpenAI image generation returned no image data.");
+  if (!imageData) throw new Error("Image generation returned no image data.");
 
   return { data: imageData, mimeType: "image/png", prompt, provider: "openai" };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,19 @@
  *   const answer = await engine.run("What are today's NBA scores?");
  */
 
+// Filter only the AI SDK "reasoningEffort not supported" warning that fires
+// when talking to OpenAI-compatible NIM endpoints that don't honor it (the
+// engine still works — the param is silently dropped). All other SDK warnings
+// pass through unchanged so future deprecations stay visible.
+{
+  const originalWarn = console.warn.bind(console);
+  console.warn = (...args: unknown[]) => {
+    const msg = args.map((a) => (typeof a === "string" ? a : "")).join(" ");
+    if (msg.includes('"reasoningEffort" is not supported')) return;
+    originalWarn(...args);
+  };
+}
+
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { execFile } from "node:child_process";
@@ -1943,9 +1956,18 @@ async function cmdQuery(args: string[]): Promise<void> {
   if (headlessMode) {
     emitNdjson({ type: "start", timestamp: new Date().toISOString(), yolo: yoloMode });
     try {
+      let inboundImages: any[] | undefined;
+      if (process.env.SPORTSCLAW_INBOUND_IMAGES) {
+        try {
+          inboundImages = JSON.parse(process.env.SPORTSCLAW_INBOUND_IMAGES);
+        } catch (err) {
+          console.error("[sportsclaw] Failed to parse SPORTSCLAW_INBOUND_IMAGES env:", err);
+        }
+      }
       const result = await engine.run(prompt, {
         userId,
         systemPrompt,
+        ...(inboundImages && { images: inboundImages }),
         onProgress: (event) => emitNdjson({ ...event, category: "progress" }),
       });
       const formatted = formatResponse(result, formatArg as any);

--- a/src/llm-providers.ts
+++ b/src/llm-providers.ts
@@ -28,6 +28,31 @@ import { google } from "@ai-sdk/google";
 
 import type { LLMProvider } from "./types.js";
 
+/**
+ * Fetch wrapper that injects Nemotron-specific request body fields.
+ * Nemotron 3 family has reasoning/thinking ON by default, which produces
+ * verbose chain-of-thought in the response. NIM exposes the opt-out via
+ * the per-request `chat_template_kwargs.enable_thinking` body field.
+ * Gated on model name to avoid breaking non-Nemotron models that happen
+ * to route through the same OpenAI-compat path.
+ */
+function nimNemotronFetch(): typeof fetch {
+  return async (input, init) => {
+    if (init?.body && typeof init.body === "string") {
+      try {
+        const parsed = JSON.parse(init.body) as Record<string, unknown>;
+        if (typeof parsed.model === "string" && parsed.model.startsWith("nvidia/")) {
+          parsed.chat_template_kwargs = { enable_thinking: false };
+          init = { ...init, body: JSON.stringify(parsed) };
+        }
+      } catch {
+        // body not JSON — leave alone
+      }
+    }
+    return fetch(input, init);
+  };
+}
+
 /** Resolved OpenShell routing decision passed into `resolveModel`. */
 export interface OpenShellRoute {
   /** Base URL handed to the AI SDK provider factory. */
@@ -76,6 +101,7 @@ export function resolveModel(
         return createOpenAI({
           baseURL: openshell.baseUrl,
           apiKey: "openshell-unused",
+          fetch: nimNemotronFetch(),
         }).chat(modelId);
       case "google":
         throw new Error(
@@ -86,8 +112,23 @@ export function resolveModel(
   switch (provider) {
     case "anthropic":
       return anthropic(modelId);
-    case "openai":
+    case "openai": {
+      // When OPENAI_BASE_URL points at a self-hosted endpoint (NIM, vLLM,
+      // etc.), force POST /v1/chat/completions and inject Nemotron-specific
+      // body kwargs. Most self-hosted endpoints only serve /v1/chat/completions
+      // and 404 on /v1/responses. Real OpenAI keeps the default factory so
+      // o1/o3/gpt-5 reasoning features (reasoningEffort, web_search, etc.)
+      // continue to work via /v1/responses.
+      const customBase = process.env.OPENAI_BASE_URL;
+      if (customBase) {
+        return createOpenAI({
+          baseURL: customBase,
+          apiKey: process.env.OPENAI_API_KEY ?? undefined,
+          fetch: nimNemotronFetch(),
+        }).chat(modelId);
+      }
       return openai(modelId);
+    }
     case "google":
       return google(modelId);
     default:


### PR DESCRIPTION
## Summary
- Add a self-hosted NIM path for both reasoning (Nemotron-3-Nano on a Hopper-class GPU) and image generation (Qwen-Image-2512), routed through the existing OpenAI provider via `OPENAI_BASE_URL` / `NIM_IMAGE_BASE_URL`
- Switch the OpenAI provider to `.chat()` (POST `/v1/chat/completions`) when a custom base URL is configured, so requests work against vLLM-served NIMs that don't implement `/v1/responses`
- Inject `chat_template_kwargs.enable_thinking=false` via a fetch wrapper for `nvidia/*` models so Nemotron stops emitting verbose chain-of-thought in normal responses
- Suppress the cosmetic `"reasoningEffort" is not supported` warning from the AI SDK; all other warnings pass through unchanged
- Backwards-compatible: when no NIM env vars are set, real-OpenAI / Anthropic / Google providers behave exactly as before

## Test plan
- [x] One-shot ask against Nemotron NIM returns clean output (1.9s, no chain-of-thought wall)
- [x] Operator daemon ticks at 90s cadence with proper tool dispatch via Nemotron
- [x] Qwen-Image generation roundtrip via `generate_image` tool returns valid b64 PNG
- [x] Real OpenAI calls still hit `/v1/responses` (no `OPENAI_BASE_URL` set) — `reasoningEffort` and other Responses-API features intact
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)