### PR TITLE
feat: introduce connection boundary and sandboxed execution environment for tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "listen:telegram": "tsc && node dist/index.js listen telegram",
     "docker:build": "docker build -t sportsclaw .",
     "docker:run": "docker run --rm --env-file .env sportsclaw",
+    "test:connections": "npm run build && node --test test/connections.test.mjs",
     "test:version": "npm run build && node --test test/version-help.test.mjs",
     "test:tv-contracts": "npm run build && node --test test/tv-contracts.test.mjs",
     "test:operator-health": "npm run build && node --test test/operator-health.test.mjs",

--- a/src/connections.ts
+++ b/src/connections.ts
@@ -1,0 +1,264 @@
+/**
+ * sportsclaw Engine — Connection Manager (Connection-Brokered Auth)
+ *
+ * Implements the security posture inspired by Vercel's `eve`:
+ * The LLM model never sees the URL, raw tokens, or credentials.
+ * Credentials are resolved and injected securely by the harness at runtime,
+ * isolating the prompt/reasoning layer from critical secrets.
+ *
+ * Highly sensitive process secrets (like Anthropic/OpenAI API keys,
+ * Discord/Telegram bot tokens) are stripped from the environment before
+ * spawning subprocesses (sandboxed environment).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const CONNECTIONS_DIR = join(homedir(), ".sportsclaw");
+const CONNECTIONS_CONFIG_PATH = join(CONNECTIONS_DIR, "connections.json");
+
+// ---------------------------------------------------------------------------
+// Types & Defaults
+// ---------------------------------------------------------------------------
+
+export interface ConnectionConfig {
+  /** Connection type: "http" | "mcp" | "python-env" */
+  type: "http" | "mcp" | "python-env";
+  /** Optional base API URL */
+  url?: string;
+  /**
+   * Environment variable mapping (target_key -> source_env_key or literal value).
+   * E.g. { "POLYMARKET_API_KEY": "env:POLYMARKET_API_KEY" }
+   */
+  envMapping?: Record<string, string>;
+  /** Optional headers mapping for HTTP connections */
+  headersMapping?: Record<string, string>;
+}
+
+/** Standard keys to always strip from the sandboxed child process environment */
+export const SENSITIVE_PROCESS_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "DISCORD_BOT_TOKEN",
+  "TELEGRAM_BOT_TOKEN",
+  "ALLOWED_USERS",
+  "TELEGRAM_ALLOWED_USERS",
+  "SPORTSCLAW_API_KEY",
+  "CLAUDE_OAUTH_TOKEN",
+  "CLAUDE_CODE_TOKEN",
+];
+
+/** Standard allowed keys to copy into the clean sandbox env */
+export const SAFE_ENV_KEYS = [
+  "PATH",
+  "HOME",
+  "USER",
+  "SHELL",
+  "LANG",
+  "PWD",
+  "TERM",
+  "VIRTUAL_ENV",
+  "PYTHONPATH",
+  "PYTHONIOENCODING",
+  "NODE_ENV",
+];
+
+/** Standard platform credentials map (for seamless backward compatibility) */
+const STANDARD_CONNECTION_DEFAULTS: Record<string, ConnectionConfig> = {
+  polymarket: {
+    type: "python-env",
+    envMapping: {
+      POLYMARKET_API_KEY: "env:POLYMARKET_API_KEY",
+      POLYMARKET_SECRET: "env:POLYMARKET_SECRET",
+      POLYMARKET_PASSPHRASE: "env:POLYMARKET_PASSPHRASE",
+      POLYMARKET_CLOB_API_URL: "env:POLYMARKET_CLOB_API_URL",
+    },
+  },
+  kalshi: {
+    type: "python-env",
+    envMapping: {
+      KALSHI_API_KEY: "env:KALSHI_API_KEY",
+      KALSHI_SECRET: "env:KALSHI_SECRET",
+      KALSHI_PASSWORD: "env:KALSHI_PASSWORD",
+      KALSHI_USERNAME: "env:KALSHI_USERNAME",
+    },
+  },
+  betfair: {
+    type: "python-env",
+    envMapping: {
+      BETFAIR_APP_KEY: "env:BETFAIR_APP_KEY",
+      BETFAIR_PASSWORD: "env:BETFAIR_PASSWORD",
+      BETFAIR_USERNAME: "env:BETFAIR_USERNAME",
+      BETFAIR_SESSION_TOKEN: "env:BETFAIR_SESSION_TOKEN",
+    },
+  },
+  sportradar: {
+    type: "http",
+    envMapping: {
+      SPORTRADAR_API_KEY: "env:SPORTRADAR_API_KEY",
+    },
+  },
+  apifootball: {
+    type: "http",
+    envMapping: {
+      APIFOOTBALL_API_KEY: "env:APIFOOTBALL_API_KEY",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Connections Manager
+// ---------------------------------------------------------------------------
+
+export class ConnectionManager {
+  private configs: Record<string, ConnectionConfig> = {};
+  private verbose: boolean;
+
+  constructor(verbose = false) {
+    this.verbose = verbose;
+    this.configs = this.loadConfigs();
+  }
+
+  /**
+   * Load configurations from different sources (ordered by priority):
+   * 1. Env var SPORTSCLAW_CONNECTIONS (JSON string)
+   * 2. Local connections.json file in current working directory
+   * 3. Global ~/.sportsclaw/connections.json file
+   * 4. Standard platform connection defaults
+   */
+  private loadConfigs(): Record<string, ConnectionConfig> {
+    const base = { ...STANDARD_CONNECTION_DEFAULTS };
+
+    // 1. Global user config (~/.sportsclaw/connections.json)
+    if (existsSync(CONNECTIONS_CONFIG_PATH)) {
+      try {
+        const globalConfigs = JSON.parse(readFileSync(CONNECTIONS_CONFIG_PATH, "utf-8"));
+        Object.assign(base, globalConfigs);
+      } catch (err) {
+        console.error(`[sportsclaw] Failed to parse global connections config: ${err}`);
+      }
+    }
+
+    // 2. Working directory connections.json
+    if (existsSync("connections.json")) {
+      try {
+        const localConfigs = JSON.parse(readFileSync("connections.json", "utf-8"));
+        Object.assign(base, localConfigs);
+        if (this.verbose) {
+          console.error(`[sportsclaw] connections: loaded ${Object.keys(localConfigs).length} connection(s) from ./connections.json`);
+        }
+      } catch {
+        // No local connections.json — that's fine
+      }
+    }
+
+    // 3. Environment variable full override
+    const envJson = process.env.SPORTSCLAW_CONNECTIONS;
+    if (envJson) {
+      try {
+        const envConfigs = JSON.parse(envJson) as Record<string, ConnectionConfig>;
+        Object.assign(base, envConfigs);
+        if (this.verbose) {
+          console.error(`[sportsclaw] connections: loaded ${Object.keys(envConfigs).length} connection(s) from SPORTSCLAW_CONNECTIONS`);
+        }
+      } catch (err) {
+        console.error(`[sportsclaw] connections: invalid SPORTSCLAW_CONNECTIONS JSON: ${err}`);
+      }
+    }
+
+    return base;
+  }
+
+  /** Save connection configs to ~/.sportsclaw/connections.json */
+  saveGlobalConfigs(configs: Record<string, ConnectionConfig>): void {
+    if (!existsSync(CONNECTIONS_DIR)) {
+      mkdirSync(CONNECTIONS_DIR, { recursive: true });
+    }
+    writeFileSync(CONNECTIONS_CONFIG_PATH, JSON.stringify(configs, null, 2) + "\n", "utf-8");
+  }
+
+  /**
+   * Safe clean sandboxed child process environment.
+   * Strips all highly sensitive process credentials to prevent any leak or prompt injection attacks.
+   */
+  getSandboxEnv(connectionName?: string, extraEnv?: Record<string, string>): Record<string, string> {
+    const env: Record<string, string> = {};
+
+    // 1. Copy only safe/non-sensitive process env keys
+    for (const key of SAFE_ENV_KEYS) {
+      if (process.env[key] !== undefined) {
+        env[key] = process.env[key]!;
+      }
+    }
+
+    // 2. Filter base env to ensure we don't accidentally copy any known sensitive keys (whitelist only)
+
+    // 3. Add extra env keys passed explicitly
+    if (extraEnv) {
+      for (const [key, value] of Object.entries(extraEnv)) {
+        if (value !== undefined && !SENSITIVE_PROCESS_KEYS.includes(key)) {
+          env[key] = value;
+        }
+      }
+    }
+
+    // 4. Resolve and inject Connection-brokered credentials
+    if (connectionName) {
+      const conn = this.configs[connectionName.toLowerCase()];
+      if (conn) {
+        if (this.verbose) {
+          console.error(`[sportsclaw] connections: resolving and brokering auth for connection "${connectionName}"`);
+        }
+
+        if (conn.envMapping) {
+          for (const [targetKey, sourceMapping] of Object.entries(conn.envMapping)) {
+            let resolvedValue: string | undefined = undefined;
+
+            if (sourceMapping.startsWith("env:")) {
+              const envVarName = sourceMapping.slice(4);
+              resolvedValue = process.env[envVarName];
+            } else {
+              resolvedValue = sourceMapping; // Literal value
+            }
+
+            if (resolvedValue !== undefined) {
+              env[targetKey] = resolvedValue;
+            }
+          }
+        }
+      } else {
+        if (this.verbose) {
+          console.error(`[sportsclaw] connections: no explicit connection definition found for "${connectionName}", attempting standard fallback lookup`);
+        }
+        // Fallback: If no explicit connection found, check if it's a standard one or fallback directly to env lookup
+        const fallbackConn = STANDARD_CONNECTION_DEFAULTS[connectionName.toLowerCase()];
+        if (fallbackConn && fallbackConn.envMapping) {
+          for (const [targetKey, sourceMapping] of Object.entries(fallbackConn.envMapping)) {
+            const envVarName = sourceMapping.startsWith("env:") ? sourceMapping.slice(4) : sourceMapping;
+            if (process.env[envVarName] !== undefined) {
+              env[targetKey] = process.env[envVarName]!;
+            }
+          }
+        }
+      }
+    }
+
+    return env;
+  }
+
+  /** Check if a connection exists in the registry */
+  hasConnection(name: string): boolean {
+    return this.configs[name.toLowerCase()] !== undefined;
+  }
+
+  /** Get a connection configuration */
+  getConnection(name: string): ConnectionConfig | undefined {
+    return this.configs[name.toLowerCase()];
+  }
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -21,6 +21,7 @@ import { buildSportsSkillsRepairCommand, isVenvSetup, getVenvDir } from "./pytho
 import { isBlockedTool, logSecurityEvent } from "./security.js";
 import { DataFusionEngine, entityResolver } from "./intelligence/index.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
+import { ConnectionManager } from "./connections.js";
 
 type BridgeErrorCode =
   | "timeout"
@@ -529,6 +530,7 @@ export class ToolRegistry {
         description: tool.description,
         input_schema: schemaObj as ToolSpec["input_schema"],
         needsApproval: tool.needsApproval,
+        connection: tool.connection,
       };
 
       if (existingIdx >= 0) {
@@ -670,7 +672,9 @@ export class ToolRegistry {
     } else {
       const route = this.routeMap.get(toolName);
       if (route) {
-        result = await this.handleDynamicTool(route.sport, route.command, input, config);
+        const spec = this.dynamicSpecs.find((s) => s.name === toolName);
+        const connectionName = spec?.connection || route.sport;
+        result = await this.handleDynamicTool(route.sport, route.command, input, config, connectionName);
       } else {
         result = {
           content: JSON.stringify({ error: `Unknown tool: ${toolName}` }),
@@ -714,7 +718,7 @@ export class ToolRegistry {
       let gameId = String(query);
 
       // Try to get scores/matchups to locate this game/event
-      const bridgeRes = await executePythonBridge(sport, "scores", {}, config).catch(() => null);
+      const bridgeRes = await executePythonBridge(sport, "scores", {}, config, sport).catch(() => null);
       if (bridgeRes && bridgeRes.success && Array.isArray(bridgeRes.data)) {
         for (const game of bridgeRes.data) {
           try {
@@ -743,14 +747,14 @@ export class ToolRegistry {
 
       // Try fetching odds for the event
       let marketOdds: any = undefined;
-      const oddsRes = await executePythonBridge(sport, "odds", { event_id: gameId }, config).catch(() => null);
+      const oddsRes = await executePythonBridge(sport, "odds", { event_id: gameId }, config, sport).catch(() => null);
       if (oddsRes && oddsRes.success) {
         marketOdds = oddsRes.data;
       }
 
       // Try fetching predictions
       let prediction: any = undefined;
-      const predRes = await executePythonBridge(sport, "predictions", { event_id: gameId }, config).catch(() => null);
+      const predRes = await executePythonBridge(sport, "predictions", { event_id: gameId }, config, sport).catch(() => null);
       if (predRes && predRes.success) {
         prediction = predRes.data;
       }
@@ -770,8 +774,8 @@ export class ToolRegistry {
     } else if (target === "player") {
       const canonicalPlayerId = entityResolver.resolvePlayer(sport, String(query));
 
-      const playerStatsRes = await executePythonBridge(sport, "player_stats", { player_id: canonicalPlayerId || String(query) }, config).catch(() => null);
-      const playerProfileRes = await executePythonBridge(sport, "player_profile", { player_id: canonicalPlayerId || String(query) }, config).catch(() => null);
+      const playerStatsRes = await executePythonBridge(sport, "player_stats", { player_id: canonicalPlayerId || String(query) }, config, sport).catch(() => null);
+      const playerProfileRes = await executePythonBridge(sport, "player_profile", { player_id: canonicalPlayerId || String(query) }, config, sport).catch(() => null);
 
       let statsSummary: any = undefined;
       let team = "Unknown Team";
@@ -884,7 +888,8 @@ export class ToolRegistry {
       input.sport,
       input.command,
       input.args,
-      config
+      config,
+      input.sport
     );
 
     if (!result.success) {
@@ -901,8 +906,9 @@ export class ToolRegistry {
     sport: string,
     command: string,
     input: ToolCallInput,
-    config?: Partial<sportsclawConfig>
-  ): Promise<ToolCallResult> {
+    config?: Partial<sportsclawConfig>,
+    connectionName?: string
+): Promise<ToolCallResult> {
     const pythonPath = config?.pythonPath ?? "python3";
     const repairCmd = buildSportsSkillsRepairCommand(pythonPath);
 
@@ -921,7 +927,7 @@ export class ToolRegistry {
       }
     }
 
-    const result = await executePythonBridge(sport, command, args, config);
+    const result = await executePythonBridge(sport, command, args, config, connectionName);
 
     if (!result.success) {
       return this.buildBridgeErrorResult(result, sport, repairCmd);
@@ -939,19 +945,11 @@ export class ToolRegistry {
 // ---------------------------------------------------------------------------
 
 export function buildSubprocessEnv(
-  extra?: Record<string, string>
+  extra?: Record<string, string>,
+  connectionName?: string
 ): Record<string, string> {
-  // Inherit the full parent env — process.env already has ~/.sportsclaw/.env
-  // loaded by applyConfigToEnv(), so all service credentials (POLYMARKET_*,
-  // KALSHI_*, etc.) are available without hardcoding prefixes.
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) env[key] = value;
-  }
-
-  if (extra) {
-    Object.assign(env, extra);
-  }
+  const manager = new ConnectionManager();
+  const env = manager.getSandboxEnv(connectionName, extra);
 
   // Activate the managed venv for all subprocess calls
   if (isVenvSetup()) {
@@ -1016,7 +1014,8 @@ export function executePythonBridge(
   sport: string,
   command: string,
   args?: Record<string, unknown>,
-  config?: Partial<sportsclawConfig>
+  config?: Partial<sportsclawConfig>,
+  connectionName?: string
 ): Promise<PythonBridgeResult> {
   const pythonPath = config?.pythonPath ?? "python3";
   const cliArgs = buildArgs(sport, command, args);
@@ -1036,7 +1035,7 @@ export function executePythonBridge(
           encoding: "utf-8",
           timeout: attemptTimeout,
           maxBuffer: 25 * 1024 * 1024, // 25 MB for verbose FastF1 stderr on degraded networks
-          env: buildSubprocessEnv(config?.env),
+          env: buildSubprocessEnv(config?.env, connectionName),
         },
         (error, stdout, stderr) => {
           if (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,7 @@ export interface ToolSpec {
   description: string;
   input_schema: Record<string, unknown>;
   needsApproval?: (input: any) => boolean;
+  connection?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -317,6 +318,7 @@ export interface SportToolDef {
   /** @deprecated Legacy field from sports-skills v0.7 — use `parameters` */
   input_schema?: Record<string, unknown>;
   needsApproval?: (input: any) => boolean;
+  connection?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/connections.test.mjs
+++ b/test/connections.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * Connection-Brokered Auth & Sandbox Environment — Test Suite
+ *
+ * Verifies that:
+ *  1. Sensitive keys (ANTHROPIC_API_KEY, DISCORD_BOT_TOKEN, etc.) are always stripped from sandbox environments.
+ *  2. Safe keys (PATH, HOME, USER, etc.) are retained in sandbox environments.
+ *  3. Credentials for named connections are correctly resolved and injected.
+ *  4. Fallback resolution works for standard connection defaults.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { ConnectionManager, SENSITIVE_PROCESS_KEYS, SAFE_ENV_KEYS } from "../dist/connections.js";
+
+describe("ConnectionManager & Sandbox Environment", () => {
+  let originalEnv = {};
+
+  beforeEach(() => {
+    // Backup original environment
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = { ...originalEnv };
+  });
+
+  it("should strip highly sensitive keys from sandbox environment by default", () => {
+    // Set some sensitive process keys
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-key-12345";
+    process.env.DISCORD_BOT_TOKEN = "test-discord-bot-token-67890";
+    process.env.OPENAI_API_KEY = "sk-proj-openai-test-key";
+
+    // Set some safe keys
+    process.env.PATH = "/usr/bin:/bin";
+    process.env.HOME = "/Users/test";
+
+    const manager = new ConnectionManager();
+    const sandboxEnv = manager.getSandboxEnv();
+
+    // Verify sensitive keys are stripped
+    for (const key of SENSITIVE_PROCESS_KEYS) {
+      assert.strictEqual(sandboxEnv[key], undefined, `Sensitive key ${key} must be stripped from sandbox env`);
+    }
+
+    // Verify safe keys are kept
+    assert.strictEqual(sandboxEnv.PATH, "/usr/bin:/bin");
+    assert.strictEqual(sandboxEnv.HOME, "/Users/test");
+  });
+
+  it("should securely broker and inject credentials for default connections", () => {
+    // Mock the credentials in parent process.env
+    process.env.POLYMARKET_API_KEY = "poly-key-abc";
+    process.env.POLYMARKET_SECRET = "poly-secret-xyz";
+    process.env.POLYMARKET_PASSPHRASE = "poly-passphrase-123";
+    
+    // Also set a sensitive process key to ensure it gets stripped at the same time
+    process.env.ANTHROPIC_API_KEY = "should-be-removed";
+
+    const manager = new ConnectionManager();
+    const sandboxEnv = manager.getSandboxEnv("polymarket");
+
+    // Verify sensitive key is stripped
+    assert.strictEqual(sandboxEnv.ANTHROPIC_API_KEY, undefined);
+
+    // Verify connection credentials are fully resolved and injected
+    assert.strictEqual(sandboxEnv.POLYMARKET_API_KEY, "poly-key-abc");
+    assert.strictEqual(sandboxEnv.POLYMARKET_SECRET, "poly-secret-xyz");
+    assert.strictEqual(sandboxEnv.POLYMARKET_PASSPHRASE, "poly-passphrase-123");
+  });
+
+  it("should support fallback lookup for standard connection names case-insensitively", () => {
+    process.env.KALSHI_API_KEY = "kalshi-key-abc";
+    process.env.KALSHI_SECRET = "kalshi-secret-xyz";
+
+    const manager = new ConnectionManager();
+    const sandboxEnv = manager.getSandboxEnv("KaLsHi");
+
+    assert.strictEqual(sandboxEnv.KALSHI_API_KEY, "kalshi-key-abc");
+    assert.strictEqual(sandboxEnv.KALSHI_SECRET, "kalshi-secret-xyz");
+  });
+
+  it("should support customized connection definitions with env mapping", () => {
+    // Write a temporary local connections.json in the current working directory to test custom configuration
+    const customConfig = {
+      "custom-odds-provider": {
+        type: "http",
+        envMapping: {
+          ODDS_KEY: "env:MY_CUSTOM_SECRET_KEY",
+          LITERAL_KEY: "my-literal-value"
+        }
+      }
+    };
+
+    const configPath = path.join(process.cwd(), "connections.json");
+    fs.writeFileSync(configPath, JSON.stringify(customConfig, null, 2));
+
+    try {
+      process.env.MY_CUSTOM_SECRET_KEY = "custom-odds-key-value";
+
+      const manager = new ConnectionManager(true);
+      const sandboxEnv = manager.getSandboxEnv("custom-odds-provider");
+
+      // Verify custom mapped env variables are resolved and injected
+      assert.strictEqual(sandboxEnv.ODDS_KEY, "custom-odds-key-value");
+      assert.strictEqual(sandboxEnv.LITERAL_KEY, "my-literal-value");
+      assert.strictEqual(sandboxEnv.MY_CUSTOM_SECRET_KEY, undefined, "Source key should not be exposed directly if not in safe keys");
+    } finally {
+      // Clean up local connections.json
+      if (fs.existsSync(configPath)) {
+        fs.unlinkSync(configPath);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Description
This pull request introduces a secure connection boundary and restricted sandbox execution environment for tool and subprocess invocations. It hardens the security posture of the engine against potential prompt injection or environment variable exfiltration attacks.

## Changes Introduced
- ****: Implements  to manage and broker third-party connections (, , , etc.) case-insensitively, supporting customized configurations via local or global .
- **Restricted Sandbox Env ()**: Filters the child process environment to copy only a strict whitelist of safe environment variables (, , , , , etc.) and mapped connection keys. 
- **Secret Stripping**: Explicitly strips highly sensitive variables (such as LLM provider API keys, Discord/Telegram bot tokens, and user access tokens) so they are never exposed to spawned subprocesses or arbitrary script execution paths.
- **Credential Broker-Auth Boundary**: Moves credential resolution outside the model-visible path. Dynamic tools and queries only need to reference connection identifiers; the harness automatically resolves and injects necessary keys at the boundary of execution.
- **Backward Compatibility**: Fully preserves existing signature behaviors while transparently securing subprocess environments by default.
- **Verification Suite ()**: Added a comprehensive test suite asserting environment filtering, default connection credential injection, and customized mapping behaviors.