### PR TITLE
docs(site): VitePress docs site + landing refresh

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -29,6 +29,19 @@ jobs:
       - name: Prepare site assets
         run: cp scripts/install.sh site/install.sh
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build docs (VitePress)
+        run: |
+          npm install --no-audit --no-fund
+          npm run docs:build
+          rm -rf site/docs
+          mkdir -p site/docs
+          cp -r docs/.vitepress/dist/. site/docs/
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -27,7 +27,10 @@ jobs:
         run: echo "RELEASE_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Prepare site assets
-        run: cp scripts/install.sh site/install.sh
+        run: |
+          cp scripts/install.sh site/install.sh
+          # Stamp the landing-page badge with the release tag (no stale version).
+          sed -i "s|<span id=\"version\">[^<]*</span>|<span id=\"version\">${RELEASE_NAME}</span>|" site/index.html
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -38,6 +38,12 @@ jobs:
         run: |
           npm install --no-audit --no-fund
           npm run docs:build
+          # Fail loudly if the build produced nothing — otherwise the Docker
+          # COPY below would ship an empty /docs and nginx would 404 silently.
+          if [ ! -d docs/.vitepress/dist ] || [ -z "$(ls -A docs/.vitepress/dist)" ]; then
+            echo "::error::VitePress build produced no output (docs/.vitepress/dist empty)"
+            exit 1
+          fi
           rm -rf site/docs
           mkdir -p site/docs
           cp -r docs/.vitepress/dist/. site/docs/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ docker/relay/k8s/overlays/*/secrets.env
 !docker/relay/k8s/overlays/example/secrets.env
 .vscode/settings.json
 package-lock.json
+
+# VitePress docs build artifacts + CI staging into the site image
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+site/docs/
+.gstack/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/logo.jpg" alt="sportsclaw" width="500">
 </p>
 
-# sportsclaw 🦞
+# sportsclaw
 
 A CLI and bot scaffold that connects any LLM to live sports data via [sports-skills](https://sports-skills.sh).
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,146 @@
+import { defineConfig } from 'vitepress'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  title: 'sportsclaw',
+  description:
+    'Build AI that understands live sports. One open-source engine with keyless live data, market odds, and real-time game events built in.',
+  lang: 'en-US',
+
+  // Served same-origin under sportsclaw.gg/docs (see site/Dockerfile + build-site.yml).
+  base: '/docs/',
+
+  srcExclude: ['superpowers/**', 'openshell-research.md', 'README.md'],
+
+  cleanUrls: true,
+  lastUpdated: true,
+  appearance: false, // light-only — the linen canvas is the design
+
+  head: [
+    ['link', { rel: 'icon', href: '/docs/favicon.svg', type: 'image/svg+xml' }],
+    ['meta', { name: 'theme-color', content: '#fafffa' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap',
+      },
+    ],
+    // Hide reveal targets before first paint (no flash); skipped for reduced-motion.
+    [
+      'script',
+      {},
+      "try{if(!matchMedia('(prefers-reduced-motion: reduce)').matches){document.documentElement.classList.add('sc-reveal-ready')}}catch(e){}",
+    ],
+  ],
+
+  themeConfig: {
+    siteTitle: 'sportsclaw',
+
+    nav: [
+      { text: 'Guide', link: '/getting-started/introduction' },
+      { text: 'Sports & Markets', link: '/sports-data/coverage' },
+      { text: 'CLI Reference', link: '/cli-reference' },
+      { text: 'sports-skills', link: 'https://sports-skills.sh' },
+      {
+        text: 'GitHub',
+        link: 'https://github.com/machina-sports/sportsclaw',
+      },
+    ],
+
+    sidebar: [
+      {
+        text: 'Getting Started',
+        items: [
+          { text: 'Introduction', link: '/getting-started/introduction' },
+          { text: 'Quickstart', link: '/getting-started/quickstart' },
+          { text: 'Configuration', link: '/getting-started/configuration' },
+        ],
+      },
+      {
+        text: 'Core Concepts',
+        items: [
+          { text: 'How It Works', link: '/core-concepts/how-it-works' },
+          { text: 'Read-Only by Default', link: '/core-concepts/safety-and-trading' },
+        ],
+      },
+      {
+        text: 'Building Bots',
+        items: [
+          { text: 'Discord', link: '/building-bots/discord' },
+          { text: 'Telegram', link: '/building-bots/telegram' },
+          { text: 'Live-Game Alerts', link: '/building-bots/live-game-alerts' },
+        ],
+      },
+      {
+        text: 'Sports Data & Markets',
+        items: [
+          { text: 'Coverage', link: '/sports-data/coverage' },
+          { text: 'Odds & Prediction Markets', link: '/sports-data/odds-and-markets' },
+          { text: 'Images & Vision', link: '/sports-data/images-and-vision' },
+          { text: 'Machina (Premium)', link: '/sports-data/machina' },
+        ],
+      },
+      {
+        text: 'Deployment',
+        items: [
+          { text: 'Docker', link: '/deployment/docker' },
+          { text: 'Running as a Daemon', link: '/deployment/daemons' },
+          { text: 'NVIDIA OpenShell', link: '/deployment/openshell' },
+        ],
+      },
+      {
+        text: 'Advanced',
+        items: [
+          { text: 'Connecting MCP Servers', link: '/advanced/mcp' },
+          { text: 'Watchers & Schedules', link: '/advanced/watchers' },
+          { text: 'Operator Mode', link: '/advanced/operator' },
+        ],
+      },
+      {
+        text: 'Reference',
+        items: [{ text: 'CLI Reference', link: '/cli-reference' }],
+      },
+    ],
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/machina-sports/sportsclaw' },
+    ],
+
+    search: { provider: 'local' },
+
+    editLink: {
+      pattern: 'https://github.com/machina-sports/sportsclaw/edit/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    footer: {
+      message: 'Open source under the MIT License.',
+      copyright: 'sportsclaw',
+    },
+  },
+
+  // Machine-readable index for LLM/agent ingestion.
+  buildEnd: async (siteConfig) => {
+    const pages = siteConfig.pages
+      .filter((p) => p !== 'index.md')
+      .map((p) => `- /docs/${p.replace(/\.md$/, '')}`)
+      .sort()
+    const llms = [
+      '# sportsclaw',
+      '',
+      '> Build AI that understands live sports. An open-source engine with keyless live data,',
+      '> market odds, and real-time game events built in — for chat bots, broadcast widgets,',
+      '> and odds trackers.',
+      '',
+      '## Docs',
+      ...pages,
+      '',
+    ].join('\n')
+    writeFileSync(join(siteConfig.outDir, 'llms.txt'), llms)
+  },
+})

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,228 @@
+/* sportsclaw docs — editorial broadsheet (NewForm-inspired).
+   Linen canvas, Fraunces display serif, Inter body, neon green used ONLY as
+   punctuation: the CTA fill, active-nav marks, and short section ticks. */
+
+:root {
+  /* Type */
+  --vp-font-family-base: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --vp-font-family-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', 'Menlo', monospace;
+
+  /* Canvas & ink */
+  --vp-c-bg: #fafffa;        /* linen */
+  --vp-c-bg-alt: #f3f6f3;    /* sidebar / footer */
+  --vp-c-bg-soft: #f1f4f1;
+  --vp-c-bg-elv: #fafffa;
+
+  --vp-c-text-1: #121613;    /* obsidian ink */
+  --vp-c-text-2: #516254;    /* sage */
+  --vp-c-text-3: #8a9b8d;
+
+  --vp-c-divider: #d8e2d8;
+  --vp-c-border: #c8d2c8;    /* mist */
+  --vp-c-gutter: #e6ece6;
+
+  /* Brand = ink for links/active text (ghost-link discipline); green is punctuation only */
+  --vp-c-brand-1: #121613;
+  --vp-c-brand-2: #232924;
+  --vp-c-brand-3: #2bee4b;   /* voltage — accents only */
+  --vp-c-brand-soft: rgba(43, 238, 75, 0.14);
+
+  /* The one filled button: voltage green, ink text, green glow */
+  --vp-button-brand-bg: #2bee4b;
+  --vp-button-brand-text: #121613;
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-hover-bg: #4af265;
+  --vp-button-brand-hover-text: #121613;
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-active-bg: #25d544;
+  --vp-button-brand-active-text: #121613;
+  --vp-button-brand-active-border: transparent;
+
+  --vp-code-block-bg: #f1f4f1;
+  --vp-home-hero-name-color: #121613;
+}
+
+/* ---------- Display type: tight heavy grotesque (TWK Lausanne → Inter Tight) ---------- */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.VPHomeHero .name,
+.VPHomeHero .text,
+.VPHome .VPFeature .title {
+  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  color: var(--vp-c-text-1);
+}
+
+.VPHomeHero .name {
+  font-weight: 700;
+  font-size: clamp(2.6rem, 6.5vw, 4.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+}
+.VPHomeHero .text {
+  font-weight: 600;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+  line-height: 1;
+  letter-spacing: -0.035em;
+}
+.vp-doc h1 {
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+.VPHomeHero .tagline {
+  font-family: var(--vp-font-family-base);
+  font-size: 1.1rem;
+  color: var(--vp-c-text-2);
+  letter-spacing: -0.01em;
+}
+
+/* ---------- Section tick: a short green beat replaces the divider rule ---------- */
+.vp-doc h2 {
+  border-top: 0;
+  margin-top: 3rem;
+  padding-top: 0;
+}
+.vp-doc h2::before {
+  content: '';
+  display: block;
+  width: 48px;
+  height: 2px;
+  background: var(--vp-c-brand-3);
+  margin-bottom: 1.1rem;
+}
+
+/* ---------- Links: ghost style — ink, hairline underline, green on hover ---------- */
+.vp-doc a {
+  color: var(--vp-c-text-1);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--vp-c-border);
+  transition: text-decoration-color 0.15s ease;
+}
+.vp-doc a:hover {
+  text-decoration-color: var(--vp-c-brand-3);
+}
+
+/* ---------- Inline + block code ---------- */
+.vp-doc :not(pre) > code {
+  background: var(--vp-c-brand-soft);
+  color: #1c7a2e; /* readable green, low-frequency */
+  font-size: 0.85em;
+}
+.vp-doc div[class*='language-'] {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 14px;
+}
+
+/* ---------- The CTA: green glow, never a neutral shadow ---------- */
+.VPButton.brand {
+  border-radius: 10px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow:
+    rgba(16, 94, 29, 0.45) 1px 8px 20px 0px,
+    rgba(18, 146, 39, 0.25) 1px 8px 20px 0px;
+}
+
+/* ---------- Active navigation: green is the marker ---------- */
+.VPSidebarItem.is-active > .item .text {
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+}
+.VPSidebarItem.is-active > .item .indicator {
+  background-color: var(--vp-c-brand-3) !important;
+}
+.VPNavBarMenuLink.active {
+  color: var(--vp-c-text-1) !important;
+}
+
+/* ---------- Feature cards: no container — a top hairline + type define them ---------- */
+.VPHome .VPFeature {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  border-top: 1px solid var(--vp-c-border) !important;
+  padding: 24px 24px 12px 0;
+}
+.VPHome .VPFeature .title {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+.VPHome .VPFeature .details {
+  color: var(--vp-c-text-2);
+  font-size: 0.95rem;
+}
+
+/* ---------- Wordmark ---------- */
+.VPNavBarTitle .title {
+  font-family: var(--vp-font-family-base);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* ---------- Home feature grid: ASCII motif + type, no container ---------- */
+.sc-grid {
+  max-width: 1152px;
+  margin: 12px auto 88px;
+  padding: 0 48px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 60px 48px;
+}
+@media (max-width: 960px) {
+  .sc-grid { grid-template-columns: repeat(2, 1fr); gap: 48px 40px; }
+}
+@media (max-width: 640px) {
+  .sc-grid { grid-template-columns: 1fr; padding: 0 24px; }
+}
+
+.sc-card {
+  display: block;
+  border-top: 1px solid var(--vp-c-border);
+  padding-top: 26px;
+  text-decoration: none !important;
+  color: var(--vp-c-text-1);
+  transition: transform 0.25s ease;
+}
+.sc-card:hover { transform: translateY(-3px); }
+
+.sc-card .motif {
+  font-family: var(--vp-font-family-mono);
+  font-size: 15px;
+  line-height: 1.12;
+  color: #2c3a30;
+  background: transparent;
+  border: 0;
+  margin: 0 0 20px;
+  padding: 0;
+  white-space: pre;
+  overflow: visible;
+  min-height: 102px; /* normalize so taller motifs keep titles aligned across the row */
+}
+.sc-card .motif b {
+  color: var(--vp-c-brand-3);
+  font-weight: 400;
+}
+
+.sc-card h3 {
+  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0 0 10px;
+  border: 0;
+  padding: 0;
+  transition: color 0.2s ease;
+}
+.sc-card:hover h3 { color: #1c7a2e; }
+
+.sc-card p {
+  color: var(--vp-c-text-2);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  margin: 0;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,88 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import './custom.css'
+import './reveal.css'
+
+let observer: IntersectionObserver | undefined
+
+const DOC_SELECTOR = [
+  '.vp-doc > h1',
+  '.vp-doc h2',
+  '.vp-doc h3',
+  '.vp-doc p',
+  '.vp-doc ul',
+  '.vp-doc ol',
+  '.vp-doc blockquote',
+  '.vp-doc table',
+  '.vp-doc .custom-block',
+  '.vp-doc div[class*="language-"]',
+].join(',')
+
+function reveal(el: Element) {
+  el.classList.add('sc-in')
+  // The home grid cards hide their own children via shared CSS; reveal them too.
+  if (el.classList.contains('sc-card')) {
+    el.querySelectorAll('.motif, h3, p').forEach((c) => c.classList.add('sc-in'))
+  }
+}
+
+function setupReveal() {
+  if (typeof window === 'undefined') return
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+  try {
+    document.documentElement.classList.add('sc-reveal-ready')
+    if (observer) observer.disconnect()
+
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            reveal(entry.target)
+            observer?.unobserve(entry.target)
+          }
+        }
+      },
+      { threshold: 0.1, rootMargin: '0px 0px -6% 0px' },
+    )
+
+    const isHome = !!document.querySelector('.VPHome')
+
+    if (isHome) {
+      const hero = Array.from(
+        document.querySelectorAll(
+          '.VPHomeHero .name, .VPHomeHero .text, .VPHomeHero .tagline, .VPHomeHero .actions',
+        ),
+      )
+      const cards = Array.from(document.querySelectorAll('.sc-grid .sc-card'))
+      hero.forEach((el, i) => {
+        ;(el as HTMLElement).style.transitionDelay = `${i * 90}ms`
+        observer!.observe(el)
+      })
+      cards.forEach((el, i) => {
+        ;(el as HTMLElement).style.transitionDelay = `${(i % 3) * 80}ms`
+        observer!.observe(el)
+      })
+    } else {
+      document.querySelectorAll(DOC_SELECTOR).forEach((el) => observer!.observe(el))
+    }
+  } catch {
+    document.documentElement.classList.remove('sc-reveal-ready')
+  }
+}
+
+const schedule = () =>
+  requestAnimationFrame(() => window.setTimeout(setupReveal, 60))
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ router }) {
+    if (typeof window === 'undefined') return
+    const prev = router.onAfterRouteChanged
+    router.onAfterRouteChanged = (to) => {
+      prev?.(to)
+      schedule()
+    }
+    schedule()
+  },
+} satisfies Theme

--- a/docs/.vitepress/theme/reveal.css
+++ b/docs/.vitepress/theme/reveal.css
@@ -9,7 +9,6 @@
   html.sc-reveal-ready .VPHomeHero .text,
   html.sc-reveal-ready .VPHomeHero .tagline,
   html.sc-reveal-ready .VPHomeHero .actions,
-  html.sc-reveal-ready .VPHome .VPFeature,
   html.sc-reveal-ready .sc-grid .sc-card,
   html.sc-reveal-ready .vp-doc > h1,
   html.sc-reveal-ready .vp-doc h2,

--- a/docs/.vitepress/theme/reveal.css
+++ b/docs/.vitepress/theme/reveal.css
@@ -1,0 +1,51 @@
+/* Scroll-reveal motion (NewForm-inspired): fade-up as elements enter the
+   viewport — home hero + feature cards AND interior doc content, so the page
+   reveals section-by-section as you scroll. Disabled for reduced-motion.
+   The `sc-reveal-ready` root class is set by a head script before first paint,
+   so there's no flash and no-JS users see everything. */
+
+@media (prefers-reduced-motion: no-preference) {
+  html.sc-reveal-ready .VPHomeHero .name,
+  html.sc-reveal-ready .VPHomeHero .text,
+  html.sc-reveal-ready .VPHomeHero .tagline,
+  html.sc-reveal-ready .VPHomeHero .actions,
+  html.sc-reveal-ready .VPHome .VPFeature,
+  html.sc-reveal-ready .sc-grid .sc-card,
+  html.sc-reveal-ready .vp-doc > h1,
+  html.sc-reveal-ready .vp-doc h2,
+  html.sc-reveal-ready .vp-doc h3,
+  html.sc-reveal-ready .vp-doc p,
+  html.sc-reveal-ready .vp-doc ul,
+  html.sc-reveal-ready .vp-doc ol,
+  html.sc-reveal-ready .vp-doc blockquote,
+  html.sc-reveal-ready .vp-doc table,
+  html.sc-reveal-ready .vp-doc .custom-block,
+  html.sc-reveal-ready .vp-doc div[class*='language-'] {
+    opacity: 0;
+    transform: translateY(20px);
+    transition:
+      opacity 0.65s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.65s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  html.sc-reveal-ready .sc-in {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  /* Green underscore tick drawing in under the hero headline. */
+  html.sc-reveal-ready .VPHomeHero .text::after {
+    content: '';
+    display: block;
+    width: 64px;
+    height: 4px;
+    margin: 28px auto 0;
+    background: var(--vp-c-brand-3);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.35s;
+  }
+  html.sc-reveal-ready .VPHomeHero .text.sc-in::after {
+    transform: scaleX(1);
+  }
+}

--- a/docs/advanced/mcp.md
+++ b/docs/advanced/mcp.md
@@ -1,0 +1,25 @@
+# Connecting MCP Servers
+
+sportsclaw can pull in tools from external [Model Context Protocol](https://modelcontextprotocol.io)
+servers, so your agent can reach workflows and services beyond sports data.
+
+## Add a server
+
+```bash
+sportsclaw mcp add <url>     # connect an MCP server
+sportsclaw mcp list          # see connected servers
+sportsclaw mcp remove <name> # disconnect one
+```
+
+Once connected, the tools that server exposes become available to the agent automatically,
+alongside the built-in sports tools.
+
+## What you can connect
+
+Any MCP server — including Machina Core "pods," which surface workflows, agents, and connectors
+the agent can call as part of answering a question.
+
+::: tip sportsclaw connects *to* MCP servers
+sportsclaw is an MCP **client**: it consumes tools from other servers. It does not run as an
+MCP server itself.
+:::

--- a/docs/advanced/operator.md
+++ b/docs/advanced/operator.md
@@ -1,0 +1,36 @@
+# Operator Mode
+
+Operator mode runs sportsclaw as an autonomous, time-driven agent: it wakes on a schedule,
+reasons about what's happening in live sports, and publishes output on its own — no user turn
+required. It's the foundation for things like an always-on broadcast or studio agent.
+
+::: warning Advanced & evolving
+Operator mode is the most advanced surface in sportsclaw and is still evolving. Most projects
+should start with on-demand queries and bots.
+:::
+
+## Running a job
+
+Operator behavior is defined as a **job**. List what's configured, then run one:
+
+```bash
+sportsclaw operate --list              # show configured jobs
+sportsclaw operate --job <jobId>       # run a job continuously
+sportsclaw operate --job <jobId> --once    # run a single tick
+sportsclaw operate --job <jobId> --dry-run # plan a tick without publishing
+```
+
+To run a job supervised in the background:
+
+```bash
+sportsclaw start operator <jobId>
+```
+
+It then appears in `sportsclaw status` alongside your bots.
+
+## How it differs from chat
+
+There's no person asking — a schedule fires "ticks." On each tick the agent reviews live state,
+decides whether there's anything worth saying (it can choose to stay silent), and publishes to
+the destination its job defines. It keeps a running memory between ticks so it doesn't repeat
+itself.

--- a/docs/advanced/watchers.md
+++ b/docs/advanced/watchers.md
@@ -1,0 +1,35 @@
+# Watchers & Schedules
+
+Beyond answering on demand, sportsclaw can keep an eye on things and act when a condition is
+met or on a timer.
+
+## Conditional alerts
+
+Ask the agent to watch for something and ping you when it happens:
+
+> "Ping me if LeBron scores 30 tonight."
+
+The agent records the condition and notifies you when it's met. (For following whole teams,
+[Live-Game Alerts](../building-bots/live-game-alerts) are simpler and need no phrasing.)
+
+## Scheduled tasks
+
+Ask for something on a recurring schedule:
+
+> "Send me an NFL injury report every morning at 9."
+
+The agent runs the prompt on that schedule and delivers the result. Schedules run at most once
+every few minutes.
+
+## Watching a data endpoint (CLI)
+
+For power users, `sportsclaw watch` polls a specific data endpoint and emits whenever the
+result changes:
+
+```bash
+sportsclaw watch nfl scores              # watch one endpoint for changes
+sportsclaw watch --config=watchers.json  # run several at once
+```
+
+This is a low-level primitive — most use cases are better served by team alerts or scheduled
+tasks above.

--- a/docs/building-bots/discord.md
+++ b/docs/building-bots/discord.md
@@ -1,0 +1,52 @@
+# Discord Bot
+
+Put sportsclaw in your Discord server and your community can ask about any game, any time —
+and get answers with the real numbers, rich cards, and interactive buttons.
+
+## Setup
+
+1. Create a bot in the [Discord Developer Portal](https://discord.com/developers/applications)
+   and copy its token.
+2. Add the token to sportsclaw:
+   ```bash
+   sportsclaw channels
+   ```
+3. Install the Discord library (it's an optional dependency):
+   ```bash
+   npm install -g discord.js
+   ```
+4. Start the bot:
+   ```bash
+   sportsclaw listen discord
+   ```
+
+Mention the bot or message it, and it answers. To keep it running after you close your
+terminal, see **[Running as a Daemon](../deployment/daemons)**.
+
+## What your users get
+
+- **Rich embeds** with team logos and clean formatting.
+- **Interactive buttons** — Box Score, Play-by-Play, and Full Stats expand the detail without a
+  new question.
+- **Native polls** for "who wins?"-style prompts.
+- **Image replies** — ask for a matchday graphic and the bot posts one back.
+- **Vision** — drop in a screenshot of a bracket or scoreboard and ask about it.
+
+## Turning features on and off
+
+Each surface is a feature flag, so you can tailor the experience:
+
+| Feature | Default |
+| --- | --- |
+| Embeds | On |
+| Buttons | On |
+| Polls | On |
+| Reactions | Off |
+
+Set them when you start the listener, e.g. `DISCORD_FEATURE_POLLS=false sportsclaw listen discord`.
+
+## Following teams
+
+Your users can subscribe to their teams right from chat — "alert me about the Lakers" — and the
+bot will message them automatically when the game moves. See
+**[Live-Game Alerts](./live-game-alerts)**.

--- a/docs/building-bots/discord.md
+++ b/docs/building-bots/discord.md
@@ -13,7 +13,7 @@ and get answers with the real numbers, rich cards, and interactive buttons.
    ```
 3. Install the Discord library (it's an optional dependency):
    ```bash
-   npm install -g discord.js
+   npm install discord.js
    ```
 4. Start the bot:
    ```bash

--- a/docs/building-bots/live-game-alerts.md
+++ b/docs/building-bots/live-game-alerts.md
@@ -1,0 +1,39 @@
+# Live-Game Alerts
+
+sportsclaw doesn't just answer questions — it can reach out. Users follow a team in plain
+language, and the bot messages them the moment something happens.
+
+## How users subscribe
+
+There's no menu or setup. A user just asks:
+
+> "Alert me about the Lakers."
+> "Tell me when Brazil scores."
+
+The bot confirms:
+
+> Subscribed to the Lakers (NBA). I'll message you on scores, lead changes, and the final.
+
+To stop, they say "stop alerting me about the Lakers." Team names are matched loosely — "niners"
+finds the 49ers, "man u" finds Manchester United, "spurs" finds Tottenham.
+
+## What triggers an alert
+
+Once anyone is following a team, sportsclaw watches that team's games in the background and
+sends a message on each meaningful moment:
+
+| Event | Example |
+| --- | --- |
+| **Game start** | "Lakers vs. Warriors is underway." |
+| **Score change** | "Warriors 24, Lakers 21 — end of Q1." |
+| **Lead change** | "🔄 The Lakers take the lead, 58–56." |
+| **Final** | "Final: Lakers 112, Warriors 108." |
+
+Routine updates are delivered instantly from templates; the bigger moments — a lead change, the
+final — get a short, written-up message.
+
+## Good to know
+
+- Subscriptions are **per user** and persist across restarts.
+- Alerts work on both **Discord** and **Telegram**.
+- The watch loop only runs for sports someone is actually following, so it stays light.

--- a/docs/building-bots/telegram.md
+++ b/docs/building-bots/telegram.md
@@ -1,0 +1,30 @@
+# Telegram Bot
+
+Run sportsclaw as a Telegram bot — in DMs, group chats, or inline in any conversation.
+
+## Setup
+
+1. Create a bot with [@BotFather](https://t.me/botfather) and copy the token.
+2. Add it to sportsclaw:
+   ```bash
+   sportsclaw channels
+   ```
+3. Start the bot:
+   ```bash
+   sportsclaw listen telegram
+   ```
+
+To keep it running in the background, see **[Running as a Daemon](../deployment/daemons)**.
+
+## What your users get
+
+- **Inline keyboards** for quick actions and picking a sport or team.
+- **Inline queries** — type `@yourbot lakers score` in any chat and drop the answer inline,
+  without adding the bot to that group.
+- **Image replies** — generated graphics are sent straight into the chat.
+- **Vision** — send a photo and ask about it.
+
+## Following teams
+
+Just like Discord, users can say "tell me when Brazil scores" and the bot will message them on
+goals, lead changes, and the final whistle. See **[Live-Game Alerts](./live-game-alerts)**.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,58 @@
+# CLI Reference
+
+Every `sportsclaw` command, grouped by what you'll reach for most.
+
+## Everyday
+
+| Command | What it does |
+| --- | --- |
+| `sportsclaw "<question>"` | Ask a one-shot question and print a sourced answer |
+| `sportsclaw chat` | Start an interactive conversation |
+| `sportsclaw config` | Configure your provider, model, and integrations |
+| `sportsclaw setup` | Conversational, AI-guided setup |
+| `sportsclaw doctor` | Diagnose your install and tell you what to fix |
+| `sportsclaw health` | Report overall system status |
+| `sportsclaw login claude` | Reuse your existing Claude Code session |
+| `sportsclaw logout claude` | Stop using the Claude Code session |
+
+## Sports
+
+| Command | What it does |
+| --- | --- |
+| `sportsclaw init` | Choose and install sports interactively |
+| `sportsclaw init --all` | Pre-install all sports at once |
+| `sportsclaw add <sport>` | Install one sport (e.g. `nfl`, `nba`) |
+| `sportsclaw remove <sport>` | Remove a sport |
+| `sportsclaw list` | List installed sports |
+
+## Bots & daemons
+
+| Command | What it does |
+| --- | --- |
+| `sportsclaw channels` | Set up Discord & Telegram bot tokens |
+| `sportsclaw listen <platform>` | Run a bot in the foreground (`discord` / `telegram`) |
+| `sportsclaw start <platform>` | Run a bot in the background |
+| `sportsclaw stop <platform>` | Stop a background bot |
+| `sportsclaw restart <platform>` | Restart a background bot |
+| `sportsclaw status` | Show what's running |
+| `sportsclaw logs <platform> [--lines N]` | Tail a bot's logs |
+
+## Advanced
+
+| Command | What it does |
+| --- | --- |
+| `sportsclaw mcp add <url>` | Connect an MCP server |
+| `sportsclaw mcp list` / `remove <name>` | List / disconnect MCP servers |
+| `sportsclaw watch <sport> <command>` | Watch a data endpoint for changes |
+| `sportsclaw operate --list` | List configured operator jobs |
+| `sportsclaw operate --job <id>` | Run an operator job |
+| `sportsclaw start operator <id>` | Run an operator job in the background |
+
+## Global options
+
+| Flag | Effect |
+| --- | --- |
+| `--verbose`, `-v` | Show detailed logs |
+| `--json` | Emit structured NDJSON (for scripting) |
+| `--yolo` | Skip approval prompts |
+| `--help`, `-h` | Show help |

--- a/docs/core-concepts/how-it-works.md
+++ b/docs/core-concepts/how-it-works.md
@@ -1,0 +1,54 @@
+# How It Works
+
+You ask a question in plain language. sportsclaw turns that into the right data lookups, runs
+them against live sources, and writes an answer grounded in what it found.
+
+## The loop, in plain terms
+
+1. **You ask.** "Who's leading the Premier League, and what are the title odds?"
+2. **The agent picks tools.** It decides it needs current standings and prediction-market
+   prices, and calls the right data skills for each.
+3. **Data is fetched live.** Those skills pull real results from sources like ESPN and
+   Polymarket — no made-up numbers.
+4. **You get one answer.** The agent synthesizes everything into a single, sourced response.
+
+Because the data comes from real lookups rather than the model's memory, answers stay current
+and don't drift into hallucination. If the agent needs a specific team or player and only has a
+name, it looks up the ID first instead of guessing.
+
+## Grounded, not guessed
+
+This is the core idea: an LLM on its own will happily invent a score. sportsclaw doesn't let it
+answer from memory for anything it can look up. Live scores, standings, schedules, player
+stats, odds, and news all come from real data skills the agent is required to call.
+
+Those skills are provided by **[sports-skills](https://sports-skills.sh)** — the open Python
+data layer that the installer provisions automatically. It's the source of every sport and
+market sportsclaw can reach; see the full catalog at [sports-skills.sh](https://sports-skills.sh).
+
+## Asking about a sport for the first time
+
+sportsclaw ships knowing how to reach 14 sports, but it only installs the ones you use. The
+first time you ask about, say, cricket, it installs that skill in a couple of seconds and then
+answers. To load everything at once:
+
+```bash
+sportsclaw init --all
+```
+
+You can manage installed sports directly with `sportsclaw add <sport>`,
+`sportsclaw remove <sport>`, and `sportsclaw list`.
+
+## Where it runs
+
+The same engine powers every surface:
+
+- **CLI** — `sportsclaw "…"` for one-shot answers, `sportsclaw chat` for a conversation.
+- **Bots** — long-running Discord and Telegram listeners.
+- **Embedded** — import the engine into your own TypeScript app.
+- **Docker** — package the whole thing (engine + data layer) into one image.
+
+## Bring your own model
+
+sportsclaw is model-agnostic. Point it at Anthropic, OpenAI, or Google and the loop works the
+same way — see **[Configuration](../getting-started/configuration)**.

--- a/docs/core-concepts/safety-and-trading.md
+++ b/docs/core-concepts/safety-and-trading.md
@@ -1,0 +1,37 @@
+# Read-Only by Default
+
+sportsclaw can read live odds and prediction-market prices from Kalshi and Polymarket — but it
+is built to **track, not trade**. Placing bets, moving funds, or signing transactions is off by
+default.
+
+## What's blocked
+
+The engine refuses any action that would place or cancel an order, buy or sell, or touch a
+wallet or balance. This is enforced everywhere the agent runs — when tools are first offered to
+the model and again before any tool actually executes. A prompt that asks the bot to "buy 100
+shares" gets a refusal, not an order.
+
+## Bots and servers are always read-only
+
+Any deployment that other people talk to — your Discord bot, your Telegram bot, a hosted
+service — is hard read-only. There is no configuration in those surfaces that turns trading on.
+Your community can ask for odds, edges, and analysis; they cannot make your bot place a wager.
+
+## The local owner can opt in
+
+When you run sportsclaw yourself from your own terminal, you're the trusted owner. In that
+local session you *can* opt into trading-capable tools — but only if an underlying skill
+actually exposes them, and only for you. This never extends to a deployed bot.
+
+## Approvals for everything else
+
+Beyond markets, the engine gates other side effects — writing files, running shell commands —
+behind explicit approval, so an autonomous run can't quietly do something you didn't sanction.
+You approve an action once, or pre-approve it for the session.
+
+<div class="tip custom-block"><p class="custom-block-title">The short version</p>
+
+Read odds and markets freely. Trading is blocked for every bot and server deployment. Only you,
+locally, can opt into trade-capable tools.
+
+</div>

--- a/docs/deployment/daemons.md
+++ b/docs/deployment/daemons.md
@@ -1,0 +1,27 @@
+# Running as a Daemon
+
+`sportsclaw listen` runs a bot in the foreground — fine for testing, but it stops when you
+close your terminal. To keep a bot running, run it as a background daemon.
+
+## Start and stop
+
+```bash
+sportsclaw start discord      # start a Discord bot in the background
+sportsclaw start telegram     # …or Telegram
+
+sportsclaw stop discord       # stop it
+sportsclaw restart discord    # restart it
+```
+
+The installer sets up the process manager these commands use, so they work out of the box. (If
+you installed manually, make sure `pm2` is installed globally.)
+
+## Check status and logs
+
+```bash
+sportsclaw status                  # what's running, across all platforms
+sportsclaw logs discord            # tail the bot's output
+sportsclaw logs discord --lines 200
+```
+
+`status` also shows any running operator jobs — see **[Operator Mode](../advanced/operator)**.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,37 @@
+# Docker
+
+Package sportsclaw — the engine and the sports data layer — into a single container, ready to
+run a bot anywhere.
+
+## Build and run
+
+```bash
+npm run docker:build      # build the image
+npm run docker:run        # run it with your .env file
+```
+
+The image bundles both the Node engine and the Python data layer, so the container is
+self-contained.
+
+## Configuration
+
+Pass your credentials and bot tokens with an env file:
+
+```bash
+docker run --rm --env-file .env sportsclaw
+```
+
+| Variable | Purpose |
+| --- | --- |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | Your model provider |
+| `DISCORD_BOT_TOKEN` | Run a Discord bot |
+| `TELEGRAM_BOT_TOKEN` | Run a Telegram bot |
+
+## Persisting settings
+
+sportsclaw stores config, installed sports, and subscriptions under `~/.sportsclaw`. Mount a
+volume there if you want that state to survive container restarts:
+
+```bash
+docker run --rm --env-file .env -v sportsclaw-data:/root/.sportsclaw sportsclaw
+```

--- a/docs/deployment/openshell.md
+++ b/docs/deployment/openshell.md
@@ -1,0 +1,100 @@
+# Running with NVIDIA OpenShell
+
+You can run sportsclaw inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell)
+sandbox — a hardened, policy-enforced environment where the agent's model calls route through
+OpenShell's **Privacy Router** instead of going straight to a provider. The sandbox injects
+credentials and enforces egress policy, so your API keys never live inside the agent process.
+
+::: tip When to use it
+Reach for OpenShell when you're running sportsclaw unattended (a bot or an
+[operator job](../advanced/operator)) and want credential isolation, policy-controlled network
+egress, and a reproducible sandbox — common for broadcasters, sportsbooks, and teams with
+compliance requirements.
+:::
+
+## Check your setup
+
+The fastest way to see what's missing is the built-in doctor:
+
+```bash
+sportsclaw openshell doctor          # diagnose prerequisites + print fixes
+sportsclaw openshell doctor --json   # machine-readable
+```
+
+It checks, in order: the OpenShell CLI, a registered gateway, a configured provider, the active
+inference target, and whether a sandbox actually provisions — and prints the exact remediation
+command for anything that's off.
+
+## Guided setup
+
+```bash
+sportsclaw openshell setup
+```
+
+An interactive wizard that walks you through everything below. If you'd rather do it by hand,
+the steps are:
+
+**1. Install the OpenShell CLI**
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+```
+
+**2. Register and select a gateway**
+
+```bash
+openshell gateway add http://127.0.0.1:18080 --local --name local
+openshell gateway select local
+```
+
+**3. Create a provider** (reusing your existing keys)
+
+```bash
+openshell provider create --name claude --type anthropic --from-existing
+```
+
+`--type` is one of `anthropic`, `openai`, or `nvidia`.
+
+**4. Point inference at it**
+
+```bash
+openshell inference set --provider claude --model claude-opus-4-6 --timeout 300
+```
+
+Re-run `sportsclaw openshell doctor` to confirm everything is green.
+
+## Running sportsclaw in a sandbox
+
+Create a sandbox from your sportsclaw image (add `--gpu` if you're running a local model), then
+start the agent inside it:
+
+```bash
+openshell sandbox create --from <your-sportsclaw-image> --name sportsclaw
+openshell sandbox exec -n sportsclaw -- sportsclaw listen discord
+```
+
+Inside the sandbox, point your model provider at the Privacy Router and use a placeholder key —
+OpenShell injects the real credentials and enforces policy:
+
+```bash
+OPENAI_BASE_URL=https://inference.local/v1
+```
+
+`https://inference.local` is reachable **only from inside the sandbox**; it is never exposed to
+the host.
+
+## Operator jobs
+
+If you run sportsclaw as an autonomous [operator](../advanced/operator), opt a job into the
+Privacy Router by adding an `openshell` block to its config:
+
+```jsonc
+{
+  "openshell": {
+    "enabled": true,
+    "baseUrl": "https://inference.local/v1"
+  }
+}
+```
+
+With that set, the operator daemon routes its model calls through OpenShell on every tick.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,72 @@
+# Configuration
+
+sportsclaw needs one thing to run: a connection to an AI model. The sports data is free and
+keyless — only the reasoning model requires credentials.
+
+## Guided setup
+
+The easiest way to configure everything is the interactive wizard:
+
+```bash
+sportsclaw config
+```
+
+It walks you through choosing a provider, picking a model, and (optionally) setting up Discord
+and Telegram bots. Your settings are saved to `~/.sportsclaw/`. Run it again any time to change
+things.
+
+Want a conversational setup that also validates your bot tokens as you go? Try
+`sportsclaw setup`.
+
+## Choosing a model
+
+sportsclaw works with three providers — bring a key from whichever you prefer:
+
+| Provider | Models | API key |
+| --- | --- | --- |
+| **Anthropic** | Claude (Opus, Sonnet) | `ANTHROPIC_API_KEY` |
+| **OpenAI** | GPT | `OPENAI_API_KEY` |
+| **Google** | Gemini | `GEMINI_API_KEY` |
+
+Set the key in your environment, or let `sportsclaw config` store it for you:
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+```
+
+::: tip Image generation
+Generating images (matchday graphics, etc.) requires **OpenAI or Google** — Anthropic models
+can't produce images. Reading images you send the bot works on any vision-capable model.
+:::
+
+## Reuse your Claude Code session
+
+If you already use Claude Code, you can skip the API key entirely and reuse that login:
+
+```bash
+sportsclaw login claude
+```
+
+sportsclaw will use your existing Claude session for reasoning. To stop, run
+`sportsclaw logout claude` — it won't affect Claude Code itself. An `ANTHROPIC_API_KEY` in your
+environment always takes priority over this.
+
+## Connecting chat platforms
+
+To run a Discord or Telegram bot, add your bot tokens:
+
+```bash
+sportsclaw channels
+```
+
+Then start a bot with `sportsclaw listen discord` or `sportsclaw listen telegram`. See
+**[Building Bots](../building-bots/discord)** for the full walkthrough.
+
+## Checking your setup
+
+```bash
+sportsclaw doctor
+```
+
+`doctor` verifies your Node and Python versions, the sports data layer, your model
+credentials, and your installed sports — and tells you exactly what to fix if something's off.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,0 +1,48 @@
+# Introduction
+
+**sportsclaw is an open-source engine for building AI that understands live sports.**
+
+Most AI assistants are guessing when you ask about sports — they don't know last night's
+score, tonight's odds, or whether the game just went to overtime. sportsclaw fixes that. It
+connects your AI model to real, live sports data and gives it the tools to follow a game in
+real time, answer with the actual numbers, and reach out the moment something happens.
+
+It's not a coding copilot and it's not a generic chatbot framework. It's a sports-native
+engine: the data, the live game events, and the real-time plumbing are already wired in, so
+you spend your time building the experience — not stitching together feeds.
+
+## What you can build
+
+- **Sports chat bots** for Discord and Telegram that answer with real scores, standings, and
+  odds — and ping followers when their team plays.
+- **Broadcast and studio tools** that pull live game state and generate graphics on demand.
+- **Odds and market trackers** that watch ESPN, Kalshi, and Polymarket and surface the edge.
+- **Anything agentic** — sportsclaw is a TypeScript engine you can embed, extend, and deploy
+  your own way.
+
+## Who it's for
+
+Developers and technical teams building for **sports fans**, **broadcasters**,
+**sportsbooks**, and **teams & leagues**. If your product needs an AI that genuinely keeps up
+with live sports, this is the foundation.
+
+## What's in the box
+
+- **14 sports** — NFL, NBA, WNBA, MLB, NHL, soccer, F1, tennis, cricket, golf, volleyball,
+  college football, college basketball, and track. No API keys needed for the data.
+
+All coverage is powered by **[sports-skills](https://sports-skills.sh)**, the open data layer
+the installer sets up for you.
+- **Live odds & prediction markets** — ESPN, Kalshi, and Polymarket, with betting math built in.
+- **Real-time game events** — the engine watches games and knows when the score, lead, or
+  status changes.
+- **Bots, images, and vision** — Discord/Telegram integrations, image generation, and the
+  ability to read images you send it.
+
+Bring your own model — Anthropic (Claude), OpenAI, or Google (Gemini).
+
+<div class="tip custom-block"><p class="custom-block-title">Ready in about a minute</p>
+
+Head to the **[Quickstart](./quickstart)** to install sportsclaw and run your first query.
+
+</div>

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart
+
+From nothing to your first answer in about a minute.
+
+## 1. Install
+
+```bash
+curl -fsSL https://sportsclaw.gg/install.sh | bash
+```
+
+This installs the `sportsclaw` command, the sports data layer, and a process manager for
+running bots in the background. You'll need **Node.js 18+** and **Python 3.9+** already on your
+machine — the installer checks for both and tells you how to get them if they're missing.
+
+::: details Prefer to install manually?
+```bash
+npm install -g sportsclaw-engine-core pm2
+python3 -m pip install --upgrade sports-skills
+```
+:::
+
+## 2. Connect a model
+
+sportsclaw uses your AI model to do the reasoning — the sports data itself is free and needs
+no key. Pick one:
+
+```bash
+# Use an API key from Anthropic, OpenAI, or Google:
+export ANTHROPIC_API_KEY=sk-...
+
+# …or, if you already use Claude Code, reuse that session:
+sportsclaw login claude
+```
+
+Prefer a guided setup? Run `sportsclaw config` and it'll walk you through choosing a provider
+and model. See **[Configuration](./configuration)** for all the options.
+
+## 3. Ask
+
+```bash
+sportsclaw "What are today's NFL scores?"
+```
+
+That's it. The agent figures out which data it needs, fetches it live, and answers:
+
+```ansi
+❯ sportsclaw "What are today's NFL scores?"
+
+  ◒  Thinking…
+  ✓  fetched NFL scores
+
+  Here are today's NFL results:
+  • Chiefs 27, Raiders 20 (Final)
+  • Eagles 31, Cowboys 17 (Final)
+  • Lions at Packers — 8:20pm ET
+```
+
+The first time you ask about a sport, sportsclaw installs it on the spot (a couple of
+seconds). To pre-install everything up front, run `sportsclaw init --all`.
+
+## Keep going
+
+```bash
+sportsclaw chat
+```
+
+`chat` opens an interactive session — ask follow-ups, dig into odds, compare teams.
+
+## What's next
+
+- **[Configuration](./configuration)** — choose your model, manage providers, set up bots
+- **[How It Works](../core-concepts/how-it-works)** — what the engine is doing under the hood
+- **[Building a Discord bot](../building-bots/discord)** — put it in front of your community

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+---
+layout: home
+
+hero:
+  name: "sportsclaw"
+  text: "Build AI that understands live sports."
+  tagline: "An open-source engine with keyless live data, market odds, and real-time game events built in. Ship chat bots, broadcast widgets, and odds trackers in minutes — not months of data plumbing."
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /getting-started/quickstart
+    - theme: alt
+      text: How It Works
+      link: /core-concepts/how-it-works
+    - theme: alt
+      text: GitHub
+      link: https://github.com/machina-sports/sportsclaw
+---
+
+<div class="sc-grid">
+
+<a class="sc-card" href="/docs/core-concepts/how-it-works">
+<pre class="motif">┌───────────┐
+│ LAL · <b>102</b> │
+│ GSW ·  98 │
+└───────────┘</pre>
+<h3>Answers grounded in real data</h3>
+<p>Ask in plain language and get answers backed by live scores, standings, stats, odds, and news across 14 sports. The agent looks it up — it doesn't guess.</p>
+</a>
+
+<a class="sc-card" href="/docs/building-bots/discord">
+<pre class="motif">╭─────────╮
+│ score?  │
+╰─────────╯
+  ╭─────────╮
+  │ <b>LAL 102</b> │
+  ╰─────────╯</pre>
+<h3>Discord &amp; Telegram bots</h3>
+<p>Run a sports bot with rich embeds, buttons, polls, and image replies in one command. Your community asks; the bot answers with the real numbers.</p>
+</a>
+
+<a class="sc-card" href="/docs/building-bots/live-game-alerts">
+<pre class="motif">   ▟█▙
+  ▟███▙
+  ▀▀▀▀▀
+    <b>●</b></pre>
+<h3>It tells you when things happen</h3>
+<p>Followers say "alert me about the Lakers" and get a message the moment the game starts, the lead changes, or it ends — no polling, no setup.</p>
+</a>
+
+<a class="sc-card" href="/docs/sports-data/odds-and-markets">
+<pre class="motif">┌─────────┐
+│      ▂▅<b>█</b>│
+│   ▂▅    │
+│▂▅       │
+└─────────┘</pre>
+<h3>Live odds &amp; prediction markets</h3>
+<p>Pull real-time odds from ESPN, Kalshi, and Polymarket, and run the betting math. Read-only by default — built to track, not trade.</p>
+</a>
+
+<a class="sc-card" href="/docs/sports-data/images-and-vision">
+<pre class="motif">┌────────┐
+│   <b>▁▄</b>   │
+│ ▁▄██▄▁ │
+└────────┘</pre>
+<h3>Generate graphics on the fly</h3>
+<p>Ask for a matchday graphic and get one back, delivered straight into the chat. Vision works too — send a screenshot and ask about it.</p>
+</a>
+
+<a class="sc-card" href="/docs/getting-started/quickstart">
+<pre class="motif">┌────────┐
+│ <b>></b> help │
+│ <b>></b> _    │
+└────────┘</pre>
+<h3>Open source, runs anywhere</h3>
+<p>MIT-licensed TypeScript. Run it from the CLI, host it as a bot, or deploy in Docker. Bring your own model — Anthropic, OpenAI, or Google.</p>
+</a>
+
+</div>

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#fafffa"/>
+  <text x="15" y="23" font-family="Georgia, 'Times New Roman', serif" font-size="22" font-weight="600" text-anchor="middle" fill="#121613">s</text>
+  <rect x="22" y="9" width="4" height="14" rx="1" fill="#2bee4b"/>
+</svg>

--- a/docs/sports-data/coverage.md
+++ b/docs/sports-data/coverage.md
@@ -1,0 +1,52 @@
+# Coverage
+
+sportsclaw comes with live data for 14 sports plus odds and prediction markets — all keyless
+for the data itself. You don't wire up feeds or manage API keys; you just ask.
+
+<div class="tip custom-block"><p class="custom-block-title">Powered by sports-skills</p>
+
+All of this coverage comes from **[sports-skills](https://sports-skills.sh)** — the open
+Python data layer that the installer sets up for you. It's what turns "who won last night?"
+into a real, sourced answer. Browse the full catalog at **[sports-skills.sh](https://sports-skills.sh)**.
+
+Need **licensed data, real-time feeds, or production SLAs**? Step up to the
+[Machina premium layer](./machina).
+
+</div>
+
+## Sports
+
+| | | |
+| --- | --- | --- |
+| 🏈 NFL | 🏀 NBA | 🏀 WNBA |
+| ⚾ MLB | 🏒 NHL | ⚽ Soccer |
+| 🏎️ Formula 1 | 🎾 Tennis | 🏏 Cricket |
+| ⛳ Golf | 🏐 Volleyball | 🏈 College Football |
+| 🏀 College Basketball | 🏃 Track & Field | |
+
+Typical questions each can answer: live and recent scores, standings, schedules, rosters,
+player stats, play-by-play, and news — availability varies a little by sport.
+
+## Markets & analysis
+
+| Source | What it gives you |
+| --- | --- |
+| **ESPN** | Live scores, standings, schedules, stats |
+| **Kalshi** | Event-market prices |
+| **Polymarket** | Prediction-market odds |
+| **Betting tools** | Edge, de-vig, Kelly, arbitrage math |
+
+See **[Odds & Prediction Markets](./odds-and-markets)** for how to use these together.
+
+## How asking works
+
+You never name a data source or a sport code — just ask naturally:
+
+```bash
+sportsclaw "How did Arsenal do this weekend?"
+sportsclaw "Show me the NBA standings"
+sportsclaw "Who's favored in the F1 championship?"
+```
+
+The first time you touch a new sport, sportsclaw installs it in a couple of seconds. To load
+everything up front: `sportsclaw init --all`. To see what's installed: `sportsclaw list`.

--- a/docs/sports-data/images-and-vision.md
+++ b/docs/sports-data/images-and-vision.md
@@ -1,0 +1,29 @@
+# Images & Vision
+
+sportsclaw can both **create** images and **read** them.
+
+## Generating graphics
+
+Ask for a graphic and the agent makes one and delivers it right into the chat or saves it
+locally:
+
+```bash
+sportsclaw "Make a hype graphic for tonight's Lakers game"
+```
+
+In a Discord or Telegram bot, the image is posted straight into the conversation.
+
+::: tip Provider requirement
+Image generation needs **OpenAI or Google** as your model provider — Anthropic models can't
+produce images. See [Configuration](../getting-started/configuration).
+:::
+
+## Reading images (vision)
+
+Send sportsclaw an image and ask about it — a screenshot of a bracket, a scoreboard, a betting
+slip — and it reads the picture as part of the question:
+
+- **Discord / Telegram** — attach an image and ask in the same message.
+- **CLI** — pass an image file path along with your question.
+
+Vision works on any vision-capable model you've connected.

--- a/docs/sports-data/machina.md
+++ b/docs/sports-data/machina.md
@@ -1,0 +1,64 @@
+# Machina — the premium layer
+
+sportsclaw's built-in coverage comes from **[sports-skills](https://sports-skills.sh)** — the
+open, keyless data layer. It's free and ideal for development and personal use. When you need
+**licensed data, real-time and zero-latency feeds, production SLAs, or packaged agent
+workflows**, you step up to the **[Machina Sports](https://machina.gg)** platform.
+
+## Open vs. premium
+
+|                | sports-skills (built in)                          | Machina (premium)                                            |
+| -------------- | ------------------------------------------------- | ------------------------------------------------------------ |
+| **Data**       | Public APIs (ESPN, Kalshi, Polymarket…), keyless  | Licensed real-time feeds, betting odds, zero-latency streams |
+| **Best for**   | Personal use, prototyping                         | Commercial / production, with SLAs and support               |
+| **Workflows**  | You build them                                    | Packaged "templates" you install                             |
+| **Access**     | Bundled with sportsclaw                            | `machina-cli` + a per-project Machina MCP server             |
+
+::: tip Licensing
+The open sports-skills rely on third-party public APIs and are intended for **personal,
+non-commercial** use. For commercial or production workloads with licensed data, use Machina.
+:::
+
+## The Machina skill
+
+The `machina` skill is published in the same **[sports-skills catalog](https://sports-skills.sh)**
+as the open skills — it's the gateway to the premium platform. It's **prompt-only**: it fetches
+no data itself. Instead it tells the agent how to use the separate **`machina-cli`** and how to
+connect to a per-project Machina MCP server.
+
+## machina-cli
+
+The command-line control plane for the Machina platform.
+
+```bash
+pip install machina-cli          # or: curl -fsSL https://raw.githubusercontent.com/machina-sports/machina-cli/main/install.sh | bash
+machina login                    # browser sign-in (or --api-key <key> for CI)
+machina org use <org-id>
+machina project use <project-id> # required before most commands
+```
+
+What it covers:
+
+- **Templates** — packaged agent workflows (connectors, prompts, datasets, live streams).
+  `machina template list`, `machina template install <name>`, `machina template push ./<dir>`.
+- **Workflows & agents** — run and manage platform workflows and agents.
+  `machina workflow run <name>`, `machina agent run <name> --watch`.
+- **Sports passthrough** — run the same sports-skills data through the platform:
+  `machina sports <sport> <command>`.
+- **Factory** — build a whole app from a prompt: `machina factory run "build a live scoreboard"`.
+- **Deploy, credentials, config** — manage deployments, API keys, and project settings.
+
+## Connecting Machina to sportsclaw
+
+Premium live data is served through a per-project **Machina MCP server** that runs on Machina
+infrastructure (not by `machina-cli`). Because sportsclaw is an
+[MCP client](../advanced/mcp), you connect it directly:
+
+1. **Install a template** — `machina template install <name>` provisions the workflow
+   server-side and returns the MCP URL (and any required headers) in its JSON output.
+2. **Add it to sportsclaw** — `sportsclaw mcp add <url>` (see
+   [Connecting MCP Servers](../advanced/mcp)).
+3. **Ask as usual** — the agent now reads Machina's licensed, real-time feeds through that MCP
+   server, right alongside the built-in sports-skills.
+
+Learn more at **[machina.gg](https://machina.gg)**.

--- a/docs/sports-data/odds-and-markets.md
+++ b/docs/sports-data/odds-and-markets.md
@@ -1,0 +1,35 @@
+# Odds & Prediction Markets
+
+sportsclaw pulls live odds and prediction-market prices alongside real game data, and can run
+the math that turns prices into insight — all read-only.
+
+## Ask across sources
+
+The agent can fetch and compare prices from ESPN, Kalshi, and Polymarket in a single question:
+
+```bash
+sportsclaw "What are the NBA Finals odds on Polymarket?"
+sportsclaw "Compare the moneyline on tonight's game across books"
+```
+
+It can also pull a single fused snapshot — scores, odds, predictions, and news for a game,
+player, or market in one go — which is handy for dashboards and broadcast tools.
+
+## Betting math, built in
+
+Beyond raw prices, sportsclaw can do the analysis:
+
+- **De-vig** — strip the bookmaker margin to get true implied probability.
+- **Edge** — compare a market price to a fair estimate.
+- **Kelly** — suggest stake sizing from an edge.
+- **Arbitrage** — spot price gaps across sources.
+
+```bash
+sportsclaw "De-vig these odds and tell me if there's any edge"
+```
+
+## Read-only by default
+
+sportsclaw reads markets; it doesn't place bets. Trading is blocked for every bot and server
+deployment, and only a local owner session can opt into trade-capable tools. See
+**[Read-Only by Default](../core-concepts/safety-and-trading)** for the full picture.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "marked": "^15.0.12",
         "marked-terminal": "^7.3.0",
         "picocolors": "^1.1.1",
-        "proper-lockfile": "^4.1.2"
+        "proper-lockfile": "^4.1.2",
+        "undici": "^6.6.0"
       },
       "bin": {
         "sportsclaw": "dist/index.js"
@@ -32,7 +33,8 @@
         "@types/marked-terminal": "^6.1.1",
         "@types/node": "^22.0.0",
         "@types/proper-lockfile": "^4.1.4",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitepress": "^1.6.3"
       },
       "optionalDependencies": {
         "discord.js": "^14.16.0"
@@ -158,6 +160,314 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.1.tgz",
+      "integrity": "sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.1.tgz",
+      "integrity": "sha512-miW8RzAtBgNiEJ9fGEhsOPgWUpekAe64YcVufqXrlykj0Jjmo5nj0a5f/HAzRVX5ZuU1GAVd7BkzFDx7q50P3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.1.tgz",
+      "integrity": "sha512-eR3J3kB9JX6DdCvDRi3I4KPfwO6fR9HWYRXhVke2TXIoOQafMKCRAneg33JRmIrb+DnnJ/eWApJLF1O1CLPERg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.1.tgz",
+      "integrity": "sha512-P5ak7EurwYqgAiDyb95mgA3WRR/Zu8CPMv36lWTISvL2AmlPyqQPy2nX/KEJRTcwaeTWwrk6wJV4/M93GfjOWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.1.tgz",
+      "integrity": "sha512-OVtj9uA//+pjvKQI5INnzbyLrf3ClNv3XRbWswwJ2kHIStQNHtBfHo+LofNB/WhM9xjuXlW5ANn2aMj65UGx7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.1.tgz",
+      "integrity": "sha512-oKlVFlp+qbIEe4p7E54zSiP2gEV/vDu972Ykv8VDMFwEvreS7m0YKA3a8hGGHwc7yiBUGGiR3LlwzMLfnJmy6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.1.tgz",
+      "integrity": "sha512-BOVrld6vdtsFmotVDMTVQfYXwrVplJ+DUvy60JFi+tkWV698q2J9NNPKEO3dr5qxtSLKQP4vHF8n+3U5PDWhOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.1.tgz",
+      "integrity": "sha512-GAqHl9zERhC3bbBfubwUu07G3UXO06gORvOcsiTBZB3et0s3auNUbHlYdYNp4VKa3sUZqH5AcD3OKzU/KDGXjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.1.tgz",
+      "integrity": "sha512-BXZw+C+gsWL7pZvbnhJUnCXASiDLGcQxVV7h55Pyh2DmSzwdZIVccE5xc9RVD2trtrhIqk5smuODTxtaZqd0IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.1.tgz",
+      "integrity": "sha512-9g/ceZrZTqA62FA3588Xj0onRPjDNfu0pVQqefK0rrHp9H6Wblph/YmzGjZ2g8uqbTh0ZGIvAGCzErU8f7MHpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.1.tgz",
+      "integrity": "sha512-cZTIrGyAP+W4A6jDVwvWM/JOaoJKQkD/2a5eLUEeNdKAD45jN7BCpsMDONyhZlosLa4UwL8uiINQzj4iFy9nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.1.tgz",
+      "integrity": "sha512-N6I3leW0UO8Y9Zv90yo2UHgYGuxZO0mjbvzNxDIJDjO0qECEF7Z9XMvSNeUWXQh/iNDA9lr8MfEy3rmZGIcclw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.1.tgz",
+      "integrity": "sha512-ukU5zeeFs44rQkzv+TRdYard+d+3lmPGs8lPZhHtWE8rfz+LlBSF6s9kP3VQ7LeOYL8Dz0u6tZfnyTrqrumbHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.1.tgz",
+      "integrity": "sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@clack/core": {
@@ -329,6 +639,448 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
@@ -348,6 +1100,30 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.87",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.87.tgz",
+      "integrity": "sha512-8YciStObhSji3OZFmWAWK6kBujyqO5bLCxeDwLxf3CR3F4PVelq7keC2LBvgTqviWzSTysj5/g4PCFLiAMVGsw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -414,6 +1190,356 @@
         "zod": "^4.3.6"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
@@ -450,6 +1576,93 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -475,6 +1688,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/fluent-ffmpeg": {
       "version": "2.1.28",
       "resolved": "https://registry.npmjs.org/@types/fluent-ffmpeg/-/fluent-ffmpeg-2.1.28.tgz",
@@ -483,6 +1703,34 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "node_modules/@types/marked-terminal": {
@@ -511,6 +1759,23 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -538,6 +1803,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -548,6 +1827,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
@@ -555,6 +1841,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
@@ -566,6 +1866,257 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
+      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
+      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
+      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.38",
+        "@vue/runtime-core": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
+      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38"
+      },
+      "peerDependencies": {
+        "vue": "3.5.38"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/accepts": {
@@ -629,6 +2180,32 @@
         }
       }
     },
+    "node_modules/algoliasearch": {
+      "version": "5.55.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
+      "integrity": "sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.21.1",
+        "@algolia/client-abtesting": "5.55.1",
+        "@algolia/client-analytics": "5.55.1",
+        "@algolia/client-common": "5.55.1",
+        "@algolia/client-insights": "5.55.1",
+        "@algolia/client-personalization": "5.55.1",
+        "@algolia/client-query-suggestions": "5.55.1",
+        "@algolia/client-search": "5.55.1",
+        "@algolia/ingestion": "1.55.1",
+        "@algolia/monitoring": "1.55.1",
+        "@algolia/recommend": "5.55.1",
+        "@algolia/requester-browser-xhr": "5.55.1",
+        "@algolia/requester-fetch": "5.55.1",
+        "@algolia/requester-node-http": "5.55.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -681,6 +2258,16 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -740,6 +2327,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -759,6 +2357,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cli-highlight": {
@@ -842,6 +2462,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -887,6 +2518,22 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -916,6 +2563,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -938,6 +2592,30 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/discord-api-types": {
@@ -1002,6 +2680,13 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emojilib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
@@ -1014,6 +2699,19 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -1055,6 +2753,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1068,6 +2805,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1238,6 +2982,16 @@
         "which": "bin/which"
       }
     },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1252,6 +3006,21 @@
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1354,6 +3123,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -1369,6 +3176,24 @@
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-errors": {
@@ -1440,6 +3265,19 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1490,6 +3328,23 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -1531,6 +3386,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -1549,6 +3426,100 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -1573,6 +3544,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1587,6 +3572,25 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/negotiator": {
@@ -1651,6 +3655,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -1697,6 +3713,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1711,6 +3734,46 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -1720,6 +3783,17 @@
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/proxy-addr": {
@@ -1770,6 +3844,33 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1796,6 +3897,58 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1815,6 +3968,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1881,6 +4042,23 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {
@@ -1975,6 +4153,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1997,6 +4206,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -2016,6 +4240,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {
@@ -2046,6 +4283,13 @@
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -2073,6 +4317,17 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-mixer": {
@@ -2121,7 +4376,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
       "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.17"
       }
@@ -2142,6 +4396,79 @@
         "node": ">=4"
       }
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2156,6 +4483,160 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
+      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-sfc": "3.5.38",
+        "@vue/runtime-dom": "3.5.38",
+        "@vue/server-renderer": "3.5.38",
+        "@vue/shared": "3.5.38"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -2282,6 +4763,17 @@
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,10 @@
     "test:game-subscriptions": "npm run build && node --test test/game-subscriptions.test.mjs",
     "test:game-alerts": "npm run build && node --test test/game-alerts.test.mjs",
     "test:game-alert-tools": "npm run build && node --test test/game-alert-tools.test.mjs",
-    "bench:moment-to-air": "npm run build && node scripts/bench-moment-to-air.mjs"
+    "bench:moment-to-air": "npm run build && node scripts/bench-moment-to-air.mjs",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
   },
   "keywords": [
     "sports",
@@ -98,7 +101,8 @@
     "@types/marked-terminal": "^6.1.1",
     "@types/node": "^22.0.0",
     "@types/proper-lockfile": "^4.1.4",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitepress": "^1.6.3"
   },
   "dependencies": {
     "@agent-relay/sdk": "^2.4.7",

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -3,6 +3,8 @@ FROM nginx:alpine
 COPY index.html /usr/share/nginx/html/index.html
 COPY install.sh /usr/share/nginx/html/install.sh
 COPY logos/ /usr/share/nginx/html/logos/
+# Built VitePress docs, staged into site/docs by CI (see build-site.yml).
+COPY docs/ /usr/share/nginx/html/docs/
 
 EXPOSE 80
 

--- a/site/index.html
+++ b/site/index.html
@@ -15,7 +15,7 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>sportsclaw — Self-Evolving Sports AI</title>
+  <title>sportsclaw — Build AI that understands live sports</title>
   <meta name="description" content="Host an autonomous sports AI on Discord and Telegram. Persistent memory, live data, prediction markets. Gets smarter every day.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -215,6 +215,15 @@
       font-size: clamp(1rem, 2vw, 1.2rem);
       max-width: 650px;
       margin: 0 auto 3rem;
+    }
+
+    .hero p.hero-audience {
+      font-size: 0.8rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      opacity: 0.7;
+      margin: -1.5rem auto 3rem;
     }
 
     .terminal-container {
@@ -967,9 +976,11 @@
   <main>
     <!-- Hero -->
     <section class="hero container">
-      <div class="badge">v0.7.2 Released</div>
-      <h1>Self-Evolving Sports AI for Your Chat Apps</h1>
-      <p>Host an autonomous sports AI on Discord and Telegram. It builds persistent memory, adapts to your users, and gets smarter every day.</p>
+      <!-- TODO: build-inject version from package.json instead of hardcoding -->
+      <div class="badge">OPEN SOURCE · MIT · v0.26.2</div>
+      <h1>Build AI that understands live sports.</h1>
+      <p>One open-source engine with keyless live data, market odds, and real-time game events built in. Ship chat bots, broadcast widgets, and odds trackers in minutes — not months of data plumbing.</p>
+      <p class="hero-audience">For fans · broadcasters · sportsbooks · teams &amp; leagues</p>
 
       <div style="position: relative; display: inline-block;">
         <div id="copy-feedback" class="copy-feedback">Copied!</div>
@@ -981,6 +992,7 @@
           </button>
         </div>
       </div>
+      <p style="margin-top: 10px; font-size: 0.85em; color: #888;">macOS / Linux · verify the published SHA-256 before running. Windows: <code>npm install -g sportsclaw-engine-core</code></p>
 
       <div class="terminal-container">
         <div class="terminal">
@@ -1012,6 +1024,8 @@
           <div style="color: #e0e0e0;"><strong>Arsenal leads the Premier League</strong> with 61 points from 28 games (18W-7D-3L). They have a 5-point lead over second-place Manchester City.</div>
           <br>
           <div style="color: #e0e0e0;">On Polymarket, the <strong>Oklahoma City Thunder</strong> are the current favorites to win the 2026 NBA Finals at 34.5%, followed by the Spurs (12.6%) and Nuggets (11.5%).</div>
+          <br>
+          <div style="color: #555; font-size: 0.82em;">// illustrative output — live values vary by query time</div>
         </div>
       </div>
     </section>

--- a/site/index.html
+++ b/site/index.html
@@ -976,8 +976,8 @@
   <main>
     <!-- Hero -->
     <section class="hero container">
-      <!-- TODO: build-inject version from package.json instead of hardcoding -->
-      <div class="badge">OPEN SOURCE · MIT · v0.26.2</div>
+      <!-- #version is substituted from the release tag at deploy time (build-site.yml). -->
+      <div class="badge">OPEN SOURCE · MIT · <span id="version">v0.26.2</span></div>
       <h1>Build AI that understands live sports.</h1>
       <p>One open-source engine with keyless live data, market odds, and real-time game events built in. Ship chat bots, broadcast widgets, and odds trackers in minutes — not months of data plumbing.</p>
       <p class="hero-audience">For fans · broadcasters · sportsbooks · teams &amp; leagues</p>


### PR DESCRIPTION
## What

A real documentation site plus a refreshed landing page, both served same-origin from the repo.

- **`docs/`** — VitePress site with an editorial theme and on-scroll reveals: Getting Started, Core Concepts, Building Bots (Discord/Telegram/alerts), Sports Data & Markets (coverage, odds, images, Machina), Deployment (Docker, daemon, OpenShell), Advanced (MCP, watchers, operator), and a CLI reference. Coverage is attributed to **sports-skills** (linked).
- **`site/index.html`** — refreshed hero + a six-card feature grid with clean monospace ASCII motifs.
- **CI + Dockerfile** — build the docs and serve them alongside the landing page under `/docs`.
- **README** — drop the stray emoji from the title.
- **package.json** — `vitepress` devDep + `docs:dev/build/preview` scripts.

## Build
`npm run docs:build` passes with dead-link checking on. Build artifacts (`docs/.vitepress/dist`, `site/docs`) are gitignored; CI builds them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)