### PR TITLE
feat(engine): surface connected MCP servers in get_agent_config

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -50,7 +50,7 @@ import { loadConfig, saveConfig, SPORTS_SKILLS_DISCLAIMER } from "./config.js";
 import { MemoryManager, PodMemoryStorage } from "./memory.js";
 import { routePromptToSkills, routeToAgents } from "./router.js";
 import { loadAgents, type AgentDef } from "./agents.js";
-import { McpManager } from "./mcp.js";
+import { McpManager, summarizeMcpServers } from "./mcp.js";
 import { loadSkillGuides } from "./skill-guides.js";
 import type { SkillGuide } from "./types.js";
 import { readFileSync } from "node:fs";
@@ -1127,7 +1127,8 @@ export class sportsclawEngine {
       description:
         "Return the current agent configuration as JSON. Includes provider, model, " +
         "router settings, routing parameters, Python path, installed sports, " +
-        "available (uninstalled) sports, chat integrations status, and version.",
+        "available (uninstalled) sports, chat integrations status, connected MCP " +
+        "servers (name/provider/url, secret-free), and version.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {},
@@ -1147,6 +1148,7 @@ export class sportsclawEngine {
             pythonPath: config.pythonPath,
             installedSports: installed,
             availableSports: available,
+            mcpServers: summarizeMcpServers(),
             chatIntegrations: {
               discord: {
                 configured: !!discord?.botToken,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -157,6 +157,36 @@ export function validateConnectBundle(
   return { ok: true, name, url, token, durable };
 }
 
+export interface McpServerSummary {
+  name: string;
+  provider: string;
+  url: string;
+  hasToken: boolean;
+}
+
+/**
+ * Agent-facing, secret-free summary of the configured MCP servers — so the
+ * agent (via get_agent_config) can see which pods are wired without being able
+ * to read or mutate them. Never includes the token itself, only whether one is
+ * resolvable (env var or an inline auth header), mirroring resolveTokens.
+ */
+export function summarizeMcpServers(
+  configs: Record<string, McpServerConfig> = loadMcpConfigs(),
+  env: NodeJS.ProcessEnv = process.env
+): McpServerSummary[] {
+  return Object.entries(configs).map(([name, c]) => ({
+    name,
+    provider: c.provider ?? "custom",
+    url: c.url,
+    hasToken:
+      !!env[mcpEnvKey(name)] ||
+      !!(c.headers &&
+        Object.keys(c.headers).some(
+          (h) => h.toLowerCase() === "authorization" || h.toLowerCase() === "x-api-token"
+        )),
+  }));
+}
+
 /** Load the user-managed MCP config from ~/.sportsclaw/mcp.json */
 export function loadMcpConfigs(): Record<string, McpServerConfig> {
   if (!existsSync(MCP_CONFIG_PATH)) return {};

--- a/test/mcp-helpers.test.mjs
+++ b/test/mcp-helpers.test.mjs
@@ -15,6 +15,7 @@ import {
   isValidMcpServerName,
   envKeyCollision,
   validateConnectBundle,
+  summarizeMcpServers,
 } from "../dist/mcp.js";
 
 describe("mcpEnvKey", () => {
@@ -115,6 +116,38 @@ describe("validateConnectBundle", () => {
     const r = validateConnectBundle({ ...good, name: "nba_premium" }, { "nba-premium": { url: "https://x" } });
     assert.equal(r.ok, false);
     assert.match(r.error, /token slot/);
+  });
+});
+
+describe("summarizeMcpServers", () => {
+  const configs = {
+    "nba-premium": { url: "https://pod/mcp/sse", provider: "machina" },
+    "my-custom": { url: "https://other/mcp", headers: { "X-Api-Token": "inline" } },
+    "no-auth": { url: "https://bare/mcp" },
+  };
+
+  it("summarizes name/provider/url without leaking any token", () => {
+    const env = { SPORTSCLAW_MCP_TOKEN_NBA_PREMIUM: "sk_secret" };
+    const out = summarizeMcpServers(configs, env);
+    const serialized = JSON.stringify(out);
+    assert.doesNotMatch(serialized, /sk_secret|inline/, "must not contain any token value");
+    assert.deepEqual(out.find((s) => s.name === "nba-premium"), {
+      name: "nba-premium",
+      provider: "machina",
+      url: "https://pod/mcp/sse",
+      hasToken: true,
+    });
+  });
+
+  it("reports hasToken from an env var or an inline auth header", () => {
+    const out = summarizeMcpServers(configs, {});
+    assert.equal(out.find((s) => s.name === "nba-premium").hasToken, false); // no env var
+    assert.equal(out.find((s) => s.name === "my-custom").hasToken, true); // inline header
+    assert.equal(out.find((s) => s.name === "no-auth").hasToken, false);
+  });
+
+  it("defaults provider to \"custom\" when absent", () => {
+    assert.equal(summarizeMcpServers(configs, {}).find((s) => s.name === "no-auth").provider, "custom");
   });
 });
 


### PR DESCRIPTION
## What

`get_agent_config` now includes an `mcpServers` array, so the agent can *see* which MCP pods are wired. Connecting a pod stays operator-only (it consumes a credential from interactive `machina login` — correct); this only closes the **context-parity** gap flagged by ce-agent-native in the #102 review (the agent previously couldn't tell "no pods" from "two pods connected").

## How

- New pure helper `summarizeMcpServers(configs?, env?)` in `mcp.ts` → `{ name, provider, url, hasToken }[]`.
- **Secret-free:** never emits the token value, only `hasToken` (resolvable via env var or an inline auth header — mirrors `resolveTokens`).
- Wired as `mcpServers` into the `get_agent_config` return; description updated.

## Verification

`npm run build` clean. New unit tests (isolated, no engine boot): summary shape, `hasToken` from env-var vs inline header, provider defaulting, **and an assertion that no token value is ever serialized**. `mcp-helpers` + `builtin-tools` + `connections` 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)