### PR TITLE
feat(machina): `sportsclaw machina connect` — one-command premium pod wiring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,8 @@ import {
   saveMcpConfigs,
   removeMcpConfig,
   getMcpConfigPath,
+  mcpEnvKey,
+  isValidMcpServerName,
   McpManager,
 } from "./mcp.js";
 import { WatchManager } from "./watch.js";
@@ -1084,11 +1086,13 @@ async function cmdDoctor(_opts?: { fromChat?: boolean }): Promise<void> {
   const machinaPods = Object.entries(mcpServers).filter(([, c]) => c.provider === "machina");
   let machinaCli = false;
   try {
-    execFileSync("machina", ["version"], { stdio: "ignore" });
+    execFileSync("machina", ["version"], { stdio: "ignore", timeout: 5_000 });
     machinaCli = true;
   } catch (e) {
-    // ENOENT = not installed; any other error still means the binary is present
-    machinaCli = (e as { code?: string }).code !== "ENOENT";
+    // ENOENT = not installed; EACCES = present but not executable. Any other
+    // error (non-zero exit, timeout) still means the binary is present.
+    const code = (e as { code?: string }).code;
+    machinaCli = code !== "ENOENT" && code !== "EACCES";
   }
   if (machinaPods.length > 0) {
     console.log(
@@ -2418,7 +2422,7 @@ async function cmdMcp(args: string[]): Promise<void> {
     }
 
     // Validate name
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    if (!isValidMcpServerName(name)) {
       console.error(`Invalid server name "${name}". Use only alphanumeric, hyphens, and underscores.`);
       process.exit(1);
     }
@@ -2437,7 +2441,7 @@ async function cmdMcp(args: string[]): Promise<void> {
 
     // Store token in ~/.sportsclaw/.env (not in mcp.json — keep secrets separate)
     if (token) {
-      const envKey = `SPORTSCLAW_MCP_TOKEN_${name.replace(/-/g, "_").toUpperCase()}`;
+      const envKey = mcpEnvKey(name);
       writeEnvVar(ENV_PATH, envKey, token);
       console.log(pc.dim(`Token saved to ${ENV_PATH} as ${envKey}`));
     }
@@ -2453,7 +2457,7 @@ async function cmdMcp(args: string[]): Promise<void> {
     console.log(pc.dim(`Config: ${getMcpConfigPath()}`));
 
     if (!token) {
-      const envKey = `SPORTSCLAW_MCP_TOKEN_${name.replace(/-/g, "_").toUpperCase()}`;
+      const envKey = mcpEnvKey(name);
       console.log("");
       console.log(pc.yellow("No token provided. If the server requires auth, add one:"));
       console.log(`  sportsclaw mcp add ${url} --name ${name} --token <your-token>`);
@@ -2616,12 +2620,18 @@ async function cmdMachina(args: string[]): Promise<void> {
     raw = execFileSync("machina", connectArgs, {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
     });
   } catch (err) {
     const e = err as { code?: string; stdout?: Buffer | string; stderr?: Buffer | string };
     if (e.code === "ENOENT") {
       console.error(pc.red("machina-cli not found."));
       console.error(`  Install it: ${pc.cyan("pip install machina-cli")}, then ${pc.cyan("machina login")}.`);
+      process.exit(1);
+    }
+    if (e.code === "ETIMEDOUT") {
+      console.error(pc.red("machina connect timed out (30s) — the pod may be unreachable."));
+      console.error(`  Check ${pc.cyan("machina status")} and retry.`);
       process.exit(1);
     }
     const out = (e.stdout ?? "").toString().trim();
@@ -2662,21 +2672,34 @@ async function cmdMachina(args: string[]): Promise<void> {
     console.error(pc.red("machina connect returned no token. Retry, or check `machina connect --reveal`."));
     process.exit(1);
   }
+  // `name` becomes the mcp.json key, the env-key segment, AND a tool-cache
+  // filename — validate it the same way `mcp add` does (no path traversal).
+  if (!isValidMcpServerName(name)) {
+    console.error(pc.red(`machina connect returned an invalid pod name ("${name}").`));
+    process.exit(1);
+  }
+  // The token is written verbatim into ~/.sportsclaw/.env — a newline would
+  // inject additional dotenv lines, so refuse one.
+  if (/[\r\n]/.test(token)) {
+    console.error(pc.red("machina connect returned a malformed token (contains a newline)."));
+    process.exit(1);
+  }
+  // We pass --mint, so a durable X-Api-Token is expected. Refuse any other
+  // header rather than writing a secret into mcp.json.
+  if (header.toLowerCase() !== "x-api-token") {
+    console.error(pc.red(`Unexpected auth header from machina connect ("${header}"); expected X-Api-Token.`));
+    console.error(`  Upgrade machina-cli (${pc.cyan("pip install --upgrade machina-cli")}) and retry.`);
+    process.exit(1);
+  }
 
-  // 3. Register the MCP server, mirroring `mcp add`: config in mcp.json, secret
-  //    in ~/.sportsclaw/.env. The standard X-Api-Token is injected from env by
-  //    the MCP manager; a non-standard header is set inline as a fallback.
+  // Register like `mcp add`: write the secret to ~/.sportsclaw/.env FIRST (so a
+  // failure never leaves a tokenless config), then the config in mcp.json. The
+  // MCP manager injects SPORTSCLAW_MCP_TOKEN_<NAME> as X-Api-Token at connect time.
+  writeEnvVar(ENV_PATH, mcpEnvKey(name), token);
   const configs = loadMcpConfigs();
   const isUpdate = name in configs;
-  if (header.toLowerCase() === "x-api-token") {
-    configs[name] = { url, provider: "machina" };
-    saveMcpConfigs(configs);
-    const envKey = `SPORTSCLAW_MCP_TOKEN_${name.replace(/-/g, "_").toUpperCase()}`;
-    writeEnvVar(ENV_PATH, envKey, token);
-  } else {
-    configs[name] = { url, provider: "machina", headers: { [header]: token } };
-    saveMcpConfigs(configs);
-  }
+  configs[name] = { url, provider: "machina" };
+  saveMcpConfigs(configs);
 
   console.log(pc.green(isUpdate ? `Reconnected Machina pod "${name}"` : `Connected Machina pod "${name}"`));
   console.log(`  URL: ${url}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@
 
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 import { Transform, type TransformCallback } from "node:stream";
@@ -1077,6 +1077,33 @@ async function cmdDoctor(_opts?: { fromChat?: boolean }): Promise<void> {
   // 8. Schema directory location
   if (schemas.length > 0) {
     console.log(pc.green("  ✓") + ` Schema dir: ${getSchemaDir()}`);
+  }
+
+  // 8b. Machina premium (optional) — connected pods + machina-cli presence
+  const mcpServers = loadMcpConfigs();
+  const machinaPods = Object.entries(mcpServers).filter(([, c]) => c.provider === "machina");
+  let machinaCli = false;
+  try {
+    execFileSync("machina", ["version"], { stdio: "ignore" });
+    machinaCli = true;
+  } catch (e) {
+    // ENOENT = not installed; any other error still means the binary is present
+    machinaCli = (e as { code?: string }).code !== "ENOENT";
+  }
+  if (machinaPods.length > 0) {
+    console.log(
+      pc.green("  ✓") +
+        ` Machina premium: ${machinaPods.length} pod(s) connected (${machinaPods.map(([n]) => n).join(", ")})`,
+    );
+  } else if (machinaCli) {
+    console.log(
+      pc.dim("  •") + ` Machina premium: machina-cli installed — connect with ${pc.cyan("sportsclaw machina connect")}`,
+    );
+  } else {
+    console.log(
+      pc.dim("  •") +
+        ` Machina premium (optional): ${pc.cyan("pip install machina-cli")} then ${pc.cyan("sportsclaw machina connect")}`,
+    );
   }
 
   // 9. Config drift across env, ~/.sportsclaw/.env, and config.json
@@ -2541,6 +2568,128 @@ function cmdLogout(args: string[]): void {
 }
 
 // ---------------------------------------------------------------------------
+// CLI: `sportsclaw machina connect [project]` — wire a Machina premium pod
+// into this agent via the machina-cli `connect` resolver (no pasted URL).
+// ---------------------------------------------------------------------------
+
+async function cmdMachina(args: string[]): Promise<void> {
+  const sub = args[0];
+  if (sub !== "connect") {
+    console.error("Usage: sportsclaw machina connect [project] [--org <org>] [--probe]");
+    console.error("  Connects a Machina premium pod via machina-cli (mints a durable key).");
+    process.exit(1);
+  }
+
+  let project: string | undefined;
+  let org: string | undefined;
+  let probe = false;
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--org" && args[i + 1]) org = args[++i];
+    else if (a === "--probe") probe = true;
+    else if (!a.startsWith("-") && !project) project = a;
+  }
+
+  const parse = (s: string): Record<string, unknown> | null => {
+    try {
+      return JSON.parse(s) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  };
+
+  // Resolve the connection bundle via machina-cli (it owns auth + MCP
+  // resolution). --mint yields a durable X-Api-Token (no expiry); --reveal
+  // returns the real token so we can register it.
+  const connectArgs = [
+    "connect",
+    ...(project ? [project] : []),
+    "--json",
+    "--reveal",
+    "--mint",
+    ...(org ? ["--org", org] : []),
+    ...(probe ? ["--probe"] : []),
+  ];
+
+  let raw: string;
+  try {
+    raw = execFileSync("machina", connectArgs, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    const e = err as { code?: string; stdout?: Buffer | string; stderr?: Buffer | string };
+    if (e.code === "ENOENT") {
+      console.error(pc.red("machina-cli not found."));
+      console.error(`  Install it: ${pc.cyan("pip install machina-cli")}, then ${pc.cyan("machina login")}.`);
+      process.exit(1);
+    }
+    const out = (e.stdout ?? "").toString().trim();
+    const errText = (e.stderr ?? "").toString().trim();
+    const combined = `${out}\n${errText}`;
+    if (/no such command|usage: machina/i.test(combined) && !parse(out)?.error) {
+      console.error(pc.red("This machina-cli is too old — it has no `connect` command."));
+      console.error(`  Upgrade it: ${pc.cyan("pip install --upgrade machina-cli")}`);
+      process.exit(1);
+    }
+    const msg = parse(out)?.error ?? errText ?? "machina connect failed";
+    console.error(pc.red(`Could not connect: ${String(msg)}`));
+    if (/auth|session|login|not authenticated/i.test(combined)) {
+      console.error(`  Run ${pc.cyan("machina login")} first, then retry.`);
+    } else if (/organization|org/i.test(combined)) {
+      console.error(`  Pass ${pc.cyan("--org <org-id>")} or set a default org in machina-cli.`);
+    }
+    process.exit(1);
+  }
+
+  const bundle = parse(raw.trim());
+  if (!bundle || bundle.error) {
+    console.error(pc.red(`Could not connect: ${String(bundle?.error ?? "unexpected output from machina connect")}`));
+    process.exit(1);
+  }
+
+  const name = bundle.name as string | undefined;
+  const url = bundle.url as string | undefined;
+  const token = bundle.token as string | null | undefined;
+  const header = (bundle.auth_header as string | undefined) ?? "X-Api-Token";
+  const durable = bundle.durable === true;
+
+  if (!name || !url) {
+    console.error(pc.red("machina connect did not return a usable url/name."));
+    process.exit(1);
+  }
+  if (!token) {
+    console.error(pc.red("machina connect returned no token. Retry, or check `machina connect --reveal`."));
+    process.exit(1);
+  }
+
+  // 3. Register the MCP server, mirroring `mcp add`: config in mcp.json, secret
+  //    in ~/.sportsclaw/.env. The standard X-Api-Token is injected from env by
+  //    the MCP manager; a non-standard header is set inline as a fallback.
+  const configs = loadMcpConfigs();
+  const isUpdate = name in configs;
+  if (header.toLowerCase() === "x-api-token") {
+    configs[name] = { url, provider: "machina" };
+    saveMcpConfigs(configs);
+    const envKey = `SPORTSCLAW_MCP_TOKEN_${name.replace(/-/g, "_").toUpperCase()}`;
+    writeEnvVar(ENV_PATH, envKey, token);
+  } else {
+    configs[name] = { url, provider: "machina", headers: { [header]: token } };
+    saveMcpConfigs(configs);
+  }
+
+  console.log(pc.green(isUpdate ? `Reconnected Machina pod "${name}"` : `Connected Machina pod "${name}"`));
+  console.log(`  URL: ${url}`);
+  console.log(pc.dim(`  Auth: ${header}${durable ? " (durable key)" : " (session token — may expire)"}`));
+  console.log(pc.dim(`  Config: ${getMcpConfigPath()}`));
+  if (!durable) {
+    console.log(pc.yellow("  Note: not a durable key — re-run this if the connection later returns 401."));
+  }
+  console.log("");
+  console.log(`Verify with ${pc.cyan("sportsclaw mcp list")}. Restart any running listeners to pick it up.`);
+}
+
+// ---------------------------------------------------------------------------
 // CLI: `sportsclaw --help` — usage text
 // ---------------------------------------------------------------------------
 
@@ -2577,6 +2726,7 @@ function printHelp(): void {
   console.log("  sportsclaw mcp add <url>           Connect an MCP server (Machina pod, etc.)");
   console.log("  sportsclaw mcp remove <name>       Disconnect an MCP server");
   console.log("  sportsclaw mcp list                List configured MCP servers");
+  console.log("  sportsclaw machina connect [proj]  Connect a Machina premium pod (via machina-cli)");
   console.log("  sportsclaw watch <sport> <command>  Watch an endpoint for realtime changes");
   console.log("  sportsclaw watch --config=<path>   Run multiple watchers from config file");
   console.log("  sportsclaw plugin install <name>   Install an optional plugin");
@@ -2804,6 +2954,8 @@ case "plugin":
       return cmdPlugin(subArgs);
     case "mcp":
       return cmdMcp(subArgs);
+    case "machina":
+      return cmdMachina(subArgs);
     case "watch":
       return cmdWatch(subArgs);
     default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ import {
   getMcpConfigPath,
   mcpEnvKey,
   isValidMcpServerName,
+  envKeyCollision,
   McpManager,
 } from "./mcp.js";
 import { WatchManager } from "./watch.js";
@@ -1089,10 +1090,10 @@ async function cmdDoctor(_opts?: { fromChat?: boolean }): Promise<void> {
     execFileSync("machina", ["version"], { stdio: "ignore", timeout: 5_000 });
     machinaCli = true;
   } catch (e) {
-    // ENOENT = not installed; EACCES = present but not executable. Any other
+    // ENOENT = not installed; EACCES/EPERM = present but not runnable. Any other
     // error (non-zero exit, timeout) still means the binary is present.
     const code = (e as { code?: string }).code;
-    machinaCli = code !== "ENOENT" && code !== "EACCES";
+    machinaCli = code !== "ENOENT" && code !== "EACCES" && code !== "EPERM";
   }
   if (machinaPods.length > 0) {
     console.log(
@@ -2429,6 +2430,11 @@ async function cmdMcp(args: string[]): Promise<void> {
 
     // Build server config
     const configs = loadMcpConfigs();
+    const collision = envKeyCollision(name, configs);
+    if (collision) {
+      console.error(`Server name "${name}" shares a token slot with existing server "${collision}". Remove it first or use a distinct name.`);
+      process.exit(1);
+    }
     const isUpdate = name in configs;
     const config: McpServerConfig = {
       url,
@@ -2642,7 +2648,7 @@ async function cmdMachina(args: string[]): Promise<void> {
       console.error(`  Upgrade it: ${pc.cyan("pip install --upgrade machina-cli")}`);
       process.exit(1);
     }
-    const msg = parse(out)?.error ?? errText ?? "machina connect failed";
+    const msg = parse(out)?.error || errText || "machina connect failed";
     console.error(pc.red(`Could not connect: ${String(msg)}`));
     if (/auth|session|login|not authenticated/i.test(combined)) {
       console.error(`  Run ${pc.cyan("machina login")} first, then retry.`);
@@ -2658,14 +2664,34 @@ async function cmdMachina(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const name = bundle.name as string | undefined;
-  const url = bundle.url as string | undefined;
-  const token = bundle.token as string | null | undefined;
-  const header = (bundle.auth_header as string | undefined) ?? "X-Api-Token";
+  // The bundle is untrusted external JSON (Record<string, unknown>) — narrow by
+  // runtime type, never `as`, so a non-string field can't slip through coercion.
+  const name = typeof bundle.name === "string" ? bundle.name : undefined;
+  const url = typeof bundle.url === "string" ? bundle.url : undefined;
+  const token = typeof bundle.token === "string" ? bundle.token : undefined;
+  const header = typeof bundle.auth_header === "string" ? bundle.auth_header : "X-Api-Token";
   const durable = bundle.durable === true;
 
   if (!name || !url) {
     console.error(pc.red("machina connect did not return a usable url/name."));
+    process.exit(1);
+  }
+  // The minted token is sent to `url` as a bearer header, so refuse to persist a
+  // url we can't parse or one that would send the secret in cleartext to a
+  // remote host (http is allowed only for loopback dev pods).
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    console.error(pc.red(`machina connect returned an unparseable url ("${url}").`));
+    process.exit(1);
+  }
+  const isLoopback =
+    parsedUrl.hostname === "localhost" ||
+    parsedUrl.hostname === "127.0.0.1" ||
+    parsedUrl.hostname === "::1";
+  if (parsedUrl.protocol !== "https:" && !(parsedUrl.protocol === "http:" && isLoopback)) {
+    console.error(pc.red(`Refusing to send the token to a non-HTTPS url ("${url}").`));
     process.exit(1);
   }
   if (!token) {
@@ -2692,14 +2718,29 @@ async function cmdMachina(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const configs = loadMcpConfigs();
+  // Reject a name that shares a token slot with a different existing server —
+  // otherwise resolveTokens would inject one pod's token for the other.
+  const collision = envKeyCollision(name, configs);
+  if (collision) {
+    console.error(pc.red(`Pod name "${name}" shares a token slot with existing server "${collision}".`));
+    console.error(`  Remove "${collision}" first (${pc.cyan(`sportsclaw mcp remove ${collision}`)}), or connect under a distinct name.`);
+    process.exit(1);
+  }
+  const isUpdate = name in configs;
+
   // Register like `mcp add`: write the secret to ~/.sportsclaw/.env FIRST (so a
   // failure never leaves a tokenless config), then the config in mcp.json. The
   // MCP manager injects SPORTSCLAW_MCP_TOKEN_<NAME> as X-Api-Token at connect time.
-  writeEnvVar(ENV_PATH, mcpEnvKey(name), token);
-  const configs = loadMcpConfigs();
-  const isUpdate = name in configs;
-  configs[name] = { url, provider: "machina" };
-  saveMcpConfigs(configs);
+  try {
+    writeEnvVar(ENV_PATH, mcpEnvKey(name), token);
+    configs[name] = { url, provider: "machina" };
+    saveMcpConfigs(configs);
+  } catch (e) {
+    console.error(pc.red(`Failed to save the connection: ${(e as Error).message}`));
+    console.error(`  The token may be in ${ENV_PATH} but the pod was not registered — re-run to retry.`);
+    process.exit(1);
+  }
 
   console.log(pc.green(isUpdate ? `Reconnected Machina pod "${name}"` : `Connected Machina pod "${name}"`));
   console.log(`  URL: ${url}`);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -49,6 +49,23 @@ export function isValidMcpServerName(name: string): boolean {
   return /^[a-zA-Z0-9_-]+$/.test(name);
 }
 
+/**
+ * If a *different* existing server resolves to the same env-key as `name`,
+ * return its name. mcpEnvKey folds case and `-`/`_`, so "my-pod" and "my_pod"
+ * share one token slot — registering both would make resolveTokens inject one
+ * pod's token into requests for the other. Callers reject the collision.
+ */
+export function envKeyCollision(
+  name: string,
+  configs: Record<string, McpServerConfig>
+): string | null {
+  const key = mcpEnvKey(name);
+  for (const existing of Object.keys(configs)) {
+    if (existing !== name && mcpEnvKey(existing) === key) return existing;
+  }
+  return null;
+}
+
 /** Load the user-managed MCP config from ~/.sportsclaw/mcp.json */
 export function loadMcpConfigs(): Record<string, McpServerConfig> {
   if (!existsSync(MCP_CONFIG_PATH)) return {};

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -35,6 +35,20 @@ import { join } from "node:path";
 const MCP_CONFIG_DIR = join(homedir(), ".sportsclaw");
 const MCP_CONFIG_PATH = join(MCP_CONFIG_DIR, "mcp.json");
 
+/**
+ * Env-var key holding a server's bearer token. This is the contract between the
+ * writer (`mcp add` / `machina connect`) and the reader (`resolveTokens`) — keep
+ * it single-source so the two can never drift.
+ */
+export function mcpEnvKey(name: string): string {
+  return `SPORTSCLAW_MCP_TOKEN_${name.replace(/-/g, "_").toUpperCase()}`;
+}
+
+/** A server name is safe to use as a config key, env-key segment, and cache filename. */
+export function isValidMcpServerName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name);
+}
+
 /** Load the user-managed MCP config from ~/.sportsclaw/mcp.json */
 export function loadMcpConfigs(): Record<string, McpServerConfig> {
   if (!existsSync(MCP_CONFIG_PATH)) return {};
@@ -248,7 +262,7 @@ export class McpManager {
         );
 
       if (!hasAuth) {
-        const envKey = `SPORTSCLAW_MCP_TOKEN_${name.replace(/-/g, "_").toUpperCase()}`;
+        const envKey = mcpEnvKey(name);
         const token = process.env[envKey];
         if (token) {
           config.headers = { ...config.headers, "X-Api-Token": token };

--- a/src/prompts/sections.ts
+++ b/src/prompts/sections.ts
@@ -53,7 +53,7 @@ export const PREMIUM_SIGNAL = `## Premium Signal
 
 A tool result may carry an \`upgrade\` field. That is the data layer's signal that a public API rate-limited the request, or that licensed / real-time data exists beyond what the free skill returned. It is informational — never a blocker, and never something you decide on your own.
 
-- Answer first with the data you DID get. Only then, if a real user is on the other end, add ONE short line surfacing the option — what it unlocks and the \`sports-skills premium\` path (licensed / real-time feeds via Machina).
+- Answer first with the data you DID get. Only then, if a real user is on the other end, add ONE short line surfacing the option — what it unlocks and how to get it: the \`sports-skills premium\` path, or \`sportsclaw machina connect\` to wire a licensed Machina pod (real-time / licensed feeds) into this agent.
  - Surface it ONLY when a tool result actually contains the \`upgrade\` field. Never invent a premium hint — what is premium is decided by the data layer, not by you.
 - Keep it to a single, non-pushy line, and do not repeat it within the same conversation.
 - Omit it entirely from autonomous broadcasts, alerts, and \`[SILENT]\` ticks.`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,6 +404,8 @@ export interface McpServerConfig {
   timeoutMs?: number;
   /** Server description injected into LLM system prompt for tool context */
   description?: string;
+  /** Origin of this server config (e.g. "machina" when added via `sportsclaw machina connect`). */
+  provider?: "machina";
 }
 
 // ---------------------------------------------------------------------------

--- a/test/mcp-helpers.test.mjs
+++ b/test/mcp-helpers.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * MCP helper utilities — test suite
+ *
+ * Guards the two helpers shared by `mcp add` and `machina connect`:
+ *  1. mcpEnvKey() — derives the ~/.sportsclaw/.env key from a server name.
+ *  2. isValidMcpServerName() — gates names that become mcp.json keys, env-key
+ *     segments, and tool-cache filenames (path-traversal guard).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { mcpEnvKey, isValidMcpServerName } from "../dist/mcp.js";
+
+describe("mcpEnvKey", () => {
+  it("uppercases and converts hyphens to underscores", () => {
+    assert.equal(mcpEnvKey("my-pod"), "SPORTSCLAW_MCP_TOKEN_MY_POD");
+  });
+
+  it("leaves underscore/alphanumeric names intact", () => {
+    assert.equal(mcpEnvKey("pod_1"), "SPORTSCLAW_MCP_TOKEN_POD_1");
+  });
+
+  it("is stable across the two call sites (mcp add / machina connect)", () => {
+    assert.equal(mcpEnvKey("acme-feed"), mcpEnvKey("acme-feed"));
+  });
+});
+
+describe("isValidMcpServerName", () => {
+  it("accepts alphanumerics, hyphens, and underscores", () => {
+    for (const name of ["pod", "my-pod", "pod_1", "ABC-123_x"]) {
+      assert.ok(isValidMcpServerName(name), `${name} should be valid`);
+    }
+  });
+
+  it("rejects path-traversal and separator characters", () => {
+    for (const name of ["../etc", "a/b", "a\\b", "a.b", "a b", "a:b", ""]) {
+      assert.ok(!isValidMcpServerName(name), `${JSON.stringify(name)} should be rejected`);
+    }
+  });
+});

--- a/test/mcp-helpers.test.mjs
+++ b/test/mcp-helpers.test.mjs
@@ -10,7 +10,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { mcpEnvKey, isValidMcpServerName } from "../dist/mcp.js";
+import { mcpEnvKey, isValidMcpServerName, envKeyCollision } from "../dist/mcp.js";
 
 describe("mcpEnvKey", () => {
   it("uppercases and converts hyphens to underscores", () => {
@@ -21,8 +21,26 @@ describe("mcpEnvKey", () => {
     assert.equal(mcpEnvKey("pod_1"), "SPORTSCLAW_MCP_TOKEN_POD_1");
   });
 
-  it("is stable across the two call sites (mcp add / machina connect)", () => {
-    assert.equal(mcpEnvKey("acme-feed"), mcpEnvKey("acme-feed"));
+  it("produces the documented key shape (the resolveTokens contract)", () => {
+    assert.equal(mcpEnvKey("acme-feed"), "SPORTSCLAW_MCP_TOKEN_ACME_FEED");
+  });
+});
+
+describe("envKeyCollision", () => {
+  it("flags a different name that folds to the same env-key", () => {
+    const configs = { "my-pod": { url: "https://a" } };
+    assert.equal(envKeyCollision("my_pod", configs), "my-pod");
+    assert.equal(envKeyCollision("MY-POD", configs), "my-pod");
+  });
+
+  it("does not flag the same name (reconnect is not a collision)", () => {
+    const configs = { "my-pod": { url: "https://a" } };
+    assert.equal(envKeyCollision("my-pod", configs), null);
+  });
+
+  it("returns null when no existing name shares the slot", () => {
+    const configs = { "other-pod": { url: "https://a" } };
+    assert.equal(envKeyCollision("my-pod", configs), null);
   });
 });
 

--- a/test/premium-signal.test.mjs
+++ b/test/premium-signal.test.mjs
@@ -28,6 +28,10 @@ describe("premium signal prompt section", () => {
     assert.ok(/sports-skills premium/.test(PREMIUM_SIGNAL));
   });
 
+  it("offers the native `sportsclaw machina connect` path", () => {
+    assert.ok(/sportsclaw machina connect/.test(PREMIUM_SIGNAL));
+  });
+
   it("answers with data first and stays non-pushy", () => {
     assert.ok(/answer first/i.test(PREMIUM_SIGNAL));
     assert.ok(/single|one short line/i.test(PREMIUM_SIGNAL));


### PR DESCRIPTION
## What

The sportsclaw side of the native Machina integration — the U11/U12/U13 units. Closes the loop to **one command** on top of the merged `machina connect` (machina-cli #22).

- **`sportsclaw machina connect [project] [--org <org>] [--probe]`** — shells `machina connect --json --reveal --mint`, parses the bundle, and registers the MCP server exactly like `mcp add`: config in `mcp.json` (tagged `provider: "machina"`), the durable `X-Api-Token` in `~/.sportsclaw/.env` as `SPORTSCLAW_MCP_TOKEN_<PROJECT>`. Reuses the existing MCP connect + pod-discovery path — **no new transport/auth code**, and `--mint` gives a durable key so **nothing expires**.
- **Graceful degradation** — clear, actionable messages when machina-cli is missing (`ENOENT`), too old to have `connect`, or when auth/org is required (points at `machina login` / `--org`).
- **`doctor`** — reports Machina premium status (connected pods, CLI present, or how to connect). Informational only; never fails the check (premium is optional).
- **`PREMIUM_SIGNAL`** — now surfaces `sportsclaw machina connect` alongside the `sports-skills premium` path; the test asserts both (and all prior guards stay green).

`McpServerConfig` gains an optional `provider` field.

## Verification

tsc strict clean; premium-signal + guide tests pass (15). Smoke-verified the degradation paths against the locally-installed (older) machina-cli: it correctly prints the "too old — upgrade" guidance, and `doctor` detects the CLI. The live end-to-end connect activates once machina-cli ships #21/#22.

Builds on machina-cli #21 (`mcp url`) and #22 (`connect`). The header sportsclaw injects from env (`X-Api-Token`, mcp.ts:254) already matches `machina connect`'s `auth_header`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)