### PR TITLE
fix(config): restrict .env to 0600 + clean up temp on write failure

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@
  * Environment variables always override config file values.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, chmodSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import pc from "picocolors";
@@ -245,8 +245,17 @@ export function writeEnvVar(filePath: string, key: string, value: string): void 
   // Atomic write (same-dir temp + rename) so a crash mid-write can't tear the
   // .env and lose other keys. Matches token-ledger.ts / saveMcpConfigs.
   const tmp = `${filePath}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
-  writeFileSync(tmp, lines.join("\n") + "\n", "utf-8");
-  renameSync(tmp, filePath);
+  try {
+    writeFileSync(tmp, lines.join("\n") + "\n", "utf-8");
+    renameSync(tmp, filePath);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch { /* tmp may not exist */ }
+    throw e;
+  }
+  // .env holds bearer tokens — restrict to owner like credentials.ts. The
+  // create-temp-then-rename above resets mode to the umask default, so set it
+  // explicitly after the rename. Best-effort (no-op on platforms without chmod).
+  try { chmodSync(filePath, 0o600); } catch { /* chmod best-effort */ }
 }
 
 /**

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1128,7 +1128,7 @@ export class sportsclawEngine {
         "Return the current agent configuration as JSON. Includes provider, model, " +
         "router settings, routing parameters, Python path, installed sports, " +
         "available (uninstalled) sports, chat integrations status, connected MCP " +
-        "servers (name/provider/url, secret-free), and version.",
+        "servers (name/provider/url/hasToken, secret-free), and version.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {},

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -206,8 +206,13 @@ export function saveMcpConfigs(configs: Record<string, McpServerConfig>): void {
   // swallows a parse error as {} — silently dropping every server. Write to a
   // same-dir temp then rename (atomic on one filesystem). Matches token-ledger.ts.
   const tmp = `${MCP_CONFIG_PATH}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
-  writeFileSync(tmp, JSON.stringify(configs, null, 2) + "\n", "utf-8");
-  renameSync(tmp, MCP_CONFIG_PATH);
+  try {
+    writeFileSync(tmp, JSON.stringify(configs, null, 2) + "\n", "utf-8");
+    renameSync(tmp, MCP_CONFIG_PATH);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch { /* tmp may not exist */ }
+    throw e;
+  }
   clearToolCache(); // Invalidate cache on config change
 }
 

--- a/test/atomic-config-writes.test.mjs
+++ b/test/atomic-config-writes.test.mjs
@@ -1,14 +1,16 @@
 /**
  * Atomic config writes — test suite
  *
- * writeEnvVar (and saveMcpConfigs, same idiom) write to a same-dir temp file
- * then rename over the target, so a crash mid-write can't tear the file. These
- * tests pin the round-trip contract and that no .tmp residue is left behind.
+ * writeEnvVar writes to a same-dir temp file then renames over the target, so a
+ * crash mid-write can't tear the file. These tests pin the round-trip contract,
+ * that no .tmp residue is left behind, and that the secrets file is owner-only.
+ * (saveMcpConfigs shares the identical idiom but writes to a fixed ~/.sportsclaw
+ * path, so it is not exercised here — covered by inspection / the shared idiom.)
  */
 
 import assert from "node:assert/strict";
 import { describe, it, before, after } from "node:test";
-import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -49,5 +51,9 @@ describe("writeEnvVar (atomic)", () => {
   it("leaves no .tmp residue in the directory", () => {
     const leftover = readdirSync(dir).filter((f) => f.endsWith(".tmp"));
     assert.deepEqual(leftover, [], `unexpected temp files: ${leftover.join(", ")}`);
+  });
+
+  it("restricts the .env to owner-only (0600) since it holds tokens", { skip: process.platform === "win32" }, () => {
+    assert.equal(statSync(envPath).mode & 0o077, 0, "group/other bits must be clear");
   });
 });

--- a/test/mcp-helpers.test.mjs
+++ b/test/mcp-helpers.test.mjs
@@ -123,6 +123,7 @@ describe("summarizeMcpServers", () => {
   const configs = {
     "nba-premium": { url: "https://pod/mcp/sse", provider: "machina" },
     "my-custom": { url: "https://other/mcp", headers: { "X-Api-Token": "inline" } },
+    "bearer-auth": { url: "https://bearer/mcp", headers: { Authorization: "Bearer inline_auth" } },
     "no-auth": { url: "https://bare/mcp" },
   };
 
@@ -142,7 +143,8 @@ describe("summarizeMcpServers", () => {
   it("reports hasToken from an env var or an inline auth header", () => {
     const out = summarizeMcpServers(configs, {});
     assert.equal(out.find((s) => s.name === "nba-premium").hasToken, false); // no env var
-    assert.equal(out.find((s) => s.name === "my-custom").hasToken, true); // inline header
+    assert.equal(out.find((s) => s.name === "my-custom").hasToken, true); // inline X-Api-Token
+    assert.equal(out.find((s) => s.name === "bearer-auth").hasToken, true); // inline Authorization
     assert.equal(out.find((s) => s.name === "no-auth").hasToken, false);
   });
 


### PR DESCRIPTION
## Context

`ce-code-review` of the three merged follow-up PRs (#104/#105/#106) surfaced two real defects introduced by the atomic-write change in #104, plus one doc gap. This PR fixes them.

## Findings fixed

**P1 — `.env` left world-readable; tighter perms clobbered.** The create-temp-then-`renameSync` in `writeEnvVar` produces a fresh file at the umask default (`0644`) and, on an existing file, *replaces* it — discarding any `0600` the old in-place write preserved. The file holds the **durable** Machina `X-Api-Token`. Fix: `chmodSync(.env, 0600)` after the rename, best-effort, matching the repo's existing secrets-file convention (`credentials.ts:110`, `anthropic-oauth.ts:203`). Flagged independently by **security + correctness + learnings**.

**P2 — orphaned `.tmp` on rename failure.** `writeEnvVar` and `saveMcpConfigs` left the temp file behind if `renameSync` threw after the temp write. Wrap both in try/catch that unlinks the temp and rethrows; the original target stays intact. (reliability + testing)

**P3 — incomplete tool contract.** `get_agent_config` description listed `name/provider/url` but omitted `hasToken`. Added. (api-contract)

## Tests

- Assert `.env` is `0600` after `writeEnvVar` (POSIX-guarded skip on Windows).
- Cover the `Authorization`-header branch of `summarizeMcpServers` `hasToken` (was only `X-Api-Token`).
- Correct the `atomic-config-writes` header comment that overclaimed `saveMcpConfigs` coverage.

## Deliberately deferred (separate follow-ups)

- **Extract a shared `atomicWriteFileSync` helper** — the idiom is now in 6 files (maintainability P2). Best done as its own codebase-wide refactor, not half-applied here.
- `durability.ts` non-randomised `.tmp` suffix (pre-existing race); `summarizeMcpServers` URL with embedded query-string creds (pre-existing edge); concurrent-writer lost-update (inherent to read-modify-write, documented in `token-ledger.ts`).

## Verification

`npm run build` clean; `atomic-config-writes` + `mcp-helpers` + `connections` 32/32 (the `0600` assertion runs and passes on macOS CI/Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)