### PR TITLE
fix(durability): read pre-substrate state files instead of losing them (#92)

### DIFF
--- a/src/durability.ts
+++ b/src/durability.ts
@@ -105,7 +105,30 @@ export class DurableStateStore {
   }
 
   /**
+   * Detect a DurableStatePayload envelope. Pre-substrate files stored the bare
+   * domain object at the same path with no wrapper; the `namespace` field is the
+   * discriminator no legacy object carries (a legacy object that happens to have
+   * a `data` key still won't have a matching `namespace`).
+   */
+  private isEnvelope<T>(
+    parsed: unknown,
+    namespace: StateNamespace
+  ): parsed is DurableStatePayload<T> {
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { namespace?: unknown }).namespace === namespace &&
+      "data" in (parsed as object) &&
+      typeof (parsed as { createdAt?: unknown }).createdAt === "string"
+    );
+  }
+
+  /**
    * Load payload from disk. Auto-expires if TTL is exceeded.
+   *
+   * Backward-compatible: a pre-substrate file (the bare domain object, no
+   * envelope) is returned as the data itself rather than lost. Such files are
+   * upgraded to the envelope format naturally on the next save().
    */
   async load<T>(
     namespace: StateNamespace,
@@ -117,14 +140,19 @@ export class DurableStateStore {
 
     try {
       const raw = await readFile(path, "utf-8");
-      const payload = JSON.parse(raw) as DurableStatePayload<T>;
+      const parsed = JSON.parse(raw) as unknown;
 
-      if (payload.expiresAt && new Date(payload.expiresAt).getTime() < Date.now()) {
+      // Legacy pre-substrate file: the whole object IS the data.
+      if (!this.isEnvelope<T>(parsed, namespace)) {
+        return parsed as T;
+      }
+
+      if (parsed.expiresAt && new Date(parsed.expiresAt).getTime() < Date.now()) {
         await this.delete(namespace, id, opts);
         return null;
       }
 
-      return payload.data;
+      return parsed.data;
     } catch {
       return null;
     }

--- a/test/durability.test.mjs
+++ b/test/durability.test.mjs
@@ -87,7 +87,7 @@ describe("DurableStateStore Substrate", () => {
 
   it("should support safe deletions of payload data", async () => {
     await store.save("approvals", "req_1", { approved: false });
-    
+
     // Delete it
     const deleted = await store.delete("approvals", "req_1");
     assert.strictEqual(deleted, true);
@@ -99,5 +99,63 @@ describe("DurableStateStore Substrate", () => {
     // Deleting again should return false (already deleted)
     const deletedAgain = await store.delete("approvals", "req_1");
     assert.strictEqual(deletedAgain, false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Backward compatibility: pre-substrate files stored the bare domain object
+  // at the same path (no envelope wrapper). load() must read them as the data,
+  // not lose them by reading a non-existent `.data` field.
+  // ---------------------------------------------------------------------------
+
+  it("reads a legacy pre-substrate file (no envelope) as the data itself", async () => {
+    // Simulate a file written by the OLD SessionStore: a raw SessionEntry,
+    // not a DurableStatePayload envelope.
+    const legacy = {
+      messages: [{ role: "user", content: "hello" }],
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    };
+    const dir = path.join(tmpRootDir, "sessions");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "legacy_session.json"), JSON.stringify(legacy));
+
+    const loaded = await store.load("sessions", "legacy_session");
+    assert.deepEqual(loaded, legacy, "legacy file must be read as the data, not lost");
+  });
+
+  it("does not mistake a legacy object that happens to carry a `data` field for an envelope", async () => {
+    // A legacy payload may itself contain a `data` key; only the namespace
+    // discriminator distinguishes a real envelope.
+    const legacy = { data: { nested: true }, updatedAt: "2026-06-01T00:00:00.000Z" };
+    const dir = path.join(tmpRootDir, "tasks");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "legacy_task.json"), JSON.stringify(legacy));
+
+    const loaded = await store.load("tasks", "legacy_task");
+    assert.deepEqual(loaded, legacy, "legacy object must be returned whole, not unwrapped");
+  });
+
+  it("lists legacy and new-format entries together", async () => {
+    // New-format entry via the store
+    await store.save("tasks", "new_task", { id: "new_task", status: "active" });
+    // Legacy entry written directly
+    const dir = path.join(tmpRootDir, "tasks");
+    fs.writeFileSync(
+      path.join(dir, "old_task.json"),
+      JSON.stringify({ id: "old_task", status: "completed" })
+    );
+
+    const all = await store.list("tasks");
+    const byId = Object.fromEntries(all.map((e) => [e.id, e.data]));
+    assert.deepEqual(byId["new_task"], { id: "new_task", status: "active" });
+    assert.deepEqual(byId["old_task"], { id: "old_task", status: "completed" });
+  });
+
+  it("still round-trips and TTL-expires new-format envelopes after the compat change", async () => {
+    await store.save("sessions", "fresh", { messages: ["a"] });
+    assert.deepEqual(await store.load("sessions", "fresh"), { messages: ["a"] });
+
+    await store.save("memory", "ttl", { x: 1 }, { ttlMs: 5 });
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(await store.load("memory", "ttl"), null, "envelope TTL must still expire");
   });
 });


### PR DESCRIPTION
Closes #92.

## Problem

PR #87 changed every persisted namespace's on-disk shape from the bare domain object to a `DurableStatePayload` envelope `{id,namespace,data,createdAt,updatedAt,expiresAt}` — **while keeping the same file paths** and providing **no migration**. On upgrade, `load()` reads `payload.data` from a legacy file that has no `data` field → `undefined`, so existing state is silently lost:

- **Sessions** → conversation history reset to `[]`
- **Watcher tasks**, **pending approvals**, **suspended ask-user halts** → dropped

## Fix

Make `load()` backward-compatible. A pre-substrate file is the bare domain object with no wrapper; the envelope's `namespace` field is the discriminator no legacy object carries (even a legacy object that happens to have a `data` key won't have a matching `namespace`). When the parsed file isn't an envelope, return it as the data itself. Legacy files upgrade to the envelope format naturally on the next `save()`. New-format round-trip and TTL expiry are unchanged.

```ts
if (!this.isEnvelope<T>(parsed, namespace)) {
  return parsed as T;   // legacy bare object — the whole thing IS the data
}
```

The fix lives in the generic `load()`, so it covers every namespace (sessions/approvals/tasks/memory) and sub-paths uniformly.

## Testing

- Legacy bare-object read returns the data (not lost).
- Legacy object carrying a `data` key is **not** mistaken for an envelope.
- `list()` returns legacy + new-format entries together.
- New-format round-trip + TTL expiry regression guard.
- `npm run build` clean · full suite **731/731**.

## Notes / out of scope

- PR #87's description also claimed `memory.ts` (chat memory) was migrated to the substrate — it wasn't. But there's **no code artifact to correct**: the substrate docstring never claims it, and `memory.ts` stores markdown date-files (a fundamentally different format from JSON envelopes), so folding it into the substrate is a separate refactor, not part of this data-loss fix.
- Independent of #90 (approval regression); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)