### PR TITLE
fix(approvals): restore actionable tool denial, remove dead-end halt (#85 regression)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -68,8 +68,6 @@ import { AskUserQuestionHalt } from "./ask.js";
 import {
   isActionPreApproved,
   ApprovalPendingHalt,
-  generateApprovalId,
-  saveApprovalRequest,
 } from "./approval.js";
 import { isGuideIntent, generateGuideResponse } from "./guide.js";
 import { recordTokens, tokensUsedToday } from "./token-ledger.js";
@@ -1035,23 +1033,19 @@ export class sportsclawEngine {
             throw new Error(skipReason);
           }
 
-          // Declarative tool-level approval check
+          // Declarative tool-level approval check.
+          // No interactive approval-resume UI is wired into the listeners, so a
+          // denial surfaces as an actionable, model-visible error (which the
+          // agent relays to the user) rather than an unrecoverable halt.
           if (!config.yoloMode && spec.needsApproval && spec.needsApproval(args)) {
             const platform = runPlatform ?? "cli";
             const userId = runUserId ?? "anonymous";
             const preApproved = await isActionPreApproved(platform, userId, spec.name as any);
             if (!preApproved) {
-              const request = {
-                id: generateApprovalId(),
-                action: spec.name as any,
-                description: `Execution of ${spec.name} with arguments: ${JSON.stringify(args)}`,
-                toolArgs: args,
-                platform,
-                userId,
-                createdAt: new Date().toISOString(),
-              };
-              await saveApprovalRequest(request);
-              throw new ApprovalPendingHalt(request);
+              throw new Error(
+                `${spec.name} denied: user approval required. Pass --yolo to bypass approval gates, ` +
+                `or pre-approve via /approve.`
+              );
             }
           }
 
@@ -2906,9 +2900,9 @@ export class sportsclawEngine {
 
     // -----------------------------------------------------------------
     // Agentic Tools — write_file and execute_command
-    // These tools require explicit user approval before execution.
-    // When invoked, they throw ApprovalPendingHalt to halt the engine
-    // loop and prompt the user for consent.
+    // These tools require explicit user consent before execution. Without
+    // --yolo or a pre-approval rule they deny with an actionable, model-visible
+    // error (the agent relays the remedy to the user).
     // -----------------------------------------------------------------
 
     const agenticPlatform = "cli"; // default; listeners override via RunOptions
@@ -2997,18 +2991,12 @@ export class sportsclawEngine {
           return executeWriteFile(filePath, fileContent);
         }
 
-        // Not approved and not YOLO: halt and suspend using ApprovalPendingHalt
-        const request = {
-          id: generateApprovalId(),
-          action: "write_file" as const,
-          description: `Write file to ${filePath} (${fileContent.length} bytes)`,
-          toolArgs: args,
-          platform: agenticPlatform,
-          userId: agenticUserId,
-          createdAt: new Date().toISOString(),
-        };
-        await saveApprovalRequest(request);
-        throw new ApprovalPendingHalt(request);
+        // Not approved and not YOLO: deny with an actionable, model-visible
+        // error (no stdin blocking, no dead-end halt).
+        throw new Error(
+          `write_file denied: user approval required. Pass --yolo to bypass approval gates, ` +
+          `or pre-approve via /approve. Target: ${filePath} (${fileContent.length} bytes)`
+        );
       },
     });
 
@@ -3110,18 +3098,12 @@ export class sportsclawEngine {
           return runCommand();
         }
 
-        // Not approved and not YOLO: halt and suspend using ApprovalPendingHalt
-        const request = {
-          id: generateApprovalId(),
-          action: "execute_command" as const,
-          description: `Execute command: ${cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd}`,
-          toolArgs: args,
-          platform: agenticPlatform,
-          userId: agenticUserId,
-          createdAt: new Date().toISOString(),
-        };
-        await saveApprovalRequest(request);
-        throw new ApprovalPendingHalt(request);
+        // Not approved and not YOLO: deny with an actionable, model-visible
+        // error (no stdin blocking, no dead-end halt).
+        throw new Error(
+          `execute_command denied: user approval required. Pass --yolo to bypass approval gates, ` +
+          `or pre-approve via /approve. Command: ${cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd}`
+        );
       },
     });
 

--- a/test/declarative-approval.test.mjs
+++ b/test/declarative-approval.test.mjs
@@ -1,11 +1,16 @@
 /**
  * Declarative Tool Approvals — test suite
  *
- * Verifies that:
- *  1. built-in write_file throws ApprovalPendingHalt when not pre-approved.
- *  2. built-in execute_command throws ApprovalPendingHalt when not pre-approved.
- *  3. Dynamic tools with a declarative needsApproval function throw ApprovalPendingHalt when triggered.
+ * There is no interactive approval-resume UI wired into any listener, so a
+ * denied gate must surface an actionable, model-visible error (which the agent
+ * relays to the user) rather than throwing ApprovalPendingHalt — an
+ * unrecoverable halt that no listener catches, which silently aborts the turn
+ * with a generic error. Verifies that:
+ *  1. built-in write_file returns an actionable denial when not pre-approved.
+ *  2. built-in execute_command returns an actionable denial when not pre-approved.
+ *  3. Dynamic tools with a declarative needsApproval function are denied (not halted) when triggered.
  *  4. Pre-approved rules allow execution to proceed.
+ *  5. The denial is never an ApprovalPendingHalt (no dead-end).
  */
 
 import assert from "node:assert/strict";
@@ -28,7 +33,7 @@ describe("Declarative & Built-in Tool Approvals", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("write_file and execute_command throw ApprovalPendingHalt when yoloMode is off and not pre-approved", async () => {
+  it("write_file and execute_command surface an actionable denial (not a dead-end halt) when yoloMode is off and not pre-approved", async () => {
     const engine = new sportsclawEngine({
       yoloMode: false,
       rootDir: tmpDir,
@@ -39,16 +44,19 @@ describe("Declarative & Built-in Tool Approvals", () => {
     // Test write_file
     const writeFileTool = tools["write_file"];
     assert.ok(writeFileTool, "write_file tool must exist");
+    const targetPath = path.join(tmpDir, "test.txt");
 
     try {
-      await writeFileTool.execute({ path: path.join(tmpDir, "test.txt"), content: "hello" });
-      assert.fail("write_file should have thrown ApprovalPendingHalt");
+      await writeFileTool.execute({ path: targetPath, content: "hello" });
+      assert.fail("write_file should have denied execution");
     } catch (err) {
-      assert.ok(err instanceof ApprovalPendingHalt, `expected ApprovalPendingHalt, got: ${err.name}`);
-      assert.strictEqual(err.request.action, "write_file");
-      assert.strictEqual(err.request.userId, "user_1");
-      assert.strictEqual(err.request.platform, "cli");
+      assert.ok(!(err instanceof ApprovalPendingHalt), "denial must not be an unrecoverable ApprovalPendingHalt");
+      assert.match(err.message, /write_file denied/);
+      assert.match(err.message, /approval required/i);
+      assert.match(err.message, /--yolo/);
     }
+    // The file must NOT have been written.
+    assert.ok(!fs.existsSync(targetPath), "write_file must not write when denied");
 
     // Test execute_command
     const execCmdTool = tools["execute_command"];
@@ -56,10 +64,12 @@ describe("Declarative & Built-in Tool Approvals", () => {
 
     try {
       await execCmdTool.execute({ command: "echo 'hello'" });
-      assert.fail("execute_command should have thrown ApprovalPendingHalt");
+      assert.fail("execute_command should have denied execution");
     } catch (err) {
-      assert.ok(err instanceof ApprovalPendingHalt, `expected ApprovalPendingHalt, got: ${err.name}`);
-      assert.strictEqual(err.request.action, "execute_command");
+      assert.ok(!(err instanceof ApprovalPendingHalt), "denial must not be an unrecoverable ApprovalPendingHalt");
+      assert.match(err.message, /execute_command denied/);
+      assert.match(err.message, /approval required/i);
+      assert.match(err.message, /--yolo/);
     }
   });
 
@@ -104,16 +114,15 @@ describe("Declarative & Built-in Tool Approvals", () => {
       assert.ok(!(err instanceof ApprovalPendingHalt), "should not require approval for amount <= 10");
     }
 
-    // 2. amount > 10 should trigger declarative approval check and throw ApprovalPendingHalt
+    // 2. amount > 10 should trigger the declarative approval check and be denied
+    //    with an actionable error — never a dead-end ApprovalPendingHalt.
     try {
       await betTool.execute({ amount: 15 });
       assert.fail("should have required approval for amount > 10");
     } catch (err) {
-      assert.ok(err instanceof ApprovalPendingHalt, "expected ApprovalPendingHalt");
-      assert.strictEqual(err.request.action, "high_risk_bet");
-      assert.strictEqual(err.request.userId, "user_2");
-      assert.strictEqual(err.request.platform, "cli");
-      assert.deepEqual(err.request.toolArgs, { amount: 15 });
+      assert.ok(!(err instanceof ApprovalPendingHalt), "denial must not be an unrecoverable ApprovalPendingHalt");
+      assert.match(err.message, /high_risk_bet denied/);
+      assert.match(err.message, /approval required/i);
     }
   });
 


### PR DESCRIPTION
## Problem

PR #85 converted `write_file`/`execute_command` denials — and the new dynamic `needsApproval` gate — to `throw new ApprovalPendingHalt(...)` to "pause the engine loop." But **no listener catches `ApprovalPendingHalt`** and **nothing calls `resolveApproval`**, so a denied tool falls through to the generic catch:

> Sorry, I encountered an error processing your request.

…and the user's turn is silently dropped. For `write_file`/`execute_command` this is a **regression**: pre-#85 they threw a descriptive `Error` the model relays to the user (`"...denied: user approval required. Pass --yolo... or pre-approve via /approve"`).

## Fix

No interactive approval-resume UI exists in any listener (Discord/Telegram/CLI) — building one is a separate feature (tracked in #91). So this restores **actionable, model-visible denials** at all three gate sites instead of the unrecoverable halt:

- **`write_file` / `execute_command`** — restore the prior `throw new Error(...)` denial text.
- **dynamic `needsApproval` gate** (new in #85, same dead-end flaw) — throw the same actionable error; preserves the block-unless-approved intent without the dead-end.
- Remove now-orphaned `generateApprovalId` / `saveApprovalRequest` imports and correct the stale header comment. `ApprovalPendingHalt` is **kept** (still referenced by `isHalt`) so a future PR can wire the real resume UI.

## Testing

- Rewrote `test/declarative-approval.test.mjs` to assert the corrected behavior (red → green).
- Confirmed **zero** `throw new ApprovalPendingHalt` remain in `src/`.
- `npm run build` clean · full suite **727/727 pass**.

## Out of scope (tracked separately)

- Interactive approval-resume UI (the actual approval feature) — the real follow-up.
- #87 durability: no migration of pre-upgrade on-disk state.
- #86 sandbox: credential starvation on `executePythonBridge` calls that pass no `connectionName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)