### PR TITLE
fix(bridge): pass egress proxy + TLS CA env into the sandboxed tool subprocess

### DIFF
--- a/src/connections.ts
+++ b/src/connections.ts
@@ -68,6 +68,17 @@ export const SAFE_ENV_KEYS = [
   "PYTHONIOENCODING",
   "NODE_ENV",
   "XDG_CACHE_HOME", // sports_skills cricket cache dir (falls back to ~/.cache)
+  // Egress proxy + TLS CA bundle. In a network-isolated sandbox (e.g. OpenShell)
+  // ALL outbound traffic must go through the egress proxy, and the proxy MITMs
+  // TLS so the child needs its CA. Without these the sandboxed sports_skills
+  // child can't resolve DNS ("Temporary failure in name resolution") and every
+  // live data call fails. These are network/TLS config, not credentials — safe
+  // to pass through; harmless (unset) outside a sandbox. Both cases for tools
+  // (Python/urllib reads lowercase; some libs read uppercase).
+  "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "GRPC_PROXY",
+  "http_proxy", "https_proxy", "all_proxy", "no_proxy", "grpc_proxy",
+  "SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
+  "NODE_EXTRA_CA_CERTS",
 ];
 
 /**

--- a/test/connections.test.mjs
+++ b/test/connections.test.mjs
@@ -52,6 +52,28 @@ describe("ConnectionManager & Sandbox Environment", () => {
     assert.strictEqual(sandboxEnv.HOME, "/Users/test");
   });
 
+  it("passes the egress proxy + TLS CA env through to the sandbox (network-isolated deploys need it)", () => {
+    // In an OpenShell-style sandbox all outbound traffic must traverse the egress
+    // proxy, which MITMs TLS — without these the sandboxed sports_skills child
+    // fails DNS ("Temporary failure in name resolution") and every live call dies.
+    process.env.HTTPS_PROXY = "http://10.200.0.1:3128";
+    process.env.https_proxy = "http://10.200.0.1:3128";
+    process.env.NO_PROXY = "127.0.0.1,localhost";
+    process.env.SSL_CERT_FILE = "/etc/openshell-tls/ca-bundle.pem";
+    process.env.REQUESTS_CA_BUNDLE = "/etc/openshell-tls/ca-bundle.pem";
+    process.env.NODE_EXTRA_CA_CERTS = "/etc/openshell-tls/openshell-ca.pem";
+
+    const manager = new ConnectionManager();
+    const sandboxEnv = manager.getSandboxEnv();
+
+    assert.strictEqual(sandboxEnv.HTTPS_PROXY, "http://10.200.0.1:3128");
+    assert.strictEqual(sandboxEnv.https_proxy, "http://10.200.0.1:3128");
+    assert.strictEqual(sandboxEnv.NO_PROXY, "127.0.0.1,localhost");
+    assert.strictEqual(sandboxEnv.SSL_CERT_FILE, "/etc/openshell-tls/ca-bundle.pem");
+    assert.strictEqual(sandboxEnv.REQUESTS_CA_BUNDLE, "/etc/openshell-tls/ca-bundle.pem");
+    assert.strictEqual(sandboxEnv.NODE_EXTRA_CA_CERTS, "/etc/openshell-tls/openshell-ca.pem");
+  });
+
   it("should broker and inject the Polymarket private key the data layer actually reads", () => {
     // sports_skills reads POLYMARKET_PRIVATE_KEY (polymarket/_cli.py) — not an
     // api-key/secret/passphrase trio — so that is the credential we broker.


### PR DESCRIPTION
## Why

In a network-isolated sandbox (OpenShell), **every live data call from a brain-invoked `sports_skills` tool fails DNS**:

```
python3 -m sports_skills football get_daily_schedule --date=...
→ <urlopen error [Errno -3] Temporary failure in name resolution>
```

Root cause: PR #86's connection boundary (`getSandboxEnv`) copies only `SAFE_ENV_KEYS` into the child env and strips everything else — but that allowlist **omits the egress proxy and TLS CA vars**. In the sandbox all outbound traffic must traverse the egress proxy (which MITMs TLS and needs its CA), so with no proxy the child can't resolve any host.

Observed live on the World Cup TV channel: every tick the brain's `football_get_daily_schedule` retried ~10 leagues × 3 attempts → **~181s**, blowing the 240s inference watchdog and killing whole broadcasts. (The operator-sink's own `football.ts` works fine — it inherits the full, unsanitized env.)

## What

Add the proxy + CA keys to `SAFE_ENV_KEYS`:
`HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY/GRPC_PROXY` (+ lowercase), `SSL_CERT_FILE/SSL_CERT_DIR/REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE/NODE_EXTRA_CA_CERTS`.

These are **network/TLS configuration, not credentials** — safe to pass through, and harmless (unset) outside a sandbox. Adds a regression test asserting passthrough.

## Test
`node --test test/connections.test.mjs` → 6/6 pass (incl. new case). `tsc` clean.

## Notes
- The downstream TV channel also applied an interim ops mitigation (`SPORTSCLAW_SKILLS` allowlist dropping the generic `football` skill from the brain) to stop the dead-air immediately; this PR is the durable engine-side fix so all sandboxed tool calls work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)