### PR TITLE
feat(picker): add Gemini 3.5 Flash as Google default

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,12 +84,16 @@ export const PROVIDER_MODEL_PROFILES: Record<LLMProvider, ProviderModelProfile> 
     ],
   },
   google: {
-    defaultModel: "gemini-3-flash-preview",
+    defaultModel: "gemini-3.5-flash",
     selectableModels: [
+      {
+        value: "gemini-3.5-flash",
+        label: "Gemini 3.5 Flash",
+        hint: "recommended",
+      },
       {
         value: "gemini-3-flash-preview",
         label: "Gemini 3 Flash",
-        hint: "recommended",
       },
       {
         value: "gemini-3-pro-preview",


### PR DESCRIPTION
## What

Adds **`gemini-3.5-flash`** to the Google model picker (`PROVIDER_MODEL_PROFILES.google`) and makes it the default.

## Changes
- `defaultModel` → `gemini-3.5-flash`
- New first selectable entry: **Gemini 3.5 Flash** (`gemini-3.5-flash`), hint `recommended`
- Dropped the now-duplicate `recommended` hint from the prior **Gemini 3 Flash** (`gemini-3-flash-preview`) entry, which remains selectable

## Notes
- Model ID is `gemini-3.5-flash` (no `-preview` suffix) per request — passed verbatim to the Google provider.
- `tsc --noEmit` passes. No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)