### PR TITLE
feat(guide): built-in guide for the Machina premium option

### DIFF
--- a/src/guide.ts
+++ b/src/guide.ts
@@ -21,6 +21,12 @@ import type { SportSchema } from "./types.js";
 // Intent detection — decides if the Guide should handle the query
 // ---------------------------------------------------------------------------
 
+// Premium / licensed-data upgrade intent. Deliberately tight so it never
+// matches "premier league" (no "premium") or incidental mentions like
+// "Machina Sports TV pod" (only `machina premium|cli|platform` qualifies).
+const PREMIUM_INTENT =
+  /\b(?:premium (?:data|tier|feeds?|plan|access)|licensed (?:data|feeds?)|real-?time (?:data|feeds?)|machina (?:premium|cli|platform)|how (?:do i|to) (?:upgrade|go premium))\b/i;
+
 const GUIDE_PATTERNS = [
   /^(?:help|getting started|tutorial)$/i,
   /\bhow (?:do|can|to) (?:i |you )?(?:use|start|get started|set ?up)\b/i,
@@ -29,6 +35,7 @@ const GUIDE_PATTERNS = [
   /\b(?:supported sports?|available sports?)\b/i,
   /\bhow does (?:this|sportsclaw) work\b/i,
   /^(?:list|show|what are) (?:your |the |all )?(?:commands|features|capabilities)\s*\??$/i,
+  PREMIUM_INTENT,
 ];
 
 /**
@@ -95,6 +102,9 @@ const FEATURE_MANIFESTO = `
 - **Config** — Change LLM provider, model, routing settings
 - **Agents** — Custom agent personas with specialized knowledge
 
+### Premium Data
+- **Machina** — Licensed, real-time, zero-latency feeds beyond the open data layer. Connect via \`machina-cli\` + \`sportsclaw mcp add\`; run \`sports-skills premium\` for details.
+
 ### Supported Sports
 US Pro: NFL, NBA, NHL, MLB, WNBA
 College: CFB (College Football), CBB (College Basketball)
@@ -120,6 +130,23 @@ News: Sports News via RSS & Google News
 export function generateGuideResponse(prompt: string): string {
   const lower = prompt.toLowerCase();
   const { installed, available } = getInstalledVsAvailable();
+
+  // premium / licensed-data upgrade
+  if (PREMIUM_INTENT.test(lower)) {
+    return [
+      "## Premium data via Machina",
+      "",
+      "Your built-in data comes from sports-skills — open and keyless, ideal for",
+      "development and personal use. For licensed, real-time, and zero-latency feeds,",
+      "Machina is the premium option.",
+      "",
+      "To connect:",
+      "1. Install the Machina CLI: `pip install machina-cli`, then `machina login`.",
+      "2. Connect Machina's data server to sportsclaw with `sportsclaw mcp add <url>`.",
+      "",
+      "Run `sports-skills premium` for the upgrade details, or see https://machina.gg.",
+    ].join("\n");
+  }
 
   // "what sports" / "supported sports" / "available sports"
   if (/\b(?:what sports|supported sports?|available sports?|what data do you)\b/i.test(lower)) {

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -25,7 +25,7 @@ import type { SportSchema } from "./types.js";
 // matches "premier league" (no "premium") or incidental mentions like
 // "Machina Sports TV pod" (only `machina premium|cli|platform` qualifies).
 const PREMIUM_INTENT =
-  /\b(?:premium (?:data|tier|feeds?|plan|access)|licensed (?:data|feeds?)|real-?time (?:data|feeds?)|machina (?:premium|cli|platform)|how (?:do i|to) (?:upgrade|go premium))\b/i;
+  /\b(?:premium (?:data|tier|feeds?|plan|access)|licensed (?:data|feeds?)|real[- ]?time (?:data|feeds?)|machina (?:premium|cli|platform)|how (?:do i|to) (?:upgrade|go premium))\b/i;
 
 const GUIDE_PATTERNS = [
   /^(?:help|getting started|tutorial)$/i,

--- a/test/guide.test.mjs
+++ b/test/guide.test.mjs
@@ -21,3 +21,29 @@ describe("guide intent routing", () => {
     assert.equal(isGuideIntent("what sports do you support?"), true);
   });
 });
+
+describe("premium / Machina guide", () => {
+  it("routes premium-data intents to the guide", () => {
+    assert.equal(isGuideIntent("how do I get premium data?"), true);
+    assert.equal(isGuideIntent("I need licensed feeds"), true);
+    assert.equal(isGuideIntent("machina cli setup"), true);
+  });
+
+  it("does not false-positive on premier league or incidental machina mentions", () => {
+    assert.equal(isGuideIntent("premier league standings"), false);
+    assert.equal(
+      isGuideIntent("is the api-football from the Machina Sports TV pod?"),
+      false,
+    );
+    assert.equal(isGuideIntent("what are today's NBA scores?"), false);
+  });
+
+  it("explains Machina using only existing commands", () => {
+    const response = generateGuideResponse("how do I get premium data?");
+    assert.match(response, /machina/i);
+    assert.match(response, /machina-cli/);
+    assert.match(response, /sportsclaw mcp add/);
+    assert.match(response, /sports-skills premium/);
+    assert.doesNotMatch(response, FORBIDDEN_PROMO);
+  });
+});

--- a/test/guide.test.mjs
+++ b/test/guide.test.mjs
@@ -14,6 +14,9 @@ describe("guide intent routing", () => {
     const response = generateGuideResponse("help");
     assert.ok(response.includes("sportsclaw Features"));
     assert.doesNotMatch(response, FORBIDDEN_PROMO);
+    // the manifesto's Premium Data section must survive future edits
+    assert.match(response, /Premium Data/);
+    assert.match(response, /machina-cli/);
   });
 
   it("still handles explicit help intents", () => {
@@ -27,6 +30,13 @@ describe("premium / Machina guide", () => {
     assert.equal(isGuideIntent("how do I get premium data?"), true);
     assert.equal(isGuideIntent("I need licensed feeds"), true);
     assert.equal(isGuideIntent("machina cli setup"), true);
+    // cover the remaining intent arms so a regex edit can't silently drop one
+    assert.equal(isGuideIntent("what's the premium plan"), true);
+    assert.equal(isGuideIntent("licensed data please"), true);
+    assert.equal(isGuideIntent("real-time feeds"), true);
+    assert.equal(isGuideIntent("I need real time data"), true); // space variant
+    assert.equal(isGuideIntent("how do I upgrade"), true);
+    assert.equal(isGuideIntent("does it use the machina platform"), true);
   });
 
   it("does not false-positive on premier league or incidental machina mentions", () => {


### PR DESCRIPTION
## What

The agent now knows about the Machina premium data option out of the box, with zero LLM cost.

- A tight `PREMIUM_INTENT` regex routes premium/licensed/real-time-data (and `machina cli/premium/platform`) queries to the guide.
- The response references **only existing commands** — `pip install machina-cli`, `machina login`, `sportsclaw mcp add <url>`, `sports-skills premium`. (No reference to any not-yet-shipped native command.)
- A `Premium Data` line added to the feature manifesto.

## False-positive safety
The pattern does **not** match `premier league` (no "premium") or incidental mentions like `Machina Sports TV pod` (only `machina premium|cli|platform` qualifies) — both asserted in tests, including the pre-existing api-football/TV-pod guard.

## Tests
`test/guide.test.mjs`: routing, false-positive guards, existing-command + forbidden-promo assertions. Build + guide tests pass. Reviewed via multi-persona code review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)