### PR TITLE
fix(connections): prune dead broker mappings, fix Polymarket credential (#93)

### DIFF
--- a/src/connections.ts
+++ b/src/connections.ts
@@ -67,47 +67,24 @@ export const SAFE_ENV_KEYS = [
   "PYTHONPATH",
   "PYTHONIOENCODING",
   "NODE_ENV",
+  "XDG_CACHE_HOME", // sports_skills cricket cache dir (falls back to ~/.cache)
 ];
 
-/** Standard platform credentials map (for seamless backward compatibility) */
+/**
+ * Standard platform credentials map.
+ *
+ * Only providers whose credentials `sports_skills` actually reads belong here.
+ * Polymarket trading (`polymarket/_cli.py`) reads `POLYMARKET_PRIVATE_KEY`; its
+ * public read endpoints, Kalshi (public API), and the ESPN-backed sports need no
+ * credentials. Betfair/Sportradar/api-football have no integration in the data
+ * layer, so they are intentionally absent — a mapping here would only broker env
+ * vars nothing reads.
+ */
 const STANDARD_CONNECTION_DEFAULTS: Record<string, ConnectionConfig> = {
   polymarket: {
     type: "python-env",
     envMapping: {
-      POLYMARKET_API_KEY: "env:POLYMARKET_API_KEY",
-      POLYMARKET_SECRET: "env:POLYMARKET_SECRET",
-      POLYMARKET_PASSPHRASE: "env:POLYMARKET_PASSPHRASE",
-      POLYMARKET_CLOB_API_URL: "env:POLYMARKET_CLOB_API_URL",
-    },
-  },
-  kalshi: {
-    type: "python-env",
-    envMapping: {
-      KALSHI_API_KEY: "env:KALSHI_API_KEY",
-      KALSHI_SECRET: "env:KALSHI_SECRET",
-      KALSHI_PASSWORD: "env:KALSHI_PASSWORD",
-      KALSHI_USERNAME: "env:KALSHI_USERNAME",
-    },
-  },
-  betfair: {
-    type: "python-env",
-    envMapping: {
-      BETFAIR_APP_KEY: "env:BETFAIR_APP_KEY",
-      BETFAIR_PASSWORD: "env:BETFAIR_PASSWORD",
-      BETFAIR_USERNAME: "env:BETFAIR_USERNAME",
-      BETFAIR_SESSION_TOKEN: "env:BETFAIR_SESSION_TOKEN",
-    },
-  },
-  sportradar: {
-    type: "http",
-    envMapping: {
-      SPORTRADAR_API_KEY: "env:SPORTRADAR_API_KEY",
-    },
-  },
-  apifootball: {
-    type: "http",
-    envMapping: {
-      APIFOOTBALL_API_KEY: "env:APIFOOTBALL_API_KEY",
+      POLYMARKET_PRIVATE_KEY: "env:POLYMARKET_PRIVATE_KEY",
     },
   },
 };

--- a/test/connections.test.mjs
+++ b/test/connections.test.mjs
@@ -52,12 +52,11 @@ describe("ConnectionManager & Sandbox Environment", () => {
     assert.strictEqual(sandboxEnv.HOME, "/Users/test");
   });
 
-  it("should securely broker and inject credentials for default connections", () => {
-    // Mock the credentials in parent process.env
-    process.env.POLYMARKET_API_KEY = "poly-key-abc";
-    process.env.POLYMARKET_SECRET = "poly-secret-xyz";
-    process.env.POLYMARKET_PASSPHRASE = "poly-passphrase-123";
-    
+  it("should broker and inject the Polymarket private key the data layer actually reads", () => {
+    // sports_skills reads POLYMARKET_PRIVATE_KEY (polymarket/_cli.py) — not an
+    // api-key/secret/passphrase trio — so that is the credential we broker.
+    process.env.POLYMARKET_PRIVATE_KEY = "0xprivkey-abc";
+
     // Also set a sensitive process key to ensure it gets stripped at the same time
     process.env.ANTHROPIC_API_KEY = "should-be-removed";
 
@@ -67,21 +66,35 @@ describe("ConnectionManager & Sandbox Environment", () => {
     // Verify sensitive key is stripped
     assert.strictEqual(sandboxEnv.ANTHROPIC_API_KEY, undefined);
 
-    // Verify connection credentials are fully resolved and injected
-    assert.strictEqual(sandboxEnv.POLYMARKET_API_KEY, "poly-key-abc");
-    assert.strictEqual(sandboxEnv.POLYMARKET_SECRET, "poly-secret-xyz");
-    assert.strictEqual(sandboxEnv.POLYMARKET_PASSPHRASE, "poly-passphrase-123");
+    // Verify the brokered credential is resolved and injected
+    assert.strictEqual(sandboxEnv.POLYMARKET_PRIVATE_KEY, "0xprivkey-abc");
   });
 
-  it("should support fallback lookup for standard connection names case-insensitively", () => {
-    process.env.KALSHI_API_KEY = "kalshi-key-abc";
-    process.env.KALSHI_SECRET = "kalshi-secret-xyz";
+  it("should resolve standard connection names case-insensitively", () => {
+    process.env.POLYMARKET_PRIVATE_KEY = "0xprivkey-xyz";
 
     const manager = new ConnectionManager();
-    const sandboxEnv = manager.getSandboxEnv("KaLsHi");
+    const sandboxEnv = manager.getSandboxEnv("PoLyMaRkEt");
 
-    assert.strictEqual(sandboxEnv.KALSHI_API_KEY, "kalshi-key-abc");
-    assert.strictEqual(sandboxEnv.KALSHI_SECRET, "kalshi-secret-xyz");
+    assert.strictEqual(sandboxEnv.POLYMARKET_PRIVATE_KEY, "0xprivkey-xyz");
+  });
+
+  it("does not broker credentials for providers the data layer never reads", () => {
+    // kalshi (public API), betfair/sportradar/apifootball (no integration in
+    // sports_skills) were dead mappings — pruned. Brokering must inject nothing.
+    process.env.KALSHI_API_KEY = "k";
+    process.env.SPORTRADAR_API_KEY = "s";
+    process.env.APIFOOTBALL_API_KEY = "a";
+    process.env.BETFAIR_APP_KEY = "b";
+
+    const manager = new ConnectionManager();
+    for (const name of ["kalshi", "betfair", "sportradar", "apifootball"]) {
+      const env = manager.getSandboxEnv(name);
+      assert.strictEqual(env.KALSHI_API_KEY, undefined, `${name} must not inject KALSHI_API_KEY`);
+      assert.strictEqual(env.SPORTRADAR_API_KEY, undefined, `${name} must not inject SPORTRADAR_API_KEY`);
+      assert.strictEqual(env.APIFOOTBALL_API_KEY, undefined, `${name} must not inject APIFOOTBALL_API_KEY`);
+      assert.strictEqual(env.BETFAIR_APP_KEY, undefined, `${name} must not inject BETFAIR_APP_KEY`);
+    }
   });
 
   it("should support customized connection definitions with env mapping", () => {


### PR DESCRIPTION
Closes #93.

## Background

Triage of the #86 "credential starvation" concern (full findings on #93) showed it was **not a real regression** — every no-`connectionName` bridge path runs unauthenticated ESPN endpoints. What it *did* surface is that the brokered provider defaults diverge from what `sports_skills` actually reads. This PR cleans that up (cosmetic/latent; no behavior regression).

## Changes

- **Polymarket credential corrected** — the mapping brokered `POLYMARKET_API_KEY/SECRET/PASSPHRASE/CLOB_API_URL`, but `sports_skills` (`polymarket/_cli.py`) reads **`POLYMARKET_PRIVATE_KEY`**. The one real credential was never injected on any path; now the var the data layer reads is brokered.
- **Dead mappings pruned** — `kalshi` (public API, no auth), `betfair` / `sportradar` / `apifootball` (no integration exists in `sports_skills`). No `src/` code references them; they only brokered env vars nothing reads.
- **`XDG_CACHE_HOME` added to `SAFE_ENV_KEYS`** — lets the cricket on-disk cache honour a configured dir instead of always falling back to `~/.cache`.

## Why this is safe

The pruned providers' credentials were never consumed by the data layer, so removing them changes no behavior. ESPN-backed sports need no credentials. The allowlist-based secret-stripping (the actual security mechanism) is untouched.

## Testing

- Updated `connections.test.mjs`: brokered Polymarket key, case-insensitive resolution, and a guard that pruned providers inject nothing.
- `npm run build` clean · full suite **732/732**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)