### PR TITLE
fix(config): atomic writes for mcp.json and .env

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@
  * Environment variables always override config file values.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import pc from "picocolors";
@@ -242,7 +242,11 @@ export function writeEnvVar(filePath: string, key: string, value: string): void 
     lines.push(`${key}=${value}`);
   }
 
-  writeFileSync(filePath, lines.join("\n") + "\n", "utf-8");
+  // Atomic write (same-dir temp + rename) so a crash mid-write can't tear the
+  // .env and lose other keys. Matches token-ledger.ts / saveMcpConfigs.
+  const tmp = `${filePath}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+  writeFileSync(tmp, lines.join("\n") + "\n", "utf-8");
+  renameSync(tmp, filePath);
 }
 
 /**

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -24,7 +24,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { ToolSpec, McpServerConfig } from "./types.js";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -172,7 +172,12 @@ export function saveMcpConfigs(configs: Record<string, McpServerConfig>): void {
   if (!existsSync(MCP_CONFIG_DIR)) {
     mkdirSync(MCP_CONFIG_DIR, { recursive: true });
   }
-  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(configs, null, 2) + "\n", "utf-8");
+  // Atomic write: a crash/ENOSPC mid-write would tear mcp.json, and loadMcpConfigs
+  // swallows a parse error as {} — silently dropping every server. Write to a
+  // same-dir temp then rename (atomic on one filesystem). Matches token-ledger.ts.
+  const tmp = `${MCP_CONFIG_PATH}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+  writeFileSync(tmp, JSON.stringify(configs, null, 2) + "\n", "utf-8");
+  renameSync(tmp, MCP_CONFIG_PATH);
   clearToolCache(); // Invalidate cache on config change
 }
 

--- a/test/atomic-config-writes.test.mjs
+++ b/test/atomic-config-writes.test.mjs
@@ -1,0 +1,53 @@
+/**
+ * Atomic config writes — test suite
+ *
+ * writeEnvVar (and saveMcpConfigs, same idiom) write to a same-dir temp file
+ * then rename over the target, so a crash mid-write can't tear the file. These
+ * tests pin the round-trip contract and that no .tmp residue is left behind.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeEnvVar } from "../dist/config.js";
+
+let dir;
+let envPath;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "sportsclaw-env-"));
+  envPath = join(dir, ".env");
+});
+
+after(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeEnvVar (atomic)", () => {
+  it("writes a key and reads it back", () => {
+    writeEnvVar(envPath, "SPORTSCLAW_MCP_TOKEN_A", "tok_a");
+    assert.match(readFileSync(envPath, "utf-8"), /^SPORTSCLAW_MCP_TOKEN_A=tok_a$/m);
+  });
+
+  it("appends a second key without clobbering the first", () => {
+    writeEnvVar(envPath, "SPORTSCLAW_MCP_TOKEN_B", "tok_b");
+    const body = readFileSync(envPath, "utf-8");
+    assert.match(body, /^SPORTSCLAW_MCP_TOKEN_A=tok_a$/m);
+    assert.match(body, /^SPORTSCLAW_MCP_TOKEN_B=tok_b$/m);
+  });
+
+  it("replaces an existing key in place", () => {
+    writeEnvVar(envPath, "SPORTSCLAW_MCP_TOKEN_A", "tok_a2");
+    const body = readFileSync(envPath, "utf-8");
+    assert.match(body, /^SPORTSCLAW_MCP_TOKEN_A=tok_a2$/m);
+    assert.doesNotMatch(body, /tok_a$/m);
+  });
+
+  it("leaves no .tmp residue in the directory", () => {
+    const leftover = readdirSync(dir).filter((f) => f.endsWith(".tmp"));
+    assert.deepEqual(leftover, [], `unexpected temp files: ${leftover.join(", ")}`);
+  });
+});


### PR DESCRIPTION
## Problem

`saveMcpConfigs` (mcp.ts) and `writeEnvVar` (config.ts) overwrite their files with a bare `writeFileSync`. A crash or `ENOSPC` mid-write tears the file. For `mcp.json` this is worse than a lost write: `loadMcpConfigs` swallows the resulting JSON parse error and returns `{}` — **silently dropping every configured MCP server** on the next read. `.env` has the same exposure (other keys lost).

Surfaced by the #102 ce-code-review (adversarial + ce-learnings); pre-existing and codebase-wide.

## Fix

Write to a same-dir temp file then `renameSync` over the target — atomic on a single filesystem. Reuses the idiom already standard in `token-ledger.ts`, `memory.ts`, `session-store`, `heartbeat-state.ts`, etc. No happy-path behavior change; also hardens `mcp add` and the config wizards.

## Verification

`npm run build` clean; new `atomic-config-writes` round-trip test (write / append-preserves / in-place-replace / no `.tmp` residue) + `connections` + `mcp-helpers` — 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)