### PR TITLE
feat(approval): interactive CLI approval prompt for agentic tools (#91)

### DIFF
--- a/docs/superpowers/specs/2026-06-19-cli-interactive-approval-design.md
+++ b/docs/superpowers/specs/2026-06-19-cli-interactive-approval-design.md
@@ -1,0 +1,161 @@
+# CLI Interactive Approval — Design
+
+**Date:** 2026-06-19
+**Issue:** #91
+**Scope:** CLI only (Discord/Telegram async UI explicitly deferred)
+
+## Problem
+
+The approval gate added in #85 throws `ApprovalPendingHalt` to "pause the engine
+loop," but no surface ever catches it or resumes — so denials dead-ended until
+PR #90 reverted them to actionable, model-visible errors. That restored correct
+behavior but left the gate non-interactive: an operator running an agentic tool
+(`write_file`, `execute_command`, or a dynamic tool with `needsApproval`) on the
+CLI cannot grant consent in the moment — their only options are `--yolo`
+(bypass everything) or pre-seeding a rule out of band.
+
+This adds an interactive approval prompt for the **CLI**, the surface where a
+human operator actually triggers these tools.
+
+## Approach
+
+A CLI can prompt **synchronously and inline** during tool execution — the way
+`sudo`, `git`, and `npm` do — rather than the async halt → render-UI → re-run
+dance the Discord/Telegram `AskUserQuestionHalt` flow uses. This is simpler and
+strictly more secure: the exact arguments shown in the prompt are the exact
+arguments that execute (no re-running the LLM, which could call the tool with
+different args than were approved).
+
+`ApprovalPendingHalt` and the persisted-request machinery from #85 remain in the
+codebase (the class is still referenced by `isHalt`) so a future PR can build
+the async Discord/Telegram UI on top. This change does not use them on the CLI
+path.
+
+## Architecture — one helper, three call sites
+
+A single `gateApproval()` in `src/approval.ts` centralizes the decision. The
+three gate sites in `src/engine.ts` (the dynamic `needsApproval` gate, the
+built-in `write_file`, and the built-in `execute_command`) each `await` it and
+then proceed to execute. Today those sites duplicate the pre-approval check and
+the denial throw; this folds them into one place.
+
+```
+gateApproval(action, description, platform, userId, { interactive, prompt? }):
+  if await isActionPreApproved(platform, userId, action)   -> return            // proceed
+  if interactive:
+     decision = await (prompt ?? promptApprovalDecision)(action, description)
+     allow-once   -> return                                                     // proceed
+     allow-always -> await addAllowAlwaysRule(platform, userId, action); return // proceed
+     deny         -> throw Error("<action> denied: user approval required ...")
+  else:                                                                         // non-TTY / non-cli
+     throw Error("<action> denied: user approval required. Pass --yolo ...")
+```
+
+`gateApproval` returns `void` on "proceed" and throws on denial. The thrown
+`Error` is a plain (non-halt) error, so the AI SDK surfaces it to the model as a
+tool-error result (same mechanism PR #90 restored).
+
+### `src/engine.ts` integration
+
+- Compute once in `buildTools`:
+  `const interactive = (runPlatform ?? "cli") === "cli" && !!process.stdin.isTTY;`
+- The existing `--yolo` branches (with their `YOLO_BLOCKED_PATHS` /
+  `YOLO_BLOCKED_COMMANDS` safety checks) are **untouched** — `gateApproval` is
+  only reached on the non-yolo path.
+- Each gate site becomes:
+  ```ts
+  // dynamic gate
+  if (!config.yoloMode && spec.needsApproval && spec.needsApproval(args)) {
+    await gateApproval(spec.name, `Execution of ${spec.name} with arguments: ${JSON.stringify(args)}`, platform, userId, { interactive });
+  }
+  // write_file (non-yolo branch)
+  await gateApproval("write_file", `Write file to ${filePath} (${fileContent.length} bytes)`, platform, userId, { interactive });
+  return executeWriteFile(filePath, fileContent);
+  // execute_command (non-yolo branch)
+  await gateApproval("execute_command", `Execute command: ${truncated}`, platform, userId, { interactive });
+  return runCommand();
+  ```
+- The direct `isActionPreApproved` calls at the gate sites are removed (folded
+  into `gateApproval`); the now-unused `isActionPreApproved` import in
+  `engine.ts` is dropped. `ApprovalPendingHalt` import stays (used by `isHalt`).
+
+## Components in `src/approval.ts`
+
+- `parseApprovalInput(line: string): ApprovalDecision` — **pure**. `o`/`once`
+  → `allow-once`; `a`/`always` → `allow-always`; everything else, including
+  empty, EOF, and unrecognized input → `deny` (fail-closed). Case-insensitive,
+  trims whitespace.
+- `promptApprovalDecision(action: string, description: string): Promise<ApprovalDecision>`
+  — thin `node:readline` shell. Writes the prompt to **stderr** (keeps stdout
+  clean for any structured output), reads one line, returns
+  `parseApprovalInput(line)`. Resolves to `deny` on stream error/close.
+- `gateApproval(action, description, platform, userId, opts?)` — the logic
+  above. `opts.interactive` (boolean) and `opts.prompt` (injectable decision
+  function, default `promptApprovalDecision`) exist so the engine supplies the
+  TTY determination and tests can inject a stub.
+- Widen `AgenticAction` from `"write_file" | "execute_command"` to `string`,
+  removing #85's `as any` casts and letting rulesets/prompts cover dynamic tool
+  names uniformly. `buildApprovalPrompt` keeps working (its `write_file` ternary
+  becomes a label fallback for arbitrary actions); it remains for the future
+  async path.
+
+### Prompt UX (stderr)
+
+```
+⚠  Approval required — execute_command
+   Execute command: pip install pandas
+   [o]nce  [a]lways  [d]eny  (default: deny) >
+```
+
+## Data flow
+
+```
+node dist/index.js "<query>"
+  -> cmdQuery -> engine.run -> generateText multi-step loop
+  -> tool.execute (gated tool)
+  -> gateApproval -> (interactive) readline prompt -> user types "a"
+  -> addAllowAlwaysRule -> execute -> result returns into the LLM loop -> response
+Subsequent runs: isActionPreApproved -> true -> no prompt.
+```
+
+## Error handling & safety
+
+- **Non-interactive (non-TTY)**: operator daemon, piped stdin, CI. `gateApproval`
+  never blocks; it throws the actionable denial. This is also why Discord and
+  Telegram are unaffected — they run non-TTY with `platform !== "cli"`, so they
+  keep the exact #90 behavior with no code change on their paths.
+- **EOF / empty / invalid input** → `deny` (fail-closed).
+- **`--yolo`** → bypasses approval entirely (unchanged).
+- **Stream errors in readline** → resolve to `deny`.
+
+## Testing
+
+- `parseApprovalInput` — pure unit tests for every accepted token (`o`, `once`,
+  `a`, `always`, mixed case, surrounding whitespace) and fail-closed defaults
+  (empty string, `x`, `yes`).
+- `gateApproval` with an injected `prompt` stub:
+  - `allow-once` → resolves (proceeds), no rule persisted.
+  - `allow-always` → resolves and `isActionPreApproved` is true afterward.
+  - `deny` → throws with `/<action> denied/`.
+  - `interactive: false` → throws (fail-closed) without invoking the prompt.
+  - pre-approved action → resolves without invoking the prompt.
+- Regression: existing `declarative-approval.test.mjs` runs under a non-TTY test
+  process, so its denial-throws assertions continue to hold — confirming the
+  fail-closed path is intact.
+
+## Files touched
+
+- `src/approval.ts` — add `parseApprovalInput`, `promptApprovalDecision`,
+  `gateApproval`; widen `AgenticAction`.
+- `src/engine.ts` — call `gateApproval` at the three gate sites; compute
+  `interactive`; drop the now-unused `isActionPreApproved` import.
+- `test/approval-interactive.test.mjs` — new suite (pure parser + injected-prompt
+  gate behavior).
+
+## Out of scope
+
+- Discord/Telegram interactive approval UI and the async halt/resume path.
+- Migrating chat memory (`memory.ts`) to the durability substrate.
+- The `platform='cli'` hardcode in the built-in agentic tools is resolved
+  incidentally (the gate now uses the real `runPlatform`), but no broader
+  per-platform approval-state work is in scope.

--- a/src/approval.ts
+++ b/src/approval.ts
@@ -23,8 +23,12 @@ import { DurableStateStore } from "./durability.js";
 // Types
 // ---------------------------------------------------------------------------
 
-/** The action classes that can be gated by approval. */
-export type AgenticAction = "write_file" | "execute_command";
+/**
+ * The action being gated by approval. The built-in agentic tools use
+ * "write_file" / "execute_command"; dynamic schema tools with a needsApproval
+ * predicate gate under their own tool name, so this is an open string.
+ */
+export type AgenticAction = string;
 
 /** User's decision for an approval request. */
 export type ApprovalDecision = "allow-once" | "allow-always" | "deny";
@@ -204,6 +208,94 @@ export async function resolveApproval(
     case "deny":
       return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// CLI interactive approval gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single line of CLI approval input into a decision. Fail-closed:
+ * anything that isn't an explicit allow maps to "deny".
+ */
+export function parseApprovalInput(line: string): ApprovalDecision {
+  const t = line.trim().toLowerCase();
+  if (t === "o" || t === "once") return "allow-once";
+  if (t === "a" || t === "always") return "allow-always";
+  return "deny";
+}
+
+/**
+ * Prompt the operator on an interactive terminal for an approval decision.
+ * The prompt is written to stderr to keep stdout clean for structured output.
+ * Resolves to "deny" on any stream error.
+ */
+export async function promptApprovalDecision(
+  action: string,
+  description: string
+): Promise<ApprovalDecision> {
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const banner =
+    `\n⚠  Approval required — ${action}\n` +
+    `   ${description}\n` +
+    `   [o]nce  [a]lways  [d]eny  (default: deny) > `;
+  try {
+    const answer = await new Promise<string>((resolve, reject) => {
+      rl.on("error", reject);
+      // EOF without a line (e.g. Ctrl-D, closed stdin) → empty → fail-closed deny.
+      rl.on("close", () => resolve(""));
+      rl.question(banner, resolve);
+    });
+    return parseApprovalInput(answer);
+  } catch {
+    return "deny";
+  } finally {
+    rl.close();
+  }
+}
+
+export interface GateApprovalOptions {
+  /** Whether an interactive terminal is available to prompt the operator. */
+  interactive: boolean;
+  /** Decision source; defaults to the readline prompt. Injectable for tests. */
+  prompt?: (action: string, description: string) => Promise<ApprovalDecision>;
+}
+
+/**
+ * Centralized approval gate for agentic actions. Returns when the action may
+ * proceed; throws an actionable, model-visible error when denied.
+ *
+ * - Pre-approved (allow-always rule) → proceed.
+ * - Interactive → prompt once/always/deny (always persists a rule).
+ * - Non-interactive → fail-closed denial (operator daemon, pipes, non-CLI).
+ */
+export async function gateApproval(
+  action: AgenticAction,
+  description: string,
+  platform: string,
+  userId: string,
+  opts: GateApprovalOptions
+): Promise<void> {
+  if (await isActionPreApproved(platform, userId, action)) return;
+
+  const deny = (): never => {
+    throw new Error(
+      `${action} denied: user approval required (${description}). ` +
+        `Pass --yolo to bypass approval gates, or pre-approve via /approve.`
+    );
+  };
+
+  if (!opts.interactive) deny();
+
+  const prompt = opts.prompt ?? promptApprovalDecision;
+  const decision = await prompt(action, description);
+  if (decision === "allow-once") return;
+  if (decision === "allow-always") {
+    await addAllowAlwaysRule(platform, userId, action);
+    return;
+  }
+  deny();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -66,7 +66,7 @@ import {
 } from "./analytics.js";
 import { AskUserQuestionHalt } from "./ask.js";
 import {
-  isActionPreApproved,
+  gateApproval,
   ApprovalPendingHalt,
 } from "./approval.js";
 import { isGuideIntent, generateGuideResponse } from "./guide.js";
@@ -1012,6 +1012,12 @@ export class sportsclawEngine {
     const registry = this.registry;
     const verbose = this.config.verbose;
 
+    // Interactive approval prompting is only safe on an interactive CLI terminal.
+    // Everywhere else (operator daemon, piped input, Discord/Telegram) the gate
+    // fails closed with an actionable denial.
+    const interactiveApproval =
+      (runPlatform ?? "cli") === "cli" && !!process.stdin.isTTY;
+
     for (const spec of registry.getAllToolSpecs()) {
       toolMap[spec.name] = defineTool({
         description: spec.description,
@@ -1033,20 +1039,17 @@ export class sportsclawEngine {
             throw new Error(skipReason);
           }
 
-          // Declarative tool-level approval check.
-          // No interactive approval-resume UI is wired into the listeners, so a
-          // denial surfaces as an actionable, model-visible error (which the
-          // agent relays to the user) rather than an unrecoverable halt.
+          // Declarative tool-level approval gate. Interactive CLI prompts the
+          // operator; everywhere else it fails closed with an actionable,
+          // model-visible denial.
           if (!config.yoloMode && spec.needsApproval && spec.needsApproval(args)) {
-            const platform = runPlatform ?? "cli";
-            const userId = runUserId ?? "anonymous";
-            const preApproved = await isActionPreApproved(platform, userId, spec.name as any);
-            if (!preApproved) {
-              throw new Error(
-                `${spec.name} denied: user approval required. Pass --yolo to bypass approval gates, ` +
-                `or pre-approve via /approve.`
-              );
-            }
+            await gateApproval(
+              spec.name,
+              `Execution of ${spec.name} with arguments: ${JSON.stringify(args)}`,
+              runPlatform ?? "cli",
+              runUserId ?? "anonymous",
+              { interactive: interactiveApproval }
+            );
           }
 
           if (verbose) {
@@ -2905,7 +2908,7 @@ export class sportsclawEngine {
     // error (the agent relays the remedy to the user).
     // -----------------------------------------------------------------
 
-    const agenticPlatform = "cli"; // default; listeners override via RunOptions
+    const agenticPlatform = runPlatform ?? "cli";
     const agenticUserId = runUserId ?? "anonymous";
 
     // Blocked path patterns for YOLO mode — prevent writes to sensitive locations
@@ -2981,22 +2984,16 @@ export class sportsclawEngine {
           return executeWriteFile(resolved, fileContent);
         }
 
-        // Check for allow-always rule
-        const preApproved = await isActionPreApproved(
+        // Not YOLO: gate on approval (interactive prompt on a CLI terminal,
+        // fail-closed denial otherwise), then execute.
+        await gateApproval(
+          "write_file",
+          `Write file to ${filePath} (${fileContent.length} bytes)`,
           agenticPlatform,
           agenticUserId,
-          "write_file"
+          { interactive: interactiveApproval }
         );
-        if (preApproved) {
-          return executeWriteFile(filePath, fileContent);
-        }
-
-        // Not approved and not YOLO: deny with an actionable, model-visible
-        // error (no stdin blocking, no dead-end halt).
-        throw new Error(
-          `write_file denied: user approval required. Pass --yolo to bypass approval gates, ` +
-          `or pre-approve via /approve. Target: ${filePath} (${fileContent.length} bytes)`
-        );
+        return executeWriteFile(filePath, fileContent);
       },
     });
 
@@ -3088,22 +3085,16 @@ export class sportsclawEngine {
           return runCommand();
         }
 
-        // Check for allow-always rule
-        const preApproved = await isActionPreApproved(
+        // Not YOLO: gate on approval (interactive prompt on a CLI terminal,
+        // fail-closed denial otherwise), then execute.
+        await gateApproval(
+          "execute_command",
+          `Execute command: ${cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd}`,
           agenticPlatform,
           agenticUserId,
-          "execute_command"
+          { interactive: interactiveApproval }
         );
-        if (preApproved) {
-          return runCommand();
-        }
-
-        // Not approved and not YOLO: deny with an actionable, model-visible
-        // error (no stdin blocking, no dead-end halt).
-        throw new Error(
-          `execute_command denied: user approval required. Pass --yolo to bypass approval gates, ` +
-          `or pre-approve via /approve. Command: ${cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd}`
-        );
+        return runCommand();
       },
     });
 

--- a/test/approval-interactive.test.mjs
+++ b/test/approval-interactive.test.mjs
@@ -1,0 +1,137 @@
+/**
+ * CLI Interactive Approval — test suite (#91)
+ *
+ * Covers the pure input parser and the centralized gateApproval() decision
+ * helper. The real readline shell (promptApprovalDecision) is a thin I/O layer
+ * exercised via an injected prompt stub here.
+ *
+ * HOME is redirected to a temp dir BEFORE importing the module so the durable
+ * approval ruleset writes stay hermetic (DurableStateStore roots at ~/.sportsclaw).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, after } from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "approval-home-"));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const { parseApprovalInput, gateApproval, isActionPreApproved } = await import(
+  "../dist/approval.js"
+);
+
+after(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("parseApprovalInput", () => {
+  it("parses allow-once tokens", () => {
+    for (const t of ["o", "once", "O", " once ", "Once"]) {
+      assert.strictEqual(parseApprovalInput(t), "allow-once", `"${t}"`);
+    }
+  });
+
+  it("parses allow-always tokens", () => {
+    for (const t of ["a", "always", "A", " always ", "Always"]) {
+      assert.strictEqual(parseApprovalInput(t), "allow-always", `"${t}"`);
+    }
+  });
+
+  it("treats explicit deny tokens as deny", () => {
+    for (const t of ["d", "deny", "D"]) {
+      assert.strictEqual(parseApprovalInput(t), "deny", `"${t}"`);
+    }
+  });
+
+  it("fails closed on empty / unrecognized input", () => {
+    for (const t of ["", "   ", "x", "yes", "y", "nope", "1"]) {
+      assert.strictEqual(parseApprovalInput(t), "deny", `"${t}"`);
+    }
+  });
+});
+
+describe("gateApproval", () => {
+  const platform = "cli";
+  let n = 0;
+  const freshUser = () => `gate_user_${Date.now()}_${n++}`;
+  const throwingPrompt = () => {
+    throw new Error("prompt must not be called");
+  };
+
+  it("proceeds without prompting when the action is pre-approved", async () => {
+    const userId = freshUser();
+    const { addAllowAlwaysRule } = await import("../dist/approval.js");
+    await addAllowAlwaysRule(platform, userId, "write_file");
+
+    // throwingPrompt asserts the prompt is never reached
+    await gateApproval("write_file", "desc", platform, userId, {
+      interactive: true,
+      prompt: throwingPrompt,
+    });
+  });
+
+  it("proceeds on allow-once without persisting a rule", async () => {
+    const userId = freshUser();
+    await gateApproval("execute_command", "run something", platform, userId, {
+      interactive: true,
+      prompt: async () => "allow-once",
+    });
+    assert.strictEqual(
+      await isActionPreApproved(platform, userId, "execute_command"),
+      false,
+      "allow-once must not persist a standing rule"
+    );
+  });
+
+  it("proceeds and persists a rule on allow-always", async () => {
+    const userId = freshUser();
+    await gateApproval("execute_command", "run something", platform, userId, {
+      interactive: true,
+      prompt: async () => "allow-always",
+    });
+    assert.strictEqual(
+      await isActionPreApproved(platform, userId, "execute_command"),
+      true,
+      "allow-always must persist a standing rule"
+    );
+  });
+
+  it("throws an actionable denial on deny", async () => {
+    const userId = freshUser();
+    await assert.rejects(
+      () =>
+        gateApproval("write_file", "desc", platform, userId, {
+          interactive: true,
+          prompt: async () => "deny",
+        }),
+      /write_file denied/
+    );
+  });
+
+  it("fails closed (throws, never prompts) when non-interactive", async () => {
+    const userId = freshUser();
+    await assert.rejects(
+      () =>
+        gateApproval("execute_command", "desc", platform, userId, {
+          interactive: false,
+          prompt: throwingPrompt,
+        }),
+      /execute_command denied/
+    );
+  });
+
+  it("supports dynamic (non-builtin) action names", async () => {
+    const userId = freshUser();
+    await gateApproval("high_risk_bet", "amount 15", platform, userId, {
+      interactive: true,
+      prompt: async () => "allow-always",
+    });
+    assert.strictEqual(
+      await isActionPreApproved(platform, userId, "high_risk_bet"),
+      true
+    );
+  });
+});


### PR DESCRIPTION
Implements #91 (CLI scope). Design doc: `docs/superpowers/specs/2026-06-19-cli-interactive-approval-design.md`.

## Problem

The #85 approval gate threw `ApprovalPendingHalt` with no resume path; #90 reverted denials to actionable, model-visible errors but left the gate **non-interactive** — an operator on the CLI couldn't grant consent in the moment, only `--yolo` (bypass all) or pre-seed a rule out of band.

## Approach (A from the design)

A CLI prompts **synchronously and inline** during tool execution — like `sudo`/`git`/`npm` — rather than the async halt → button → re-run dance Discord/Telegram use. Simpler and more secure: the exact args shown are the exact args that run (no LLM re-execution that could call the tool with different args than were approved).

## Changes

**`src/approval.ts`**
- `parseApprovalInput(line)` — pure, fail-closed: `o|once`→allow-once, `a|always`→allow-always, everything else (empty/EOF/garbage)→deny.
- `promptApprovalDecision(action, description)` — thin `node:readline` shell; prompts on **stderr** (keeps stdout clean), defaults to deny on EOF/stream error.
- `gateApproval(...)` — one helper: pre-approved → proceed; interactive → prompt (once/always/deny, "always" persists a rule); non-interactive → fail-closed denial.
- Widen `AgenticAction` to `string` (removes #85's `as any`; covers dynamic `needsApproval` tools uniformly).

**`src/engine.ts`**
- Route all three gate sites (dynamic gate, `write_file`, `execute_command`) through `gateApproval`, collapsing the duplicated pre-approval/throw logic.
- `interactive = (runPlatform ?? "cli") === "cli" && !!process.stdin.isTTY` — the single switch that keeps the operator daemon, piped input, and Discord/Telegram on the #90 fail-closed denial with **zero changes to their paths**.
- Built-in agentic tools now use the real `runPlatform` instead of a hardcoded `"cli"`.

## Safety / out of scope

- Non-TTY (daemon, pipes, CI) and non-CLI platforms never block — they throw the actionable denial. `--yolo` bypasses unchanged. EOF/invalid → deny.
- `ApprovalPendingHalt` stays in the tree (used by `isHalt`) for a future Discord/Telegram async-UI PR. Chat-memory migration remains out of scope.

## Testing (TDD)

- New `test/approval-interactive.test.mjs`: `parseApprovalInput` tokens + fail-closed defaults; `gateApproval` allow-once / allow-always / deny / non-interactive / pre-approved / dynamic-action via an injected prompt stub.
- Existing `declarative-approval.test.mjs` runs non-TTY, so its denial assertions still hold — confirms fail-closed didn't regress.
- The readline shell verified manually end-to-end (piped `once`/`always`/garbage/EOF → correct decisions).
- `npm run build` clean · full suite **742/742**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)