### PR TITLE
feat(inference): first-class model-role routing layer (eyes/brain/hands/voice)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "test:openshell-cli": "npm run build && node --test test/openshell-cli.test.mjs",
     "test:formatters-telegram": "npm run build && node --test test/formatters-telegram.test.mjs",
     "test:formatters-discord": "npm run build && node --test test/formatters-discord.test.mjs",
-    "test:anthropic-oauth": "npm run build && node --test test/anthropic-oauth.test.mjs"
+    "test:anthropic-oauth": "npm run build && node --test test/anthropic-oauth.test.mjs",
+    "test:inference-contracts": "npm run build && node --test test/inference-contracts.test.mjs",
+    "test:model-role-router": "npm run build && node --test test/model-role-router.test.mjs",
+    "bench:moment-to-air": "npm run build && node scripts/bench-moment-to-air.mjs"
   },
   "keywords": [
     "sports",

--- a/scripts/bench-moment-to-air.mjs
+++ b/scripts/bench-moment-to-air.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Moment-to-air benchmark — per-role inference latency across the
+ * pod ⇄ inference-plane boundary.
+ *
+ * Runs the full editorial pipeline for one synthetic match moment:
+ *
+ *   eyes (visual read) -> brain (editorial reasoning)
+ *     -> hands (asset generation) -> voice (narration/copy)
+ *     -> publish (validate moment + manifest block)
+ *
+ * and prints a single JSON report with per-role latencies and
+ * role/model/locality/accelerator metadata. GPU indices are runtime
+ * metadata for the 8xH200 demo cluster — the contracts themselves are
+ * hardware-agnostic.
+ *
+ * Routes:
+ *   default          — mock route, no network, safe for CI.
+ *   BENCH_ROUTE=nim  — real NIM endpoints (requires NIM_BASE_URL or
+ *                      per-role config; endpoint values are never printed).
+ *   BENCH_ROUTE=openshell — OpenShell Privacy Router.
+ *
+ * No secrets, tokens, or endpoint URLs are printed.
+ */
+
+import { invokeModelRole } from "../dist/inference/model-role-router.js";
+import { validateMatchMoment, validatePlaylistManifest } from "../dist/schema/tv.js";
+
+const route = process.env.BENCH_ROUTE ?? "mock";
+if (!["mock", "nim", "openshell"].includes(route)) {
+  console.error(`Unknown BENCH_ROUTE "${route}" — use mock, nim, or openshell.`);
+  process.exit(1);
+}
+
+// Role -> model/accelerator placement for the 8xH200 demo cluster.
+// Locality/accelerator are trace metadata only — callers request roles.
+const ROLE_PLACEMENT = {
+  eyes: { model: "nvidia/cosmos3-nano-reasoner", gpu: 0 },
+  brain: { model: "nvidia/nemotron-3-super-120b-a12b", gpus: [1, 2, 3, 4] },
+  hands: { model: "nvidia/cosmos3-super-i2v", gpus: [5, 6] },
+  voice: { model: "nvidia/llama-3.3-nemotron-super-49b", gpu: 7 },
+};
+
+const config = {
+  roles: Object.fromEntries(
+    Object.entries(ROLE_PLACEMENT).map(([role, placement]) => [
+      role,
+      { route, locality: "h200", accelerator: "h200", model: placement.model },
+    ]),
+  ),
+};
+
+const FIXTURE_ID = "benchmark-fixture";
+
+async function timeRole(role, input) {
+  const result = await invokeModelRole({
+    role,
+    input,
+    source: "benchmark",
+    config,
+  });
+  return { latencyMs: result.trace.latencyMs, output: result.output, trace: result.trace };
+}
+
+async function main() {
+  const totalStart = Date.now();
+
+  // eyes — visual perception over a synthetic clip
+  const eyes = await timeRole("eyes", {
+    fixtureId: FIXTURE_ID,
+    clipUrl: "https://example.invalid/benchmark/clip.mp4",
+    sampledFps: 4,
+    prompt: "Describe the decisive action in this clip.",
+  });
+
+  // brain — editorial reasoning over the visual read
+  const brain = await timeRole("brain", {
+    fixtureId: FIXTURE_ID,
+    visualRead: "Left winger beats the fullback and drives a low cross.",
+    prompt: "What is the tactical meaning and broadcast angle?",
+  });
+
+  // hands — generated asset production for the moment
+  const hands = await timeRole("hands", {
+    fixtureId: FIXTURE_ID,
+    momentType: "goal_chance",
+    prompt: "Generate a short explainer clip for this moment.",
+  });
+
+  // voice — narration/chyron copy
+  const voice = await timeRole("voice", {
+    fixtureId: FIXTURE_ID,
+    broadcastAngle: "Brazil pressure is now structural, not random.",
+    prompt: "Write a 12-second narration line and a chyron.",
+  });
+
+  // publish — validate the moment + manifest block through the TV contracts
+  const publishStart = Date.now();
+  const moment = {
+    id: "benchmark-moment-1",
+    fixtureId: FIXTURE_ID,
+    clipUrl: "https://example.invalid/benchmark/clip.mp4",
+    sampledFps: 4,
+    momentType: "goal_chance",
+    visualRead: "Left winger beats the fullback and drives a low cross.",
+    tacticalMeaning: "Repeatable overloads on the left side.",
+    broadcastAngle: "Brazil pressure is now structural, not random.",
+    confidence: 0.84,
+    createdAt: new Date().toISOString(),
+    source: "benchmark",
+    trace: eyes.trace,
+  };
+  const momentCheck = validateMatchMoment(moment);
+  if (!momentCheck.ok) {
+    console.error(`Benchmark moment failed validation: ${momentCheck.error}`);
+    process.exit(1);
+  }
+  const manifestCheck = validatePlaylistManifest({
+    id: "benchmark-manifest-1",
+    channelId: "benchmark-channel",
+    createdAt: new Date().toISOString(),
+    blocks: [
+      {
+        id: "benchmark-block-1",
+        title: "Benchmark moment",
+        durationSec: 30,
+        freshness: "LIVE",
+        fallback: { blockId: "benchmark-evergreen-1", reason: "benchmark" },
+        sourceRef: `tv-match-moment:${moment.id}`,
+        freshnessTimestamp: moment.createdAt,
+      },
+    ],
+  });
+  if (!manifestCheck.ok) {
+    console.error(`Benchmark manifest failed validation: ${manifestCheck.error}`);
+    process.exit(1);
+  }
+  const publishMs = Date.now() - publishStart;
+
+  const report = {
+    cluster: "8xh200",
+    route,
+    fixture_id: FIXTURE_ID,
+    eyes_ms: eyes.latencyMs,
+    brain_ms: brain.latencyMs,
+    hands_ms: hands.latencyMs,
+    voice_ms: voice.latencyMs,
+    publish_ms: publishMs,
+    total_ms: Date.now() - totalStart,
+    roles: Object.fromEntries(
+      Object.entries(ROLE_PLACEMENT).map(([role, placement]) => [
+        role,
+        {
+          ...placement,
+          route,
+          locality: "h200",
+          accelerator: "h200",
+        },
+      ]),
+    ),
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch((err) => {
+  // Never echo endpoint config in failures — message only.
+  console.error(`moment-to-air benchmark failed: ${err instanceof Error ? err.message : err}`);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,12 +293,15 @@ export { runSetup } from "./setup.js";
 // TV Operator Contracts
 export {
   FRESHNESS_CLASSES,
+  MATCH_MOMENT_TYPES,
+  MATCH_MOMENT_SOURCES,
   buildHealthSnapshot,
   validateHealthSnapshot,
   validatePlaylistBlock,
   validatePlaylistManifest,
   validateLiveContentMeta,
   validateManifestCoverage,
+  validateMatchMoment,
 } from "./schema/tv.js";
 export type {
   FreshnessClass,
@@ -314,9 +317,43 @@ export type {
   HealthSnapshot,
   HealthSnapshotInput,
   IncidentRecord,
+  MatchMoment,
+  MatchMomentType,
+  MatchMomentSource,
   ValidationResult,
   ManifestCoverageOptions,
 } from "./schema/tv.js";
+
+// Inference Role Contracts + Router
+export { MODEL_ROLES, isModelRole } from "./inference/model-roles.js";
+export type { ModelRole } from "./inference/model-roles.js";
+export {
+  INFERENCE_ROUTES,
+  INFERENCE_TASK_SOURCES,
+  validateInferenceTaskEnvelope,
+  validateInferenceTrace,
+} from "./inference/inference-task.js";
+export type {
+  InferenceRoute,
+  InferenceTaskSource,
+  InferenceTaskEnvelope,
+  InferenceTrace,
+  InferenceResult,
+} from "./inference/inference-task.js";
+export {
+  ROLE_LOCALITIES,
+  ROLE_ACCELERATORS,
+  validateModelRoleRouterConfig,
+  invokeModelRole,
+  InferenceRouteError,
+} from "./inference/model-role-router.js";
+export type {
+  RoleLocality,
+  RoleAccelerator,
+  ModelRoleRouteConfig,
+  ModelRoleRouterConfig,
+  InvokeModelRoleArgs,
+} from "./inference/model-role-router.js";
 
 // Ledger Storage Abstraction
 export { FileLedgerStorage } from "./ledger.js";

--- a/src/inference/inference-task.ts
+++ b/src/inference/inference-task.ts
@@ -1,0 +1,149 @@
+/**
+ * sportsclaw — Inference Task Contracts
+ *
+ * Typed request/result envelopes for model-role calls across the
+ * pod ⇄ inference-plane boundary, plus lightweight runtime validators.
+ * Data-only definitions — routing behavior lives in model-role-router.ts.
+ */
+
+import type { ValidationResult } from "../schema/tv.js";
+import { isModelRole, type ModelRole } from "./model-roles.js";
+
+// ---------------------------------------------------------------------------
+// InferenceRoute — how a role is reached (never named after hardware)
+// ---------------------------------------------------------------------------
+
+export const INFERENCE_ROUTES = ["openshell", "nim", "mock"] as const;
+
+export type InferenceRoute = (typeof INFERENCE_ROUTES)[number];
+
+// ---------------------------------------------------------------------------
+// InferenceTaskEnvelope — a typed request for one model-role invocation
+// ---------------------------------------------------------------------------
+
+export const INFERENCE_TASK_SOURCES = [
+  "machina-pod",
+  "sportsclaw-operator",
+  "benchmark",
+] as const;
+
+export type InferenceTaskSource = (typeof INFERENCE_TASK_SOURCES)[number];
+
+export interface InferenceTaskEnvelope<TInput = unknown> {
+  taskId: string;
+  role: ModelRole;
+  model: string;
+  input: TInput;
+  requestedAt: string;
+  source: InferenceTaskSource;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// InferenceTrace — timing/model/route trace for one invocation
+// ---------------------------------------------------------------------------
+
+export interface InferenceTrace {
+  taskId: string;
+  role: ModelRole;
+  model: string;
+  modelVersion?: string;
+  /** Optional hardware trace (e.g. which accelerator served the call). */
+  acceleratorIndex?: number;
+  startedAt: string;
+  endedAt: string;
+  latencyMs: number;
+  route: InferenceRoute;
+  status: "completed" | "failed";
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// InferenceResult — typed output plus its trace
+// ---------------------------------------------------------------------------
+
+export interface InferenceResult<TOutput = unknown> {
+  taskId: string;
+  role: ModelRole;
+  output: TOutput;
+  trace: InferenceTrace;
+}
+
+// ---------------------------------------------------------------------------
+// Validators — lightweight runtime safety checks
+// ---------------------------------------------------------------------------
+
+export function validateInferenceTaskEnvelope(envelope: unknown): ValidationResult {
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+    return { ok: false, error: "Envelope must be a non-null object." };
+  }
+
+  const e = envelope as Record<string, unknown>;
+
+  if (typeof e.taskId !== "string" || e.taskId === "") {
+    return { ok: false, error: "Envelope must have a non-empty taskId." };
+  }
+
+  if (!isModelRole(e.role)) {
+    return { ok: false, error: "Envelope role must be one of eyes, brain, hands, voice." };
+  }
+
+  if (typeof e.model !== "string" || e.model === "") {
+    return { ok: false, error: "Envelope must have a non-empty model." };
+  }
+
+  if (typeof e.requestedAt !== "string" || e.requestedAt === "") {
+    return { ok: false, error: "Envelope must have a non-empty requestedAt timestamp." };
+  }
+
+  if (!(INFERENCE_TASK_SOURCES as readonly string[]).includes(e.source as string)) {
+    return {
+      ok: false,
+      error: "Envelope source must be machina-pod, sportsclaw-operator, or benchmark.",
+    };
+  }
+
+  return { ok: true };
+}
+
+export function validateInferenceTrace(trace: unknown): ValidationResult {
+  if (!trace || typeof trace !== "object" || Array.isArray(trace)) {
+    return { ok: false, error: "Trace must be a non-null object." };
+  }
+
+  const t = trace as Record<string, unknown>;
+
+  if (typeof t.taskId !== "string" || t.taskId === "") {
+    return { ok: false, error: "Trace must have a non-empty taskId." };
+  }
+
+  if (!isModelRole(t.role)) {
+    return { ok: false, error: "Trace role must be one of eyes, brain, hands, voice." };
+  }
+
+  if (typeof t.model !== "string" || t.model === "") {
+    return { ok: false, error: "Trace must have a non-empty model." };
+  }
+
+  if (typeof t.startedAt !== "string" || t.startedAt === "") {
+    return { ok: false, error: "Trace must have a non-empty startedAt timestamp." };
+  }
+
+  if (typeof t.endedAt !== "string" || t.endedAt === "") {
+    return { ok: false, error: "Trace must have a non-empty endedAt timestamp." };
+  }
+
+  if (typeof t.latencyMs !== "number" || !Number.isFinite(t.latencyMs) || t.latencyMs < 0) {
+    return { ok: false, error: "Trace latencyMs must be a non-negative number." };
+  }
+
+  if (!(INFERENCE_ROUTES as readonly string[]).includes(t.route as string)) {
+    return { ok: false, error: "Trace route must be openshell, nim, or mock." };
+  }
+
+  if (t.status !== "completed" && t.status !== "failed") {
+    return { ok: false, error: "Trace status must be completed or failed." };
+  }
+
+  return { ok: true };
+}

--- a/src/inference/model-role-router.ts
+++ b/src/inference/model-role-router.ts
@@ -1,0 +1,311 @@
+/**
+ * sportsclaw — Model Role Router
+ *
+ * Routes `eyes/brain/hands/voice` invocations to a configured route
+ * (`openshell`, `nim`, or `mock`) and returns typed `InferenceResult`s
+ * with timing traces. This is the single stable call surface for TV/pod
+ * workflows and operators — callers request a role, never a GPU, an
+ * endpoint URL, or a model placement.
+ *
+ * Routes adapt to the existing harness plumbing:
+ *   - `openshell` — AI SDK provider pointed at the OpenShell Privacy
+ *     Router (OpenAI-compatible), same construction as the operator
+ *     daemon's openshell block.
+ *   - `nim` — AI SDK OpenAI-compatible provider pointed at a NIM
+ *     endpoint (`baseUrl` in role config, else NIM_BASE_URL /
+ *     OPENAI_BASE_URL env). Nemotron thinking-suppression kwargs are
+ *     injected by `resolveModel`'s fetch wrapper.
+ *   - `mock` — deterministic in-process echo, no network. Used by unit
+ *     tests and the moment-to-air benchmark in CI.
+ *
+ * Extension seam: both real routes go through the OpenAI-compatible
+ * chat-completions surface (`runChatRoute`). Media-generation endpoints
+ * that are not chat-shaped (e.g. a dedicated Cosmos I2V API for the
+ * `hands` role) plug in by branching on the role's route config inside
+ * `invokeModelRole` — the envelope/trace contracts stay unchanged.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { generateText } from "ai";
+
+import { defaultOpenShellBaseUrl, resolveModel } from "../llm-providers.js";
+import type { ValidationResult } from "../schema/tv.js";
+import { isModelRole, MODEL_ROLES, type ModelRole } from "./model-roles.js";
+import {
+  INFERENCE_ROUTES,
+  type InferenceResult,
+  type InferenceRoute,
+  type InferenceTaskEnvelope,
+  type InferenceTaskSource,
+  type InferenceTrace,
+} from "./inference-task.js";
+
+// ---------------------------------------------------------------------------
+// Route config — where each role runs. Hardware is metadata, not contract.
+// ---------------------------------------------------------------------------
+
+export const ROLE_LOCALITIES = [
+  "pod",
+  "local",
+  "h200",
+  "hosted",
+  "brev",
+  "unknown",
+] as const;
+
+export type RoleLocality = (typeof ROLE_LOCALITIES)[number];
+
+export const ROLE_ACCELERATORS = ["h200", "h100", "l40s", "cpu", "unknown"] as const;
+
+export type RoleAccelerator = (typeof ROLE_ACCELERATORS)[number];
+
+export interface ModelRoleRouteConfig {
+  /** How the role is reached. */
+  route: InferenceRoute;
+  /** Model id served on that route, e.g. "nvidia/cosmos3-nano-reasoner". */
+  model: string;
+  /** Where it runs — runtime metadata only, never a contract name. */
+  locality?: RoleLocality;
+  /** Optional hardware trace metadata. */
+  accelerator?: RoleAccelerator;
+  /**
+   * Endpoint base URL for openshell/nim routes. Never put credentials
+   * here — auth flows through env/credential stores, same as every
+   * other harness route.
+   */
+  baseUrl?: string;
+}
+
+export interface ModelRoleRouterConfig {
+  roles: Partial<Record<ModelRole, ModelRoleRouteConfig>>;
+}
+
+// ---------------------------------------------------------------------------
+// validateModelRoleRouterConfig — runtime validation for the config block
+// ---------------------------------------------------------------------------
+
+export function validateModelRoleRouterConfig(config: unknown): ValidationResult {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return { ok: false, error: "Inference config must be a non-null object." };
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (!c.roles || typeof c.roles !== "object" || Array.isArray(c.roles)) {
+    return { ok: false, error: "Inference config must have a roles object." };
+  }
+
+  for (const [key, value] of Object.entries(c.roles as Record<string, unknown>)) {
+    if (!isModelRole(key)) {
+      return {
+        ok: false,
+        error: `Unknown role "${key}" — roles must be one of ${MODEL_ROLES.join(", ")}.`,
+      };
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return { ok: false, error: `Role "${key}" config must be a non-null object.` };
+    }
+
+    const r = value as Record<string, unknown>;
+
+    if (!(INFERENCE_ROUTES as readonly string[]).includes(r.route as string)) {
+      return {
+        ok: false,
+        error: `Role "${key}" route must be one of ${INFERENCE_ROUTES.join(", ")}.`,
+      };
+    }
+
+    if (typeof r.model !== "string" || r.model === "") {
+      return { ok: false, error: `Role "${key}" must have a non-empty model.` };
+    }
+
+    if (
+      r.locality !== undefined &&
+      !(ROLE_LOCALITIES as readonly string[]).includes(r.locality as string)
+    ) {
+      return {
+        ok: false,
+        error: `Role "${key}" locality must be one of ${ROLE_LOCALITIES.join(", ")}.`,
+      };
+    }
+
+    if (
+      r.accelerator !== undefined &&
+      !(ROLE_ACCELERATORS as readonly string[]).includes(r.accelerator as string)
+    ) {
+      return {
+        ok: false,
+        error: `Role "${key}" accelerator must be one of ${ROLE_ACCELERATORS.join(", ")}.`,
+      };
+    }
+
+    if (r.baseUrl !== undefined) {
+      if (typeof r.baseUrl !== "string") {
+        return { ok: false, error: `Role "${key}" baseUrl must be a string URL.` };
+      }
+      try {
+        const url = new URL(r.baseUrl);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          return { ok: false, error: `Role "${key}" baseUrl must be http(s).` };
+        }
+      } catch {
+        return { ok: false, error: `Role "${key}" baseUrl is not a valid URL.` };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// InferenceRouteError — route failures always name role + model + trace
+// ---------------------------------------------------------------------------
+
+export class InferenceRouteError extends Error {
+  readonly role: ModelRole;
+  readonly model: string;
+  readonly trace: InferenceTrace;
+
+  constructor(message: string, trace: InferenceTrace) {
+    super(message);
+    this.name = "InferenceRouteError";
+    this.role = trace.role;
+    this.model = trace.model;
+    this.trace = trace;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// invokeModelRole — the one stable call surface
+// ---------------------------------------------------------------------------
+
+export interface InvokeModelRoleArgs<TInput = unknown> {
+  role: ModelRole;
+  input: TInput;
+  source: InferenceTaskSource;
+  config: ModelRoleRouterConfig;
+  /** Caller-supplied task id; defaults to a fresh UUID. */
+  taskId?: string;
+  /** Free-form metadata attached to the task envelope. */
+  meta?: Record<string, unknown>;
+}
+
+/** Serialize arbitrary role input into a prompt for chat-shaped routes. */
+function toPrompt(input: unknown): string {
+  return typeof input === "string" ? input : JSON.stringify(input);
+}
+
+/**
+ * Run a role through the OpenAI-compatible chat-completions surface —
+ * the shape both OpenShell and NIM serve today.
+ */
+async function runChatRoute(
+  envelope: InferenceTaskEnvelope,
+  baseUrl: string,
+): Promise<string> {
+  const model = resolveModel("openai", envelope.model, { baseUrl });
+  const res = await generateText({ model, prompt: toPrompt(envelope.input) });
+  return res.text;
+}
+
+export async function invokeModelRole<TInput = unknown, TOutput = unknown>(
+  args: InvokeModelRoleArgs<TInput>,
+): Promise<InferenceResult<TOutput>> {
+  const { role, input, source, config } = args;
+
+  if (!isModelRole(role)) {
+    throw new Error(
+      `Unknown model role ${JSON.stringify(role)} — must be one of ${MODEL_ROLES.join(", ")}.`,
+    );
+  }
+
+  const routeConfig = config?.roles?.[role];
+  if (!routeConfig) {
+    throw new Error(
+      `No route configured for role "${role}" — add inference.roles.${role} to the router config.`,
+    );
+  }
+
+  const configCheck = validateModelRoleRouterConfig({ roles: { [role]: routeConfig } });
+  if (!configCheck.ok) {
+    throw new Error(`Invalid route config for role "${role}": ${configCheck.error}`);
+  }
+
+  const envelope: InferenceTaskEnvelope<TInput> = {
+    taskId: args.taskId ?? randomUUID(),
+    role,
+    model: routeConfig.model,
+    input,
+    requestedAt: new Date().toISOString(),
+    source,
+    meta: args.meta,
+  };
+
+  const startedAtMs = Date.now();
+  const startedAt = new Date(startedAtMs).toISOString();
+
+  const buildTrace = (
+    status: InferenceTrace["status"],
+    error?: string,
+  ): InferenceTrace => {
+    const endedAtMs = Date.now();
+    return {
+      taskId: envelope.taskId,
+      role,
+      model: routeConfig.model,
+      startedAt,
+      endedAt: new Date(endedAtMs).toISOString(),
+      latencyMs: endedAtMs - startedAtMs,
+      route: routeConfig.route,
+      status,
+      ...(error !== undefined ? { error } : {}),
+    };
+  };
+
+  const fail = (message: string): never => {
+    throw new InferenceRouteError(
+      `Role "${role}" (model "${routeConfig.model}", route "${routeConfig.route}") failed: ${message}`,
+      buildTrace("failed", message),
+    );
+  };
+
+  let output: unknown;
+  try {
+    switch (routeConfig.route) {
+      case "mock":
+        output = { mock: true, role, model: routeConfig.model, echo: input };
+        break;
+      case "openshell":
+        output = await runChatRoute(
+          envelope,
+          routeConfig.baseUrl ?? defaultOpenShellBaseUrl("openai"),
+        );
+        break;
+      case "nim": {
+        const baseUrl =
+          routeConfig.baseUrl ??
+          process.env.NIM_BASE_URL ??
+          process.env.OPENAI_BASE_URL;
+        if (!baseUrl) {
+          return fail(
+            "no NIM endpoint configured — set baseUrl in the role config or NIM_BASE_URL / OPENAI_BASE_URL in the environment.",
+          );
+        }
+        output = await runChatRoute(envelope, baseUrl);
+        break;
+      }
+    }
+  } catch (err) {
+    if (err instanceof InferenceRouteError) throw err;
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+
+  return {
+    taskId: envelope.taskId,
+    role,
+    output: output as TOutput,
+    trace: buildTrace("completed"),
+  };
+}

--- a/src/inference/model-roles.ts
+++ b/src/inference/model-roles.ts
@@ -1,0 +1,23 @@
+/**
+ * sportsclaw — Model Role Contracts
+ *
+ * First-class inference roles for the accelerated inference plane:
+ *
+ *   - `eyes`  — visual perception (e.g. Cosmos 3 Nano Reasoner)
+ *   - `brain` — editorial/programming reasoning (e.g. Nemotron 3 Super 120B A12B)
+ *   - `hands` — generated video/image asset production (e.g. Cosmos 3 Super I2V)
+ *   - `voice` — narration/chyrons/copy (e.g. Nemotron 49B)
+ *
+ * The abstraction is inference roles, not hardware. Hardware (H200 etc.)
+ * lives only in route metadata and benchmark output — never in contract
+ * names. The same role contract works for local NIMs, OpenShell, hosted
+ * NIM endpoints, or future cloud inference.
+ */
+
+export const MODEL_ROLES = ["eyes", "brain", "hands", "voice"] as const;
+
+export type ModelRole = (typeof MODEL_ROLES)[number];
+
+export function isModelRole(value: unknown): value is ModelRole {
+  return typeof value === "string" && (MODEL_ROLES as readonly string[]).includes(value);
+}

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -16,6 +16,10 @@ import path from "node:path";
 import { homedir } from "node:os";
 
 import type { LLMProvider, OpenShellConfig } from "./types.js";
+import {
+  validateModelRoleRouterConfig,
+  type ModelRoleRouterConfig,
+} from "./inference/model-role-router.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -113,6 +117,14 @@ export interface OperatorJobConfig {
    * See `openshell/README.md` for the deployment runbook.
    */
   openshell?: OpenShellConfig;
+  /**
+   * Model-role inference routing — maps `eyes/brain/hands/voice` roles to
+   * OpenShell/NIM/mock routes. Consumed by `invokeModelRole` in
+   * `inference/model-role-router.ts`. Hardware (locality/accelerator) is
+   * runtime metadata only — callers request roles, never GPUs. Never put
+   * credentials or endpoint tokens here.
+   */
+  inference?: ModelRoleRouterConfig;
   /**
    * Broadcast-safety validation gate. When `enabled` is true and the daemon
    * is in structured-output mode, the validated payload is passed through
@@ -392,6 +404,14 @@ export function validateOperatorJobConfig(
     }
   }
 
+  // inference — model-role router config, validated by its own module
+  if (raw.inference !== undefined) {
+    const inferenceCheck = validateModelRoleRouterConfig(raw.inference);
+    if (!inferenceCheck.ok) {
+      push("inference", inferenceCheck.error);
+    }
+  }
+
   // broadcastSafety
   if (raw.broadcastSafety !== undefined) {
     if (typeof raw.broadcastSafety !== "object" || raw.broadcastSafety === null || Array.isArray(raw.broadcastSafety)) {
@@ -454,6 +474,7 @@ export function validateOperatorJobConfig(
       sinkRole: raw.sinkRole as string | undefined,
       enableMemoryTools: raw.enableMemoryTools as boolean | undefined,
       openshell: parsedOpenShell,
+      inference: raw.inference as ModelRoleRouterConfig | undefined,
       broadcastSafety: raw.broadcastSafety as OperatorJobConfig["broadcastSafety"],
     },
   };

--- a/src/schema/tv.ts
+++ b/src/schema/tv.ts
@@ -5,6 +5,8 @@
  * These are data-only definitions — no engine wiring or behavior.
  */
 
+import type { InferenceTrace } from "../inference/inference-task.js";
+
 // ---------------------------------------------------------------------------
 // FreshnessClass — how stale is this content?
 // ---------------------------------------------------------------------------
@@ -281,6 +283,120 @@ export function validateLiveContentMeta(block: unknown): ValidationResult {
     }
     if (!b.freshnessTimestamp || typeof b.freshnessTimestamp !== "string") {
       return { ok: false, error: `${freshness} block must have a freshness timestamp (freshnessTimestamp).` };
+    }
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// MatchMoment — live visual perception output from the `eyes` model role
+// ---------------------------------------------------------------------------
+
+export const MATCH_MOMENT_TYPES = [
+  "goal",
+  "goal_chance",
+  "foul",
+  "card",
+  "save",
+  "substitution",
+  "tactical_shift",
+  "crowd_reaction",
+  "momentum_swing",
+  "controversy",
+] as const;
+
+export type MatchMomentType = (typeof MATCH_MOMENT_TYPES)[number];
+
+export const MATCH_MOMENT_SOURCES = ["cosmos3", "manual", "stats", "benchmark"] as const;
+
+export type MatchMomentSource = (typeof MATCH_MOMENT_SOURCES)[number];
+
+export interface MatchMoment {
+  id: string;
+  fixtureId: string;
+  clipUrl?: string;
+  keyframeUrls?: string[];
+  sampledFps: number;
+  momentType: MatchMomentType;
+  visualRead: string;
+  tacticalMeaning: string;
+  broadcastAngle: string;
+  confidence: number;
+  createdAt: string;
+  source?: MatchMomentSource;
+  /** Inference trace from the model-role invocation that produced this moment. */
+  trace?: InferenceTrace;
+  meta?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// validateMatchMoment — runtime validation
+// ---------------------------------------------------------------------------
+
+export function validateMatchMoment(moment: unknown): ValidationResult {
+  if (!moment || typeof moment !== "object" || Array.isArray(moment)) {
+    return { ok: false, error: "Moment must be a non-null object." };
+  }
+
+  const m = moment as Record<string, unknown>;
+
+  if (typeof m.id !== "string" || m.id === "") {
+    return { ok: false, error: "Moment must have a non-empty id." };
+  }
+
+  if (typeof m.fixtureId !== "string" || m.fixtureId === "") {
+    return { ok: false, error: "Moment must have a non-empty fixtureId." };
+  }
+
+  if (typeof m.sampledFps !== "number" || !Number.isFinite(m.sampledFps) || m.sampledFps <= 0) {
+    return { ok: false, error: "Moment sampledFps must be a positive number." };
+  }
+
+  if (!(MATCH_MOMENT_TYPES as readonly string[]).includes(m.momentType as string)) {
+    return { ok: false, error: "Moment momentType must be a known match moment type." };
+  }
+
+  if (typeof m.visualRead !== "string" || m.visualRead === "") {
+    return { ok: false, error: "Moment must have a non-empty visualRead." };
+  }
+
+  if (typeof m.tacticalMeaning !== "string" || m.tacticalMeaning === "") {
+    return { ok: false, error: "Moment must have a non-empty tacticalMeaning." };
+  }
+
+  if (typeof m.broadcastAngle !== "string" || m.broadcastAngle === "") {
+    return { ok: false, error: "Moment must have a non-empty broadcastAngle." };
+  }
+
+  if (
+    typeof m.confidence !== "number" ||
+    !Number.isFinite(m.confidence) ||
+    m.confidence < 0 ||
+    m.confidence > 1
+  ) {
+    return { ok: false, error: "Moment confidence must be a number between 0 and 1." };
+  }
+
+  if (typeof m.createdAt !== "string" || m.createdAt === "") {
+    return { ok: false, error: "Moment must have a non-empty createdAt timestamp." };
+  }
+
+  if (
+    m.source !== undefined &&
+    !(MATCH_MOMENT_SOURCES as readonly string[]).includes(m.source as string)
+  ) {
+    return { ok: false, error: "Moment source must be cosmos3, manual, stats, or benchmark." };
+  }
+
+  if (m.source === "cosmos3") {
+    const hasClip = typeof m.clipUrl === "string" && m.clipUrl !== "";
+    const hasKeyframes = Array.isArray(m.keyframeUrls) && m.keyframeUrls.length > 0;
+    if (!hasClip && !hasKeyframes) {
+      return {
+        ok: false,
+        error: "Cosmos-originated moment must have a clipUrl or non-empty keyframeUrls.",
+      };
     }
   }
 

--- a/test/inference-contracts.test.mjs
+++ b/test/inference-contracts.test.mjs
@@ -1,0 +1,223 @@
+/**
+ * Inference Contracts — test suite
+ *
+ * Tests for model-role types and inference task envelope/trace/result
+ * validators. Written test-first (TDD).
+ *
+ * The abstraction is inference roles, not hardware — H200 is only runtime
+ * metadata/trace. See the model-role router spec.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  MODEL_ROLES,
+  isModelRole,
+} from "../dist/inference/model-roles.js";
+
+import {
+  INFERENCE_ROUTES,
+  validateInferenceTaskEnvelope,
+  validateInferenceTrace,
+} from "../dist/inference/inference-task.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal valid InferenceTaskEnvelope */
+function validEnvelope(overrides = {}) {
+  return {
+    taskId: "task-1",
+    role: "eyes",
+    model: "nvidia/cosmos3-nano-reasoner",
+    input: { clipUrl: "https://example.com/clip.mp4" },
+    requestedAt: new Date().toISOString(),
+    source: "machina-pod",
+    ...overrides,
+  };
+}
+
+/** Minimal valid InferenceTrace */
+function validTrace(overrides = {}) {
+  return {
+    taskId: "task-1",
+    role: "eyes",
+    model: "nvidia/cosmos3-nano-reasoner",
+    startedAt: "2026-06-01T00:00:00.000Z",
+    endedAt: "2026-06-01T00:00:01.250Z",
+    latencyMs: 1250,
+    route: "mock",
+    status: "completed",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ModelRole
+// ---------------------------------------------------------------------------
+
+describe("MODEL_ROLES", () => {
+  it("exports exactly the four expected roles", () => {
+    assert.deepStrictEqual(
+      [...MODEL_ROLES].sort(),
+      ["brain", "eyes", "hands", "voice"].sort(),
+    );
+  });
+});
+
+describe("isModelRole", () => {
+  it("accepts every declared role", () => {
+    for (const role of MODEL_ROLES) {
+      assert.strictEqual(isModelRole(role), true, `expected ${role} to be valid`);
+    }
+  });
+
+  it("rejects unknown role strings", () => {
+    assert.strictEqual(isModelRole("gpu0"), false);
+    assert.strictEqual(isModelRole("ears"), false);
+    assert.strictEqual(isModelRole(""), false);
+  });
+
+  it("rejects non-string values", () => {
+    assert.strictEqual(isModelRole(undefined), false);
+    assert.strictEqual(isModelRole(null), false);
+    assert.strictEqual(isModelRole(42), false);
+    assert.strictEqual(isModelRole(["eyes"]), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateInferenceTaskEnvelope
+// ---------------------------------------------------------------------------
+
+describe("validateInferenceTaskEnvelope", () => {
+  it("accepts a valid envelope", () => {
+    const result = validateInferenceTaskEnvelope(validEnvelope());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts every declared source", () => {
+    for (const source of ["machina-pod", "sportsclaw-operator", "benchmark"]) {
+      const result = validateInferenceTaskEnvelope(validEnvelope({ source }));
+      assert.strictEqual(result.ok, true, `expected source ${source} to be valid`);
+    }
+  });
+
+  it("rejects a non-object", () => {
+    const result = validateInferenceTaskEnvelope(null);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("rejects a missing taskId", () => {
+    const envelope = validEnvelope();
+    delete envelope.taskId;
+    const result = validateInferenceTaskEnvelope(envelope);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("taskId"));
+  });
+
+  it("rejects an empty taskId", () => {
+    const result = validateInferenceTaskEnvelope(validEnvelope({ taskId: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("taskId"));
+  });
+
+  it("rejects an unknown role", () => {
+    const result = validateInferenceTaskEnvelope(validEnvelope({ role: "gpu0" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("role"));
+  });
+
+  it("rejects a missing model", () => {
+    const result = validateInferenceTaskEnvelope(validEnvelope({ model: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("model"));
+  });
+
+  it("rejects a missing requestedAt", () => {
+    const result = validateInferenceTaskEnvelope(validEnvelope({ requestedAt: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("requestedAt"));
+  });
+
+  it("rejects an unknown source", () => {
+    const result = validateInferenceTaskEnvelope(validEnvelope({ source: "h200" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("source"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateInferenceTrace
+// ---------------------------------------------------------------------------
+
+describe("INFERENCE_ROUTES", () => {
+  it("exports exactly the expected routes", () => {
+    assert.deepStrictEqual(
+      [...INFERENCE_ROUTES].sort(),
+      ["mock", "nim", "openshell"].sort(),
+    );
+  });
+});
+
+describe("validateInferenceTrace", () => {
+  it("accepts a valid completed trace", () => {
+    const result = validateInferenceTrace(validTrace());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts a failed trace with an error message", () => {
+    const result = validateInferenceTrace(
+      validTrace({ status: "failed", error: "NIM endpoint unreachable" }),
+    );
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects a non-object", () => {
+    const result = validateInferenceTrace("trace");
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("rejects a missing taskId", () => {
+    const result = validateInferenceTrace(validTrace({ taskId: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("taskId"));
+  });
+
+  it("rejects an unknown role", () => {
+    const result = validateInferenceTrace(validTrace({ role: "h200" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("role"));
+  });
+
+  it("rejects a negative latencyMs", () => {
+    const result = validateInferenceTrace(validTrace({ latencyMs: -5 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("latencyMs"));
+  });
+
+  it("rejects a non-numeric latencyMs", () => {
+    const result = validateInferenceTrace(validTrace({ latencyMs: "fast" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("latencyMs"));
+  });
+
+  it("rejects an unknown route", () => {
+    const result = validateInferenceTrace(validTrace({ route: "direct-gpu" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("route"));
+  });
+
+  it("rejects an unknown status", () => {
+    const result = validateInferenceTrace(validTrace({ status: "pending" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("status"));
+  });
+
+  it("rejects missing startedAt / endedAt", () => {
+    assert.strictEqual(validateInferenceTrace(validTrace({ startedAt: "" })).ok, false);
+    assert.strictEqual(validateInferenceTrace(validTrace({ endedAt: "" })).ok, false);
+  });
+});

--- a/test/model-role-router.test.mjs
+++ b/test/model-role-router.test.mjs
@@ -1,0 +1,264 @@
+/**
+ * Model Role Router — test suite
+ *
+ * Tests for role-route config validation and invokeModelRole. Written
+ * test-first (TDD). No network calls — real routes are exercised only
+ * through their config/error paths; execution goes through the mock route.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  validateModelRoleRouterConfig,
+  invokeModelRole,
+  InferenceRouteError,
+} from "../dist/inference/model-role-router.js";
+
+import { validateInferenceTrace } from "../dist/inference/inference-task.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Full four-role router config (mock routes so tests never hit a network). */
+function mockRouterConfig() {
+  return {
+    roles: {
+      eyes: { route: "mock", model: "nvidia/cosmos3-nano-reasoner" },
+      brain: { route: "mock", model: "nvidia/nemotron-3-super-120b-a12b" },
+      hands: { route: "mock", model: "nvidia/cosmos3-super-i2v" },
+      voice: { route: "mock", model: "nvidia/llama-3.3-nemotron-super-49b" },
+    },
+  };
+}
+
+/** The target production shape from the spec — NIM routes with H200 metadata. */
+function nimRouterConfig() {
+  return {
+    roles: {
+      eyes: {
+        route: "nim",
+        locality: "h200",
+        accelerator: "h200",
+        model: "nvidia/cosmos3-nano-reasoner",
+      },
+      brain: {
+        route: "nim",
+        locality: "h200",
+        accelerator: "h200",
+        model: "nvidia/nemotron-3-super-120b-a12b",
+      },
+      hands: {
+        route: "nim",
+        locality: "h200",
+        accelerator: "h200",
+        model: "nvidia/cosmos3-super-i2v",
+      },
+      voice: {
+        route: "nim",
+        locality: "h200",
+        accelerator: "h200",
+        model: "nvidia/llama-3.3-nemotron-super-49b",
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateModelRoleRouterConfig
+// ---------------------------------------------------------------------------
+
+describe("validateModelRoleRouterConfig", () => {
+  it("accepts a full mock config", () => {
+    const result = validateModelRoleRouterConfig(mockRouterConfig());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts the target NIM/H200 config shape", () => {
+    const result = validateModelRoleRouterConfig(nimRouterConfig());
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts a partial config (only some roles configured)", () => {
+    const config = { roles: { brain: { route: "mock", model: "test-model" } } };
+    const result = validateModelRoleRouterConfig(config);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects a non-object", () => {
+    assert.strictEqual(validateModelRoleRouterConfig(null).ok, false);
+    assert.strictEqual(validateModelRoleRouterConfig("inference").ok, false);
+  });
+
+  it("rejects a missing roles block", () => {
+    const result = validateModelRoleRouterConfig({});
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("roles"));
+  });
+
+  it("rejects an unknown role key", () => {
+    const config = mockRouterConfig();
+    config.roles.ears = { route: "mock", model: "test-model" };
+    const result = validateModelRoleRouterConfig(config);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("ears"));
+  });
+
+  it("rejects an unknown route", () => {
+    const config = mockRouterConfig();
+    config.roles.eyes.route = "gpu-direct";
+    const result = validateModelRoleRouterConfig(config);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("eyes"));
+    assert.ok(result.error.includes("route"));
+  });
+
+  it("rejects a missing model", () => {
+    const config = mockRouterConfig();
+    config.roles.brain.model = "";
+    const result = validateModelRoleRouterConfig(config);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("brain"));
+    assert.ok(result.error.includes("model"));
+  });
+
+  it("rejects an unknown locality", () => {
+    const config = mockRouterConfig();
+    config.roles.hands.locality = "moon-base";
+    const result = validateModelRoleRouterConfig(config);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("hands"));
+    assert.ok(result.error.includes("locality"));
+  });
+
+  it("rejects an unknown accelerator", () => {
+    const config = mockRouterConfig();
+    config.roles.voice.accelerator = "tpu9000";
+    const result = validateModelRoleRouterConfig(config);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("voice"));
+    assert.ok(result.error.includes("accelerator"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// invokeModelRole — mock route
+// ---------------------------------------------------------------------------
+
+describe("invokeModelRole (mock route)", () => {
+  it("returns an InferenceResult with a valid completed trace", async () => {
+    const result = await invokeModelRole({
+      role: "eyes",
+      input: { clipUrl: "https://example.com/clip.mp4", sampledFps: 4 },
+      source: "benchmark",
+      config: mockRouterConfig(),
+    });
+
+    assert.strictEqual(result.role, "eyes");
+    assert.ok(result.taskId.length > 0);
+    assert.strictEqual(result.trace.taskId, result.taskId);
+    assert.strictEqual(result.trace.role, "eyes");
+    assert.strictEqual(result.trace.model, "nvidia/cosmos3-nano-reasoner");
+    assert.strictEqual(result.trace.route, "mock");
+    assert.strictEqual(result.trace.status, "completed");
+    assert.ok(typeof result.trace.latencyMs === "number" && result.trace.latencyMs >= 0);
+
+    const traceCheck = validateInferenceTrace(result.trace);
+    assert.strictEqual(traceCheck.ok, true, traceCheck.ok ? "" : traceCheck.error);
+  });
+
+  it("echoes the input in the mock output", async () => {
+    const input = { headline: "Brazil pressure is structural" };
+    const result = await invokeModelRole({
+      role: "voice",
+      input,
+      source: "sportsclaw-operator",
+      config: mockRouterConfig(),
+    });
+
+    assert.strictEqual(result.output.mock, true);
+    assert.deepStrictEqual(result.output.echo, input);
+  });
+
+  it("honors a caller-supplied taskId", async () => {
+    const result = await invokeModelRole({
+      role: "brain",
+      input: "What is the tactical meaning of this moment?",
+      source: "machina-pod",
+      config: mockRouterConfig(),
+      taskId: "task-fixed-42",
+    });
+
+    assert.strictEqual(result.taskId, "task-fixed-42");
+    assert.strictEqual(result.trace.taskId, "task-fixed-42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// invokeModelRole — error paths
+// ---------------------------------------------------------------------------
+
+describe("invokeModelRole (error paths)", () => {
+  it("rejects an unknown role", async () => {
+    await assert.rejects(
+      () =>
+        invokeModelRole({
+          role: "gpu0",
+          input: {},
+          source: "benchmark",
+          config: mockRouterConfig(),
+        }),
+      (err) => err.message.includes("gpu0"),
+    );
+  });
+
+  it("fails explicitly (not silently) when a role has no route config", async () => {
+    const config = { roles: { eyes: { route: "mock", model: "m" } } };
+    await assert.rejects(
+      () =>
+        invokeModelRole({
+          role: "voice",
+          input: {},
+          source: "machina-pod",
+          config,
+        }),
+      (err) => err.message.includes("voice"),
+    );
+  });
+
+  it("route errors include role and model", async () => {
+    // nim route with no base URL resolvable — must fail fast, before any
+    // network attempt, naming the role and model.
+    const savedNim = process.env.NIM_BASE_URL;
+    const savedOpenai = process.env.OPENAI_BASE_URL;
+    delete process.env.NIM_BASE_URL;
+    delete process.env.OPENAI_BASE_URL;
+    try {
+      await assert.rejects(
+        () =>
+          invokeModelRole({
+            role: "brain",
+            input: "prompt",
+            source: "machina-pod",
+            config: {
+              roles: {
+                brain: { route: "nim", model: "nvidia/nemotron-3-super-120b-a12b" },
+              },
+            },
+          }),
+        (err) => {
+          assert.ok(err instanceof InferenceRouteError);
+          assert.ok(err.message.includes("brain"));
+          assert.ok(err.message.includes("nvidia/nemotron-3-super-120b-a12b"));
+          assert.strictEqual(err.trace.status, "failed");
+          assert.strictEqual(err.trace.route, "nim");
+          return true;
+        },
+      );
+    } finally {
+      if (savedNim !== undefined) process.env.NIM_BASE_URL = savedNim;
+      if (savedOpenai !== undefined) process.env.OPENAI_BASE_URL = savedOpenai;
+    }
+  });
+});

--- a/test/operator-config.test.mjs
+++ b/test/operator-config.test.mjs
@@ -501,3 +501,86 @@ describe("validateOperatorJobConfig — openshell block", () => {
     assert.strictEqual(r.valid, false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// inference block — model-role router config
+// ---------------------------------------------------------------------------
+
+describe("validateOperatorJobConfig — inference block", () => {
+  const base = {
+    jobId: "inference-job",
+    intervalMs: 60_000,
+    personaText: "You are an autonomous operator.",
+  };
+
+  it("accepts a config with no inference block", () => {
+    const r = validateOperatorJobConfig(base);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.config.inference, undefined);
+  });
+
+  it("accepts the target four-role NIM/H200 inference config", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      inference: {
+        roles: {
+          eyes: {
+            route: "nim",
+            locality: "h200",
+            accelerator: "h200",
+            model: "nvidia/cosmos3-nano-reasoner",
+          },
+          brain: {
+            route: "nim",
+            locality: "h200",
+            accelerator: "h200",
+            model: "nvidia/nemotron-3-super-120b-a12b",
+          },
+          hands: {
+            route: "nim",
+            locality: "h200",
+            accelerator: "h200",
+            model: "nvidia/cosmos3-super-i2v",
+          },
+          voice: {
+            route: "nim",
+            locality: "h200",
+            accelerator: "h200",
+            model: "nvidia/llama-3.3-nemotron-super-49b",
+          },
+        },
+      },
+    });
+    assert.strictEqual(r.valid, true, JSON.stringify(r.issues));
+    assert.strictEqual(r.config.inference.roles.eyes.model, "nvidia/cosmos3-nano-reasoner");
+    assert.strictEqual(r.config.inference.roles.voice.route, "nim");
+  });
+
+  it("rejects a non-object inference block", () => {
+    for (const bad of ["nim", 42, true, []]) {
+      const r = validateOperatorJobConfig({ ...base, inference: bad });
+      assert.strictEqual(r.valid, false, `inference=${JSON.stringify(bad)}`);
+      assert.ok(r.issues.find((i) => i.field === "inference"));
+    }
+  });
+
+  it("rejects an inference block with an unknown role", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      inference: { roles: { ears: { route: "mock", model: "m" } } },
+    });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.issues.find((i) => i.field === "inference"));
+  });
+
+  it("rejects an inference block with a missing model", () => {
+    const r = validateOperatorJobConfig({
+      ...base,
+      inference: { roles: { eyes: { route: "nim" } } },
+    });
+    assert.strictEqual(r.valid, false);
+    const issue = r.issues.find((i) => i.field === "inference");
+    assert.ok(issue);
+    assert.ok(issue.message.includes("eyes"));
+  });
+});

--- a/test/tv-contracts.test.mjs
+++ b/test/tv-contracts.test.mjs
@@ -12,11 +12,13 @@ import { describe, it } from "node:test";
 import {
   // Enums / constants
   FRESHNESS_CLASSES,
+  MATCH_MOMENT_TYPES,
 
   // Validators
   validatePlaylistBlock,
   validatePlaylistManifest,
   validateLiveContentMeta,
+  validateMatchMoment,
 } from "../dist/schema/tv.js";
 
 // ---------------------------------------------------------------------------
@@ -212,5 +214,158 @@ describe("validateLiveContentMeta", () => {
     delete block.freshnessTimestamp;
     const result = validateLiveContentMeta(block);
     assert.strictEqual(result.ok, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MatchMoment
+// ---------------------------------------------------------------------------
+
+/** Minimal valid Cosmos-originated MatchMoment */
+function validMatchMoment(overrides = {}) {
+  return {
+    id: "moment-1",
+    fixtureId: "fixture-bra-arg-2026",
+    clipUrl: "https://example.com/clips/moment-1.mp4",
+    sampledFps: 4,
+    momentType: "goal_chance",
+    visualRead:
+      "Left winger beats the fullback and drives a low cross through the six-yard box.",
+    tacticalMeaning: "Brazil is creating repeatable overloads on the left side.",
+    broadcastAngle: "Brazil pressure is now structural, not random.",
+    confidence: 0.84,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    source: "cosmos3",
+    ...overrides,
+  };
+}
+
+describe("MATCH_MOMENT_TYPES", () => {
+  it("exports the expected moment types", () => {
+    assert.deepStrictEqual(
+      [...MATCH_MOMENT_TYPES].sort(),
+      [
+        "goal",
+        "goal_chance",
+        "foul",
+        "card",
+        "save",
+        "substitution",
+        "tactical_shift",
+        "crowd_reaction",
+        "momentum_swing",
+        "controversy",
+      ].sort(),
+    );
+  });
+});
+
+describe("validateMatchMoment", () => {
+  it("accepts a valid Cosmos-originated moment", () => {
+    const result = validateMatchMoment(validMatchMoment());
+    assert.strictEqual(result.ok, true, result.ok ? "" : result.error);
+  });
+
+  it("accepts a moment with keyframeUrls instead of clipUrl", () => {
+    const moment = validMatchMoment({
+      keyframeUrls: ["https://example.com/kf/1.jpg"],
+    });
+    delete moment.clipUrl;
+    const result = validateMatchMoment(moment);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts a manual moment without clip or keyframes", () => {
+    const moment = validMatchMoment({ source: "manual" });
+    delete moment.clipUrl;
+    const result = validateMatchMoment(moment);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("accepts a moment carrying an InferenceTrace", () => {
+    const result = validateMatchMoment(
+      validMatchMoment({
+        trace: {
+          taskId: "task-1",
+          role: "eyes",
+          model: "nvidia/cosmos3-nano-reasoner",
+          startedAt: "2026-06-01T00:00:00.000Z",
+          endedAt: "2026-06-01T00:00:01.000Z",
+          latencyMs: 1000,
+          route: "nim",
+          status: "completed",
+        },
+      }),
+    );
+    assert.strictEqual(result.ok, true);
+  });
+
+  it("rejects a non-object", () => {
+    assert.strictEqual(validateMatchMoment(null).ok, false);
+  });
+
+  it("rejects a missing id", () => {
+    const result = validateMatchMoment(validMatchMoment({ id: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("id"));
+  });
+
+  it("rejects a missing fixtureId", () => {
+    const moment = validMatchMoment();
+    delete moment.fixtureId;
+    const result = validateMatchMoment(moment);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("fixtureId"));
+  });
+
+  it("rejects confidence below 0", () => {
+    const result = validateMatchMoment(validMatchMoment({ confidence: -0.1 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("confidence"));
+  });
+
+  it("rejects confidence above 1", () => {
+    const result = validateMatchMoment(validMatchMoment({ confidence: 1.5 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("confidence"));
+  });
+
+  it("rejects a non-positive sampledFps", () => {
+    const result = validateMatchMoment(validMatchMoment({ sampledFps: 0 }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("sampledFps"));
+  });
+
+  it("rejects an unknown momentType", () => {
+    const result = validateMatchMoment(validMatchMoment({ momentType: "nutmeg" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("momentType"));
+  });
+
+  it("rejects a cosmos3 moment missing both clipUrl and keyframeUrls", () => {
+    const moment = validMatchMoment({ source: "cosmos3" });
+    delete moment.clipUrl;
+    const result = validateMatchMoment(moment);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("clipUrl") || result.error.includes("keyframeUrls"));
+  });
+
+  it("rejects a cosmos3 moment with an empty keyframeUrls array and no clipUrl", () => {
+    const moment = validMatchMoment({ source: "cosmos3", keyframeUrls: [] });
+    delete moment.clipUrl;
+    const result = validateMatchMoment(moment);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it("rejects an unknown source", () => {
+    const result = validateMatchMoment(validMatchMoment({ source: "vhs-tape" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("source"));
+  });
+
+  it("rejects a missing createdAt", () => {
+    const result = validateMatchMoment(validMatchMoment({ createdAt: "" }));
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.error.includes("createdAt"));
   });
 });


### PR DESCRIPTION
## Summary

Implements Phases 0–2 + 5 of the SportsClaw H200 pod-boundary spec: a first-class inference routing layer for model roles. **The abstraction is inference roles, not hardware** — H200 appears only as `locality`/`accelerator` runtime metadata and in benchmark output, never in contract names.

| Role | Job | Target model |
|------|-----|--------------|
| `eyes` | visual perception | `nvidia/cosmos3-nano-reasoner` |
| `brain` | editorial/programming reasoning | `nvidia/nemotron-3-super-120b-a12b` |
| `hands` | generated video/image assets | `nvidia/cosmos3-super-i2v` |
| `voice` | narration/chyrons/copy | `nvidia/llama-3.3-nemotron-super-49b` |

## What's new

- **`src/inference/model-roles.ts`** — `MODEL_ROLES`, `ModelRole`, `isModelRole()`
- **`src/inference/inference-task.ts`** — `InferenceTaskEnvelope`, `InferenceTrace`, `InferenceResult` + runtime validators; routes are `openshell | nim | mock`
- **`src/inference/model-role-router.ts`** — `ModelRoleRouterConfig` (+ validation) and `invokeModelRole(...)`:
  - `mock` route — deterministic in-process echo, zero network (tests/CI)
  - `openshell` / `nim` routes — adapt the existing `resolveModel()` OpenAI-compatible plumbing (incl. Nemotron thinking-suppression fetch wrapper); NIM baseUrl resolves role config → `NIM_BASE_URL` → `OPENAI_BASE_URL`, failing fast with role + model named before any network attempt
  - failures throw `InferenceRouteError` carrying a `status: "failed"` trace
  - extension seam documented for non-chat-shaped endpoints (Cosmos I2V for `hands`)
- **`src/schema/tv.ts`** — `MATCH_MOMENT_TYPES`, `MatchMomentType`, `MatchMoment` (with optional `trace: InferenceTrace`), `validateMatchMoment()` — cosmos3-originated moments require `clipUrl` or `keyframeUrls`; `confidence` bounded 0–1
- **`src/operator-config.ts`** — optional `inference.roles.<role>` block on `OperatorJobConfig`, validated by delegation; missing role config fails explicitly at invoke time
- **`scripts/bench-moment-to-air.mjs`** (`npm run bench:moment-to-air`) — moment-to-air benchmark emitting `eyes_ms/brain_ms/hands_ms/voice_ms/publish_ms/total_ms` JSON with role/model/locality/accelerator metadata; mock route by default (CI-safe), `BENCH_ROUTE=nim|openshell` for real endpoints; no secrets or endpoint values printed

## Test plan

- [x] TDD throughout — every suite watched fail before implementation
- [x] `test/inference-contracts.test.mjs` — 24/24 (valid/invalid ModelRole, envelope, trace)
- [x] `test/model-role-router.test.mjs` — 16/16 (config validation, mock invoke, explicit missing-role and route errors; no network calls)
- [x] `test/tv-contracts.test.mjs` — 35/35 (incl. valid/invalid MatchMoment)
- [x] `test/operator-config.test.mjs` — 55/55 (incl. `inference` block)
- [x] Full suite: **613/613 pass**, `tsc` clean, `test/ci-smoke.mjs` passes
- [x] `node scripts/bench-moment-to-air.mjs` produces the spec's JSON shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)