### PR TITLE
refactor(ux): consumer-facing polish — drop source footers, gentler evidence gate

### DIFF
--- a/docker/relay/relay_server.py
+++ b/docker/relay/relay_server.py
@@ -373,6 +373,8 @@ def _build_env(body: dict | None = None) -> dict[str, str]:
             }
             env_var = key_map.get(provider, "ANTHROPIC_API_KEY")
             env[env_var] = body["api_key"]
+        if body.get("images"):
+            env["SPORTSCLAW_INBOUND_IMAGES"] = json.dumps(body["images"])
 
     return env
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -597,9 +597,11 @@ export class sportsclawEngine {
       const res = await generateText({
         model: this.mainModel,
         system:
-          "You are an evidence gate for a sports agent. Remove or rewrite any claim " +
-          "that depends on failed tools. Keep only claims supportable by successful tools. " +
-          "If unsure, omit the claim. Be concise and explicit about unavailable sections.",
+          "You are an evidence gate for a consumer sports chat. Remove or rewrite any claim " +
+          "that depends on failed tools. Keep only claims supportable by successful tools or the draft's successful data. " +
+          "Do not mention technical failures, tool names, integrations, upstream systems, partial data, or why data was missing. " +
+          "If some data is missing, just answer the user's question from the available evidence and skip missing sections silently. " +
+          "Be direct, concise, and get to the point.",
         prompt: [
           `User request: ${userPrompt}`,
           `Failed tools: ${failedTools.join(", ") || "none"}`,
@@ -615,13 +617,7 @@ export class sportsclawEngine {
       // fall through to deterministic fallback
     }
 
-    const failed = failedTools.join(", ");
-    const succeeded = succeededTools.join(", ");
-    return (
-      `I couldn't fully complete this because some required tools failed: ${failed}. ` +
-      `Successful tools: ${succeeded || "none"}. ` +
-      "Retry to get a complete answer."
-    );
+    return "I can’t verify that cleanly right now. Ask me again in a minute and I’ll rerun it.";
   }
 
   private filterToolsForAgent(agent: AgentDef, allToolNames: string[]): string[] | undefined {
@@ -3084,7 +3080,19 @@ export class sportsclawEngine {
       }
     }
 
-    this.messages.push({ role: "user", content: sanitizedPrompt });
+    if (options?.images && options.images.length > 0) {
+      const parts: any[] = [{ type: "text", text: sanitizedPrompt }];
+      for (const img of options.images) {
+        parts.push({
+          type: "image",
+          image: img.data,
+          mimeType: img.mimeType,
+        });
+      }
+      this.messages.push({ role: "user", content: parts });
+    } else {
+      this.messages.push({ role: "user", content: sanitizedPrompt });
+    }
 
     // --- Context pruning: prevent memory bloat during continuous execution ---
     // When the message history exceeds the configured threshold, drop older
@@ -3684,11 +3692,6 @@ export class sportsclawEngine {
     }
 
     if (netFailures.length > 0) {
-      const labels = netFailures.map((f) => f.toolName).join(", ");
-      const warning =
-        `⚠️ Partial data: some live tools failed (${labels}). ` +
-        "Treat related sections as unavailable.";
-
       responseText = await this.applyEvidenceGate({
         userPrompt: sanitizedPrompt,
         draft: responseText,
@@ -3696,7 +3699,6 @@ export class sportsclawEngine {
         succeededTools: successes.map((s) => s.toolName),
         maxOutputTokens: budgets.evidenceGate,
       });
-      responseText = `${warning}\n\n${responseText}`;
     }
 
     // --- Memory: write after LLM reply (async, non-blocking) ---

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -109,7 +109,6 @@ function parseHeaderFields(
  * Format response as a Discord embed.
  */
 function formatDiscord(response: string): DiscordEmbed {
-  const source = extractSource(response);
   const content = removeSourceLine(response);
   const hasScore = hasScores(content);
 
@@ -119,7 +118,6 @@ function formatDiscord(response: string): DiscordEmbed {
     return {
       title: "Sports Data",
       fields: fields.slice(0, 25), // Discord limit: 25 fields
-      footer: source ? { text: source } : undefined,
       color: hasScore ? EMBED_COLORS.score : EMBED_COLORS.info,
     };
   }
@@ -127,7 +125,6 @@ function formatDiscord(response: string): DiscordEmbed {
   // Simple response — use description
   return {
     description: content.slice(0, 4096), // Discord limit: 4096 chars
-    footer: source ? { text: source } : undefined,
     color: hasScore ? EMBED_COLORS.score : EMBED_COLORS.info,
   };
 }
@@ -137,7 +134,6 @@ function formatDiscord(response: string): DiscordEmbed {
  * Escapes special characters and highlights scores/team names.
  */
 function formatTelegram(response: string): string {
-  const source = extractSource(response);
   let content = removeSourceLine(response);
 
   // Escape ALL special MarkdownV2 characters in the entire content first
@@ -160,11 +156,6 @@ function formatTelegram(response: string): string {
 
   // Convert ### headers to bold (on already-escaped text)
   content = content.replace(/^\\#\\#\\#?\\s(.+)$/gm, (_, header) => `*${header}*`);
-
-  // Add source footer
-  if (source) {
-    content += `\n\n_${escape(source)}_`;
-  }
 
   return content;
 }

--- a/src/formatters/discord.ts
+++ b/src/formatters/discord.ts
@@ -2,7 +2,8 @@
  * sportsclaw — Discord Renderer
  *
  * Converts a ParsedResponse into a DiscordEmbed object.
- * Headers → embed fields, source → footer, tables → labelled multi-line cards.
+ * Headers → embed fields, tables → labelled multi-line cards.
+ * Parsed source footers are stripped for consumer chat UX.
  *
  * Tables get a Discord-native treatment: each data row becomes a card
  * (bold first cell as heading, remaining cells as `• **Header:** value`
@@ -47,7 +48,6 @@ const MAX_DESCRIPTION = 4096;
 
 export function renderDiscord(parsed: ParsedResponse): DiscordEmbed {
   const color = parsed.meta.hasScores ? EMBED_COLORS.score : EMBED_COLORS.info;
-  const footer = parsed.source ? { text: parsed.source } : undefined;
 
   // Check if we have any header blocks → use fields layout
   const hasHeaders = parsed.blocks.some((b) => b.type === "header");
@@ -81,7 +81,6 @@ export function renderDiscord(parsed: ParsedResponse): DiscordEmbed {
     return {
       title: "Sports Data",
       fields: fields.slice(0, 25), // Discord limit: 25 fields
-      footer,
       color,
     };
   }
@@ -91,7 +90,7 @@ export function renderDiscord(parsed: ParsedResponse): DiscordEmbed {
     parsed.blocks.map(renderBlockForDiscord).join("\n").trim().slice(0, MAX_DESCRIPTION) ||
     undefined;
 
-  return { description, footer, color };
+  return { description, color };
 }
 
 // ---------------------------------------------------------------------------
@@ -105,12 +104,7 @@ export function renderDiscord(parsed: ParsedResponse): DiscordEmbed {
  */
 export function formatTextForDiscord(response: string): string {
   const parsed = parseBlocks(response);
-  const rendered = parsed.blocks.map(renderBlockForDiscord).join("\n");
-
-  if (parsed.source) {
-    return rendered + "\n*Source: " + parsed.source + "*";
-  }
-  return rendered;
+  return parsed.blocks.map(renderBlockForDiscord).join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/formatters/telegram.ts
+++ b/src/formatters/telegram.ts
@@ -3,6 +3,7 @@
  *
  * Converts a ParsedResponse into an HTML string for Telegram's HTML parse mode.
  * Headers → <b>, code → <pre>, bold → <b>, inline code → <code>.
+ * Parsed source footers are stripped for consumer chat UX.
  *
  * Tables get a Telegram-native treatment: each data row becomes a labelled
  * multi-line item (bold first cell as heading, remaining cells as bulleted
@@ -53,12 +54,6 @@ export function renderTelegram(parsed: ParsedResponse): string {
         }
         break;
     }
-  }
-
-  // Source footer
-  if (parsed.source) {
-    result.push("");
-    result.push(`<i>${escapeHtml(parsed.source)}</i>`);
   }
 
   return result.join("\n");

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -29,8 +29,6 @@ const GUIDE_PATTERNS = [
   /\b(?:supported sports?|available sports?)\b/i,
   /\bhow does (?:this|sportsclaw) work\b/i,
   /^(?:list|show|what are) (?:your |the |all )?(?:commands|features|capabilities)\s*\??$/i,
-  /\b(?:machina (?:skills?|templates?|cloud)|premium (?:connectors?|data)|sportradar|stats ?perform|api.?football)\b/i,
-  /\b(?:what else|more features?|more data|upgrade|paid|cloud)\b/i,
 ];
 
 /**
@@ -104,12 +102,6 @@ Global: Football (Soccer — 13 leagues), Tennis (ATP & WTA), Golf (PGA, LPGA, D
 Markets: Kalshi, Polymarket, Betting Analysis, Unified Markets Dashboard
 News: Sports News via RSS & Google News
 
-### Machina Skills & Templates
-sportsclaw is powered by open source templates and workflows from Machina Sports.
-Premium connectors from **Sportradar**, **Stats Perform**, and **API-Football** are coming soon on Machina Clawd.
-Browse all templates: https://github.com/machina-sports/machina-templates
-Join the waitlist at https://sportsclaw.gg
-
 ### Getting Started
 1. Run \`sportsclaw config\` to set up your LLM provider and install sports
 2. Use \`sportsclaw chat\` for interactive mode or \`sportsclaw "your question"\` for one-shot
@@ -152,22 +144,6 @@ export function generateGuideResponse(prompt: string): string {
     }
 
     return lines.join("\n");
-  }
-
-  // "machina skills" / "premium connectors" / "sportradar" / "more data" / "upgrade" / "cloud"
-  if (/\b(?:machina (?:skills?|templates?|cloud)|premium|sportradar|stats ?perform|api.?football|what else|more features?|more data|upgrade|paid|cloud)\b/i.test(lower)) {
-    return [
-      "## Machina Skills & Templates",
-      "",
-      "sportsclaw is powered by open source templates and workflows from Machina Sports.",
-      "You can browse and contribute to them here: https://github.com/machina-sports/machina-templates",
-      "",
-      "### Coming Soon on Machina Clawd",
-      "Premium connectors from **Sportradar**, **Stats Perform**, and **API-Football** are on the way.",
-      "Machina Clawd will also include 24/7 hosting, conversation memory, and vector search.",
-      "",
-      "Join the waitlist at https://sportsclaw.gg to get early access.",
-    ].join("\n");
   }
 
   // "help" / "getting started" / "what can you do"

--- a/src/prompts/sections.ts
+++ b/src/prompts/sections.ts
@@ -38,7 +38,7 @@ Live data must come from tools — never from training. The user's training-data
 - When a query touches multiple data dimensions (e.g. "tell me about [team]"), issue ALL relevant tool calls in a SINGLE step — recent matches, standings, news — in parallel. Do not call them one at a time.
 - IDs are required: if a tool needs \`season_id\`, \`competition_id\`, etc., do not guess. Call the lookup tool first (\`get_competitions\`, \`get_competition_seasons\`, etc.) to resolve the exact string. A bare year like \`2025\` will fail.
 - After tools, ANSWER WITH DATA. If you successfully called data tools, your final reply MUST contain concrete numbers, names, and dates. Do not reply with only a follow-up question.
-- Cite the source. End your answer with a small italicized line naming the providers you actually called. Map skill prefixes to providers: football → Transfermarkt & FBref; nfl/nba/nhl/mlb/wnba/cfb/cbb/golf/tennis → ESPN; f1 → FastF1; news → Google News & RSS; kalshi → Kalshi; polymarket → Polymarket; betting → Betting Analysis; markets → ESPN + Kalshi + Polymarket. Example: *Source: ESPN, Google News (2025-03-15)*. Only list providers you actually called.`;
+- Do not append provider/source footer lines by default. If a user explicitly asks where the data came from, answer naturally in one sentence inside the response body.`;
 
 export const FAILURE_DISCIPLINE = `## Failure Discipline
 
@@ -101,7 +101,6 @@ User: who's winning lakers game
 Tools called: nba_get_scoreboard
 Good answer:
 Lakers up 78-71 over the Nuggets, 4:12 left in Q3. LeBron 22/6/4, Reaves on a heater (16 pts on 6/8). Jokić quiet — 14/9, foul trouble.
-*Source: ESPN*
 
 ---
 
@@ -113,7 +112,6 @@ Good answer:
 | 1 | Liverpool | 24 | +37 | 56 |
 | 2 | Arsenal | 24 | +30 | 53 |
 | 3 | Man City | 24 | +25 | 50 |
-*Source: Transfermarkt & FBref*
 
 ---
 
@@ -123,5 +121,4 @@ Good answer:
 Three plays I like:
 1. **Bills -3.5 vs Dolphins** — Buffalo 5-1 ATS as home favorite, Miami 1-5 ATS in cold weather.
 2. **Chiefs/Ravens UNDER 47.5** — both defenses top-5 in red-zone scoring rate; pace plays under in playoff settings.
-3. **Saquon Barkley over 88.5 rush yds** — Eagles facing 31st-ranked run D. Easy lean.
-*Source: ESPN, Kalshi, Polymarket*`;
+3. **Saquon Barkley over 88.5 rush yds** — Eagles facing 31st-ranked run D. Easy lean.`;

--- a/test/consumer-tool-failure-ux.test.mjs
+++ b/test/consumer-tool-failure-ux.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const source = readFileSync(new URL("../src/engine.ts", import.meta.url), "utf8");
+
+test("partial tool failures stay internal, not user-facing", () => {
+  assert(!source.includes("⚠️ Partial data: some live tools failed"));
+  assert(!source.includes("Treat related sections as unavailable."));
+  assert(source.includes("Do not mention technical failures, tool names, integrations, upstream systems, partial data, or why data was missing."));
+  assert(source.includes("skip missing sections silently"));
+});
+
+test("evidence fallback does not leak tool names", () => {
+  assert(!source.includes("some required tools failed: ${failed}"));
+  assert(!source.includes("Retry to get a complete answer."));
+  assert(source.includes("I can’t verify that cleanly right now"));
+});

--- a/test/formatters-discord.test.mjs
+++ b/test/formatters-discord.test.mjs
@@ -119,4 +119,22 @@ describe("renderDiscord — embed with table", () => {
     assert.match(embed.fields[0].value, /\*\*13\/06\/2026\*\*/);
     assert.match(embed.fields[0].value, /• \*\*Adversário:\*\* Marrocos/);
   });
+
+  it("does not put parsed source attribution into the embed footer", () => {
+    const input = "Lakers up 78-71, 4:12 left in Q3.\n*Source: ESPN*";
+    const embed = renderDiscord(parseBlocks(input));
+
+    assert.equal(embed.footer, undefined);
+    assert.match(embed.description ?? "", /Lakers up 78-71/);
+    assert.ok(!/Source:/i.test(embed.description ?? ""));
+    assert.ok(!/ESPN/.test(embed.description ?? ""));
+  });
+
+  it("does not append source attribution in plain Discord text", () => {
+    const out = formatTextForDiscord("Lakers up 78-71.\n*Source: ESPN*");
+
+    assert.match(out, /Lakers up 78-71/);
+    assert.ok(!/Source:/i.test(out));
+    assert.ok(!/ESPN/.test(out));
+  });
 });

--- a/test/formatters-telegram.test.mjs
+++ b/test/formatters-telegram.test.mjs
@@ -138,4 +138,14 @@ describe("renderTelegram — other blocks", () => {
     assert.match(out, /^• first$/m);
     assert.match(out, /^• second$/m);
   });
+
+  it("strips trailing source attribution instead of rendering a footer", () => {
+    const out = renderTelegram(
+      parseBlocks("Lakers up 78-71, 4:12 left in Q3.\n*Source: ESPN*"),
+    );
+
+    assert.match(out, /Lakers up 78-71/);
+    assert.ok(!/Source:/i.test(out), "source label must not be rendered");
+    assert.ok(!/ESPN/.test(out), "source provider footer must not be rendered");
+  });
 });

--- a/test/guide.test.mjs
+++ b/test/guide.test.mjs
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateGuideResponse, isGuideIntent } from "../dist/guide.js";
+
+const FORBIDDEN_PROMO = /Machina Clawd|machina-templates|Coming Soon on Machina|Machina Skills/i;
+
+describe("guide intent routing", () => {
+  it("does not intercept API-Football source questions as marketing/help", () => {
+    const prompt = "The api-football you refer as source there is from the Machina Sports TV pod, or directly?";
+    assert.equal(isGuideIntent(prompt), false);
+  });
+
+  it("does not include Machina Clawd or template promotion in help output", () => {
+    const response = generateGuideResponse("help");
+    assert.ok(response.includes("sportsclaw Features"));
+    assert.doesNotMatch(response, FORBIDDEN_PROMO);
+  });
+
+  it("still handles explicit help intents", () => {
+    assert.equal(isGuideIntent("help"), true);
+    assert.equal(isGuideIntent("what sports do you support?"), true);
+  });
+});

--- a/test/prompt-source-attribution.test.mjs
+++ b/test/prompt-source-attribution.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { EXAMPLES, TOOL_USE } from "../dist/prompts/sections.js";
+
+describe("prompt source attribution", () => {
+  it("does not instruct the model to append a source footer", () => {
+    assert.ok(!/End your answer with .*Source:/i.test(TOOL_USE));
+    assert.ok(!/\*Source:/i.test(TOOL_USE));
+  });
+
+  it("examples do not teach source footers", () => {
+    assert.ok(!/\*Source:/i.test(EXAMPLES));
+  });
+});


### PR DESCRIPTION
## Summary
- **engine.ts**: rewrite the evidence-gate system prompt so it stops leaking technical internals ("failed tools", "tool names", "upstream systems") to consumers. Be direct, skip missing sections silently.
- **prompts/sections.ts**: drop the "cite *Source: …*" footer instruction and few-shot example. Source attribution becomes a natural-language opt-in if a user explicitly asks where data came from.
- **formatters.ts** + **formatters/discord.ts** + **formatters/telegram.ts**: remove source-line extraction and footer rendering on both platforms. Aligned with the prompt change.
- **guide.ts**: remove premium / Machina-marketing trigger patterns from the help guide. Help surface focuses on what's available today, not "coming soon" copy.
- **relay_server.py**: pass `SPORTSCLAW_INBOUND_IMAGES` env through when the relay body carries images (multimodal input plumbing).
- **tests**: add coverage for consumer-tool-failure UX, the guide gating, and the no-source-footer behavior in both formatters.

## Test plan
- [x] Existing formatter tests pass (no source footer no longer asserted)
- [x] New tests added for consumer-tool-failure UX, guide gating, prompt source attribution
- [ ] CI passes
- [ ] Manual: chat reply with a failed tool no longer surfaces tool names to the user
- [ ] Manual: chat reply no longer carries a trailing "*Source: ESPN*" line by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)