### PR TITLE
docs: add CLAUDE.md developer guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md - sportsclaw Guidelines
+
+## Tech Stack
+- Runtime: Node.js / TypeScript / ESM
+- Package Manager: npm (do not use pnpm or bun here)
+- Formatting & Linting: Biome/Prettier for TS, Ruff for Python helpers
+- Data Access: sports-skills (Python backend bindings)
+
+## Build, Test & Lint Commands
+- Install Dependencies: `npm install`
+- Compile TS: `npm run build`
+- Run Linter: `npm run lint`
+- Run Tests: `npm test`
+- Execute CLI locally: `node dist/index.js <command>` or `npm run cli -- <command>`
+
+## Code Conventions
+- Files: kebab-case.ts
+- Variables/Functions: camelCase
+- Types/Classes: PascalCase
+- Imports: Always use explicit `.js` extensions for local module imports (ESM requirement)
+- Async/Await: Avoid raw promises or nested .then() blocks; use try/catch surgically.
+- No Invented Feeds: Never assume a sport or API feed exists unless verified in sports-skills.


### PR DESCRIPTION
Adds standard developer conventions and tech-stack guidelines for Claude Code and AI coding assistants. This establishes repo-specific context for local compilation, linting, and multi-tenant constraints.