### PR TITLE
feat(openshell): run nemotron-3-super-120b brain with reasoning ON

### DIFF
--- a/openshell/policy.yaml
+++ b/openshell/policy.yaml
@@ -97,3 +97,14 @@ network_policies:
     binaries:
       - path: /opt/venv/bin/python3
       - path: /usr/bin/python3.11
+
+  overlay_feed:
+    name: overlay-feed
+    endpoints:
+      - host: 172.17.0.1
+        port: 8090
+        protocol: rest
+        enforcement: enforce
+        access: full
+    binaries:
+      - path: /usr/local/bin/node

--- a/src/llm-providers.ts
+++ b/src/llm-providers.ts
@@ -47,25 +47,32 @@ import type { LLMProvider } from "./types.js";
  * Gated on model name so non-Nemotron OpenAI-compat targets aren't
  * affected.
  */
+/** Remove <think>…</think> reasoning (closed + unclosed) so it never leaks into parsed content. */
+function stripThink(s: string): string {
+  return s
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    .replace(/<think>[\s\S]*$/i, "")
+    .trim();
+}
+
 function nimNemotronFetch(): typeof fetch {
   return async (input, init) => {
+    let thinkingOn = false;
     if (init?.body && typeof init.body === "string") {
       try {
         const parsed = JSON.parse(init.body) as Record<string, unknown>;
         const model = typeof parsed.model === "string" ? parsed.model : "";
         if (model.startsWith("nvidia/")) {
-          // Chat template flag for Nemotron-3 family (Nano, Super-3, etc.).
-          // Llama-3.3-Nemotron-Super-49B-v1.5 ignores this — harmless when ignored.
-          parsed.chat_template_kwargs = { enable_thinking: false };
-          // /no_think system directive: only inject for Nemotron-3-Nano family,
-          // which dumps `<think>...</think>` blocks into `content` instead of
-          // the `reasoning` field, breaking JSON-mode outputs.
-          //
-          // Llama-3.3-Nemotron-Super-49B-v1.5 is deliberately allowed to think:
-          // its tool-calling reliability drops sharply without deliberation,
-          // and the custom llama_nemotron_json parser correctly extracts tool
-          // calls even when thinking is on.
-          const needsNoThink = model.includes("nemotron-3-nano") || model.includes("nemotron-3-super-120b");
+          // Reasoning ON for the brain (nemotron-3-super-120b) so it can
+          // orchestrate the scene + author the commentary; OFF for other nvidia
+          // models. We strip the resulting <think> from the RESPONSE below so it
+          // never reaches the structured-output / tool-call parser.
+          thinkingOn = model.includes("nemotron-3-super-120b");
+          parsed.chat_template_kwargs = { enable_thinking: thinkingOn };
+          // /no_think still suppresses thinking for Nemotron-3-Nano (it dumps
+          // <think> into content and breaks JSON-mode). Super-120b is now allowed
+          // to think (response-side strip handles the leakage).
+          const needsNoThink = model.includes("nemotron-3-nano");
           if (needsNoThink && Array.isArray(parsed.messages)) {
             const messages = parsed.messages as Array<Record<string, unknown>>;
             const firstSystemIdx = messages.findIndex((m) => m?.role === "system");
@@ -86,7 +93,37 @@ function nimNemotronFetch(): typeof fetch {
         // body not JSON — leave alone
       }
     }
-    return fetch(input, init);
+    const res = await fetch(input, init);
+    // Strip <think> from the (non-streaming) JSON response so reasoning never
+    // reaches the tool-call/JSON parser. Best-effort: pass through on any issue.
+    if (thinkingOn && res.ok) {
+      try {
+        const ct = res.headers.get("content-type") || "";
+        if (ct.includes("application/json")) {
+          const data = (await res.clone().json()) as {
+            choices?: Array<{ message?: { content?: unknown } }>;
+          };
+          let changed = false;
+          for (const ch of data?.choices ?? []) {
+            const m = ch?.message;
+            if (m && typeof m.content === "string" && m.content.includes("<think>")) {
+              m.content = stripThink(m.content);
+              changed = true;
+            }
+          }
+          if (changed) {
+            return new Response(JSON.stringify(data), {
+              status: res.status,
+              statusText: res.statusText,
+              headers: { "content-type": "application/json" },
+            });
+          }
+        }
+      } catch {
+        // streaming or unparseable — leave the original response untouched
+      }
+    }
+    return res;
   };
 }
 

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -322,11 +322,19 @@ const DEFAULT_TICK_PROMPT = [
 // this to 8192, giving reasoning enough headroom to commit a final answer
 // before running out.
 const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+// Structured-output ticks now run with reasoning ON (nemotron-3-super-120b):
+// CoT + multi-step tool calls + the final submit_broadcast JSON share one
+// completion budget, so give it generous headroom to avoid mid-reasoning stalls.
+const STRUCTURED_MAX_OUTPUT_TOKENS = 16384;
 // Trimmed 16 → 10 after seeing ticks spend 7-8 tool calls + still time out.
 // Capping steps forces the model to commit to a synthesis sooner; the
 // remaining headroom is healthy.
 const DEFAULT_MAX_STEPS = 10;
-const DEFAULT_INFERENCE_TIMEOUT_MS = 60_000;
+// Raised 60s → 240s: nemotron-3-super-120b runs with reasoning ON now, so a
+// tick (CoT + multi-step tool calls + final submit_broadcast) legitimately
+// takes longer than the old non-thinking 60s ceiling. Generous so reasoning
+// ticks complete; pair with a longer intervalMs so ticks don't overlap.
+const DEFAULT_INFERENCE_TIMEOUT_MS = 240_000;
 const DEFAULT_RECENT_BRIEF_LIMIT = 1;
 
 // ---------------------------------------------------------------------------
@@ -508,7 +516,7 @@ export function createOperatorDaemon(
         maxOutputTokens:
           cfg.maxOutputTokens ??
           (useStructuredOutput
-            ? DEFAULT_MAX_OUTPUT_TOKENS * 2
+            ? STRUCTURED_MAX_OUTPUT_TOKENS
             : DEFAULT_MAX_OUTPUT_TOKENS),
         // Allow the model multiple steps so it can call tools and THEN
         // produce a final synthesis text. Without stopWhen, generateText

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -859,7 +859,7 @@ describe("tickOnce — structured output", () => {
     assert.match(gen.calls[0].system, /\[SILENT\] sentinel/);
   });
 
-  it("doubles maxOutputTokens default (4096 → 8192) when outputSchema is set", async () => {
+  it("raises maxOutputTokens default (4096 → 16384) when outputSchema is set", async () => {
     const gen = makeGenWithResult(
       outputToolResult({ silent: false, narrative: "x" }),
     );
@@ -870,7 +870,7 @@ describe("tickOnce — structured output", () => {
       }),
     );
     await daemon.tickOnce();
-    assert.strictEqual(gen.calls[0].maxOutputTokens, 8192);
+    assert.strictEqual(gen.calls[0].maxOutputTokens, 16384);
   });
 
   it("respects explicit cfg.maxOutputTokens override even with outputSchema", async () => {


### PR DESCRIPTION
## What

Runs the brain (`nemotron-3-super-120b`) with **reasoning ON**, reversing the `/no_think` decision from #77. Three coordinated changes:

### `src/llm-providers.ts`
- `enable_thinking` is now ON **only** for `nemotron-3-super-120b` (other `nvidia/` models unchanged; Nano keeps `/no_think`).
- New `stripThink()` removes `<think>…</think>` (closed + unclosed) from the non-streaming JSON response so reasoning never reaches the structured-output / tool-call parser. Best-effort — passes the original response through on streaming/unparseable bodies.

### `src/operator-daemon.ts`
- Structured-output ticks: max output tokens `8192 → 16384`, inference timeout `60s → 240s`. A reasoning tick (CoT + multi-step tool calls + final `submit_broadcast`) shares one completion budget and legitimately takes longer than the old non-thinking ceiling. Pair with a longer `intervalMs` so ticks don't overlap.

### `openshell/policy.yaml`
- New `overlay_feed` egress: node → `172.17.0.1:8090`. This is the **Linux docker0 bridge gateway** equivalent of the existing `tail_server` (`host.docker.internal:8090`) rule, so the sink/overlay feed is reachable on Linux GPU hosts (Brev/Verda/AWS) where `host.docker.internal` doesn't resolve. Additive, not a duplicate.

## Notes
- Robust to the OpenShell router stripping `chat_template_kwargs` (the concern raised in #77): the response-side `stripThink()` cleans `<think>` leakage regardless of whether the thinking toggle actually reaches the NIM.
- `tsc --noEmit` passes. No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)