### PR TITLE
refactor(machina): extract testable validateConnectBundle()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ import {
   mcpEnvKey,
   isValidMcpServerName,
   envKeyCollision,
+  validateConnectBundle,
   McpManager,
 } from "./mcp.js";
 import { WatchManager } from "./watch.js";
@@ -2658,75 +2659,14 @@ async function cmdMachina(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const bundle = parse(raw.trim());
-  if (!bundle || bundle.error) {
-    console.error(pc.red(`Could not connect: ${String(bundle?.error ?? "unexpected output from machina connect")}`));
-    process.exit(1);
-  }
-
-  // The bundle is untrusted external JSON (Record<string, unknown>) — narrow by
-  // runtime type, never `as`, so a non-string field can't slip through coercion.
-  const name = typeof bundle.name === "string" ? bundle.name : undefined;
-  const url = typeof bundle.url === "string" ? bundle.url : undefined;
-  const token = typeof bundle.token === "string" ? bundle.token : undefined;
-  const header = typeof bundle.auth_header === "string" ? bundle.auth_header : "X-Api-Token";
-  const durable = bundle.durable === true;
-
-  if (!name || !url) {
-    console.error(pc.red("machina connect did not return a usable url/name."));
-    process.exit(1);
-  }
-  // The minted token is sent to `url` as a bearer header, so refuse to persist a
-  // url we can't parse or one that would send the secret in cleartext to a
-  // remote host (http is allowed only for loopback dev pods).
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(url);
-  } catch {
-    console.error(pc.red(`machina connect returned an unparseable url ("${url}").`));
-    process.exit(1);
-  }
-  const isLoopback =
-    parsedUrl.hostname === "localhost" ||
-    parsedUrl.hostname === "127.0.0.1" ||
-    parsedUrl.hostname === "::1";
-  if (parsedUrl.protocol !== "https:" && !(parsedUrl.protocol === "http:" && isLoopback)) {
-    console.error(pc.red(`Refusing to send the token to a non-HTTPS url ("${url}").`));
-    process.exit(1);
-  }
-  if (!token) {
-    console.error(pc.red("machina connect returned no token. Retry, or check `machina connect --reveal`."));
-    process.exit(1);
-  }
-  // `name` becomes the mcp.json key, the env-key segment, AND a tool-cache
-  // filename — validate it the same way `mcp add` does (no path traversal).
-  if (!isValidMcpServerName(name)) {
-    console.error(pc.red(`machina connect returned an invalid pod name ("${name}").`));
-    process.exit(1);
-  }
-  // The token is written verbatim into ~/.sportsclaw/.env — a newline would
-  // inject additional dotenv lines, so refuse one.
-  if (/[\r\n]/.test(token)) {
-    console.error(pc.red("machina connect returned a malformed token (contains a newline)."));
-    process.exit(1);
-  }
-  // We pass --mint, so a durable X-Api-Token is expected. Refuse any other
-  // header rather than writing a secret into mcp.json.
-  if (header.toLowerCase() !== "x-api-token") {
-    console.error(pc.red(`Unexpected auth header from machina connect ("${header}"); expected X-Api-Token.`));
-    console.error(`  Upgrade machina-cli (${pc.cyan("pip install --upgrade machina-cli")}) and retry.`);
-    process.exit(1);
-  }
-
   const configs = loadMcpConfigs();
-  // Reject a name that shares a token slot with a different existing server —
-  // otherwise resolveTokens would inject one pod's token for the other.
-  const collision = envKeyCollision(name, configs);
-  if (collision) {
-    console.error(pc.red(`Pod name "${name}" shares a token slot with existing server "${collision}".`));
-    console.error(`  Remove "${collision}" first (${pc.cyan(`sportsclaw mcp remove ${collision}`)}), or connect under a distinct name.`);
+  const result = validateConnectBundle(parse(raw.trim()), configs);
+  if (!result.ok) {
+    console.error(pc.red(result.error));
+    if (result.hint) console.error(pc.dim(`  ${result.hint}`));
     process.exit(1);
   }
+  const { name, url, token, durable } = result;
   const isUpdate = name in configs;
 
   // Register like `mcp add`: write the secret to ~/.sportsclaw/.env FIRST (so a
@@ -2744,7 +2684,7 @@ async function cmdMachina(args: string[]): Promise<void> {
 
   console.log(pc.green(isUpdate ? `Reconnected Machina pod "${name}"` : `Connected Machina pod "${name}"`));
   console.log(`  URL: ${url}`);
-  console.log(pc.dim(`  Auth: ${header}${durable ? " (durable key)" : " (session token — may expire)"}`));
+  console.log(pc.dim(`  Auth: X-Api-Token${durable ? " (durable key)" : " (session token — may expire)"}`));
   console.log(pc.dim(`  Config: ${getMcpConfigPath()}`));
   if (!durable) {
     console.log(pc.yellow("  Note: not a durable key — re-run this if the connection later returns 401."));

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -66,6 +66,97 @@ export function envKeyCollision(
   return null;
 }
 
+export type ConnectBundleResult =
+  | { ok: true; name: string; url: string; token: string; durable: boolean }
+  | { ok: false; error: string; hint?: string };
+
+/**
+ * Validate the JSON bundle from `machina connect --json --reveal --mint` before
+ * it is persisted. Pure — no IO, no process exit; the caller maps the result to
+ * console output. `bundle` is the parsed stdout (or null if it wasn't JSON);
+ * `configs` is the current mcp.json so a token-slot collision can be rejected.
+ * On success returns the normalized, registration-ready connection.
+ */
+export function validateConnectBundle(
+  bundle: Record<string, unknown> | null,
+  configs: Record<string, McpServerConfig>
+): ConnectBundleResult {
+  if (!bundle || bundle.error) {
+    return {
+      ok: false,
+      error: `Could not connect: ${String(bundle?.error ?? "unexpected output from machina connect")}`,
+    };
+  }
+
+  // Untrusted external JSON — narrow by runtime type, never `as`, so a
+  // non-string field can't slip through coercion.
+  const name = typeof bundle.name === "string" ? bundle.name : undefined;
+  const url = typeof bundle.url === "string" ? bundle.url : undefined;
+  const token = typeof bundle.token === "string" ? bundle.token : undefined;
+  const header = typeof bundle.auth_header === "string" ? bundle.auth_header : "X-Api-Token";
+  const durable = bundle.durable === true;
+
+  if (!name || !url) {
+    return { ok: false, error: "machina connect did not return a usable url/name." };
+  }
+
+  // The minted token is sent to `url` as a bearer header, so refuse a url we
+  // can't parse or one that would send the secret in cleartext to a remote host
+  // (http is allowed only for loopback dev pods).
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return { ok: false, error: `machina connect returned an unparseable url ("${url}").` };
+  }
+  const isLoopback =
+    parsedUrl.hostname === "localhost" ||
+    parsedUrl.hostname === "127.0.0.1" ||
+    parsedUrl.hostname === "::1";
+  if (parsedUrl.protocol !== "https:" && !(parsedUrl.protocol === "http:" && isLoopback)) {
+    return { ok: false, error: `Refusing to send the token to a non-HTTPS url ("${url}").` };
+  }
+
+  if (!token) {
+    return {
+      ok: false,
+      error: "machina connect returned no token.",
+      hint: "Retry, or check `machina connect --reveal`.",
+    };
+  }
+  // `name` becomes the mcp.json key, the env-key segment, AND a tool-cache
+  // filename — validate it the same way `mcp add` does (no path traversal).
+  if (!isValidMcpServerName(name)) {
+    return { ok: false, error: `machina connect returned an invalid pod name ("${name}").` };
+  }
+  // The token is written verbatim into ~/.sportsclaw/.env — a newline would
+  // inject additional dotenv lines, so refuse one.
+  if (/[\r\n]/.test(token)) {
+    return { ok: false, error: "machina connect returned a malformed token (contains a newline)." };
+  }
+  // We pass --mint, so a durable X-Api-Token is expected. Refuse any other
+  // header rather than writing a secret into mcp.json.
+  if (header.toLowerCase() !== "x-api-token") {
+    return {
+      ok: false,
+      error: `Unexpected auth header from machina connect ("${header}"); expected X-Api-Token.`,
+      hint: "Upgrade machina-cli (pip install --upgrade machina-cli) and retry.",
+    };
+  }
+  // A different existing server folding to the same token slot would make
+  // resolveTokens inject one pod's token for the other.
+  const collision = envKeyCollision(name, configs);
+  if (collision) {
+    return {
+      ok: false,
+      error: `Pod name "${name}" shares a token slot with existing server "${collision}".`,
+      hint: `Remove "${collision}" first (sportsclaw mcp remove ${collision}), or connect under a distinct name.`,
+    };
+  }
+
+  return { ok: true, name, url, token, durable };
+}
+
 /** Load the user-managed MCP config from ~/.sportsclaw/mcp.json */
 export function loadMcpConfigs(): Record<string, McpServerConfig> {
   if (!existsSync(MCP_CONFIG_PATH)) return {};

--- a/test/mcp-helpers.test.mjs
+++ b/test/mcp-helpers.test.mjs
@@ -10,7 +10,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { mcpEnvKey, isValidMcpServerName, envKeyCollision } from "../dist/mcp.js";
+import {
+  mcpEnvKey,
+  isValidMcpServerName,
+  envKeyCollision,
+  validateConnectBundle,
+} from "../dist/mcp.js";
 
 describe("mcpEnvKey", () => {
   it("uppercases and converts hyphens to underscores", () => {
@@ -41,6 +46,75 @@ describe("envKeyCollision", () => {
   it("returns null when no existing name shares the slot", () => {
     const configs = { "other-pod": { url: "https://a" } };
     assert.equal(envKeyCollision("my-pod", configs), null);
+  });
+});
+
+describe("validateConnectBundle", () => {
+  const good = {
+    name: "nba-premium",
+    url: "https://pod.machina.gg/mcp/sse",
+    token: "sk_live_abc123",
+    auth_header: "X-Api-Token",
+    durable: true,
+  };
+
+  it("accepts a well-formed https bundle and normalizes it", () => {
+    const r = validateConnectBundle(good, {});
+    assert.equal(r.ok, true);
+    assert.deepEqual(r, {
+      ok: true,
+      name: "nba-premium",
+      url: "https://pod.machina.gg/mcp/sse",
+      token: "sk_live_abc123",
+      durable: true,
+    });
+  });
+
+  it("allows http only for a loopback dev pod", () => {
+    assert.equal(validateConnectBundle({ ...good, url: "http://localhost:8080/mcp/sse" }, {}).ok, true);
+    const remote = validateConnectBundle({ ...good, url: "http://pod.machina.gg/mcp/sse" }, {});
+    assert.equal(remote.ok, false);
+    assert.match(remote.error, /non-HTTPS/i);
+  });
+
+  it("rejects a null bundle or a CLI error bundle", () => {
+    assert.match(validateConnectBundle(null, {}).error, /Could not connect/);
+    assert.match(validateConnectBundle({ error: "no session" }, {}).error, /no session/);
+  });
+
+  it("rejects non-string / missing name or url (no coercion)", () => {
+    assert.equal(validateConnectBundle({ ...good, name: 42 }, {}).ok, false);
+    assert.equal(validateConnectBundle({ ...good, url: undefined }, {}).ok, false);
+  });
+
+  it("rejects an unparseable url", () => {
+    assert.match(validateConnectBundle({ ...good, url: "not a url" }, {}).error, /unparseable/i);
+  });
+
+  it("rejects a missing token with a reveal hint", () => {
+    const r = validateConnectBundle({ ...good, token: null }, {});
+    assert.equal(r.ok, false);
+    assert.match(r.hint, /--reveal/);
+  });
+
+  it("rejects a path-traversal pod name", () => {
+    assert.equal(validateConnectBundle({ ...good, name: "../etc/passwd" }, {}).ok, false);
+  });
+
+  it("rejects a token containing a newline (dotenv injection guard)", () => {
+    assert.match(validateConnectBundle({ ...good, token: "abc\nINJECTED=1" }, {}).error, /newline/i);
+  });
+
+  it("rejects a non-X-Api-Token auth header with an upgrade hint", () => {
+    const r = validateConnectBundle({ ...good, auth_header: "Authorization" }, {});
+    assert.equal(r.ok, false);
+    assert.match(r.hint, /upgrade/i);
+  });
+
+  it("rejects a name that collides with an existing token slot", () => {
+    const r = validateConnectBundle({ ...good, name: "nba_premium" }, { "nba-premium": { url: "https://x" } });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /token slot/);
   });
 });
 


### PR DESCRIPTION
## What

Extracts the `machina connect` bundle validation out of `cmdMachina` (in the 3000-line `src/index.ts`) into a pure `validateConnectBundle(bundle, configs)` in `src/mcp.ts`, and adds direct unit tests.

Follow-up to #102 — addresses the ce-code-review testing finding (T-02): the security guards added during #102 hardening had **zero** test coverage because `execFileSync("machina", …)` gives no injection seam.

## How

- `validateConnectBundle()` is pure (no IO, no `process.exit`) and returns a discriminated `{ ok: true, name, url, token, durable } | { ok: false, error, hint? }`.
- `cmdMachina` now calls it and maps the result to console output / exit. The subprocess call, JSON parse, too-old-CLI detection, and the `.env` + `mcp.json` writes stay in `cmdMachina`.
- **Behavior-preserving** — identical checks in identical order.

## Guards now covered by 10 unit tests

path-traversal pod name · dotenv CR/LF token injection · cleartext (non-HTTPS) url token leak · `X-Api-Token`-only header · token-slot collision · null/CLI-error bundle · non-string field coercion · unparseable url · missing token.

## Net

`src/index.ts` −60 lines; `src/mcp.ts` +91 (function); tests +76.

## Verification

`npm run build` clean (tsc strict); `mcp-helpers` 18/18; `connections` + `cli-health` + `premium-signal` + `guide` + `version-help` 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)