### PR TITLE
docs: machina connect + premium tier

### DIFF
--- a/docs/advanced/mcp.md
+++ b/docs/advanced/mcp.md
@@ -30,7 +30,7 @@ instead of passing `--token`.
 
 ## What you can connect
 
-Any MCP server — including Machina Core "pods," which surface workflows, agents, and connectors
+Any MCP server — including Machina "pods," which surface workflows, agents, and connectors
 the agent can call as part of answering a question.
 
 ::: tip Connecting a Machina pod? Use `machina connect`

--- a/docs/advanced/mcp.md
+++ b/docs/advanced/mcp.md
@@ -6,18 +6,39 @@ servers, so your agent can reach workflows and services beyond sports data.
 ## Add a server
 
 ```bash
-sportsclaw mcp add <url>     # connect an MCP server
-sportsclaw mcp list          # see connected servers
-sportsclaw mcp remove <name> # disconnect one
+sportsclaw mcp add <url> --name <name> --token <token>   # connect an MCP server
+sportsclaw mcp list                                      # see connected servers
+sportsclaw mcp remove <name>                             # disconnect one
 ```
+
+`mcp add` accepts:
+
+- `--name <name>` — a short name for the server (auto-derived from the URL if omitted).
+- `--token <token>` — a bearer token, if the server needs auth.
+- `--description <text>` and `--timeout <ms>` — optional metadata and per-call timeout.
 
 Once connected, the tools that server exposes become available to the agent automatically,
 alongside the built-in sports tools.
+
+### Where tokens live
+
+Tokens are kept out of the config file. `mcp add --token …` writes the value to
+`~/.sportsclaw/.env` as `SPORTSCLAW_MCP_TOKEN_<NAME>` (the name uppercased, hyphens to
+underscores), while `~/.sportsclaw/mcp.json` holds only the URL and metadata. At connect time
+the engine injects the token as an `X-Api-Token` header. You can also set the env var yourself
+instead of passing `--token`.
 
 ## What you can connect
 
 Any MCP server — including Machina Core "pods," which surface workflows, agents, and connectors
 the agent can call as part of answering a question.
+
+::: tip Connecting a Machina pod? Use `machina connect`
+For Machina pods, prefer **[`sportsclaw machina connect`](../sports-data/machina#connecting-machina-to-sportsclaw)** —
+it signs you in, mints a durable key, and registers the pod automatically (no URL to copy).
+Pods it registers are tagged `provider: "machina"`, which is how `doctor` and the agent's
+`get_agent_config` recognize them. Use `mcp add` for arbitrary, non-Machina MCP servers.
+:::
 
 ::: tip sportsclaw connects *to* MCP servers
 sportsclaw is an MCP **client**: it consumes tools from other servers. It does not run as an

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ Every `sportsclaw` command, grouped by what you'll reach for most.
 | `sportsclaw chat` | Start an interactive conversation |
 | `sportsclaw config` | Configure your provider, model, and integrations |
 | `sportsclaw setup` | Conversational, AI-guided setup |
-| `sportsclaw doctor` | Diagnose your install (incl. Machina pod & machina-cli status) and tell you what to fix |
+| `sportsclaw doctor` | Diagnose your install (incl. Machina status) and tell you what to fix |
 | `sportsclaw health` | Report overall system status |
 | `sportsclaw login claude` | Reuse your existing Claude Code session |
 | `sportsclaw logout claude` | Stop using the Claude Code session |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ Every `sportsclaw` command, grouped by what you'll reach for most.
 | `sportsclaw chat` | Start an interactive conversation |
 | `sportsclaw config` | Configure your provider, model, and integrations |
 | `sportsclaw setup` | Conversational, AI-guided setup |
-| `sportsclaw doctor` | Diagnose your install and tell you what to fix |
+| `sportsclaw doctor` | Diagnose your install (incl. Machina pod & machina-cli status) and tell you what to fix |
 | `sportsclaw health` | Report overall system status |
 | `sportsclaw login claude` | Reuse your existing Claude Code session |
 | `sportsclaw logout claude` | Stop using the Claude Code session |
@@ -41,8 +41,10 @@ Every `sportsclaw` command, grouped by what you'll reach for most.
 
 | Command | What it does |
 | --- | --- |
-| `sportsclaw mcp add <url>` | Connect an MCP server |
-| `sportsclaw mcp list` / `remove <name>` | List / disconnect MCP servers |
+| `sportsclaw machina connect [project]` | Connect a Machina premium pod (mints a durable key via machina-cli) |
+| `sportsclaw mcp add <url> [--name <n>] [--token <t>]` | Connect an MCP server (also `--description`, `--timeout <ms>`) |
+| `sportsclaw mcp list` | List connected MCP servers |
+| `sportsclaw mcp remove <name>` | Disconnect an MCP server |
 | `sportsclaw watch <sport> <command>` | Watch a data endpoint for changes |
 | `sportsclaw operate --list` | List configured operator jobs |
 | `sportsclaw operate --job <id>` | Run an operator job |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -69,4 +69,8 @@ sportsclaw doctor
 ```
 
 `doctor` verifies your Node and Python versions, the sports data layer, your model
-credentials, and your installed sports — and tells you exactly what to fix if something's off.
+credentials, your installed sports, and any connected Machina premium pods — and tells you
+exactly what to fix if something's off.
+
+To connect premium data feeds, see [Machina — the premium layer](../sports-data/machina) and
+[Connecting MCP Servers](../advanced/mcp).

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -32,7 +32,8 @@ with live sports, this is the foundation.
   college football, college basketball, and track. No API keys needed for the data.
 
 All coverage is powered by **[sports-skills](https://sports-skills.sh)**, the open data layer
-the installer sets up for you.
+the installer sets up for you. When you need licensed, real-time feeds, there's a premium tier —
+see [Machina](../sports-data/machina).
 - **Live odds & prediction markets** — ESPN, Kalshi, and Polymarket, with betting math built in.
 - **Real-time game events** — the engine watches games and knows when the score, lead, or
   status changes.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -30,15 +30,15 @@ with live sports, this is the foundation.
 
 - **14 sports** — NFL, NBA, WNBA, MLB, NHL, soccer, F1, tennis, cricket, golf, volleyball,
   college football, college basketball, and track. No API keys needed for the data.
-
-All coverage is powered by **[sports-skills](https://sports-skills.sh)**, the open data layer
-the installer sets up for you. When you need licensed, real-time feeds, there's a premium tier —
-see [Machina](../sports-data/machina).
 - **Live odds & prediction markets** — ESPN, Kalshi, and Polymarket, with betting math built in.
 - **Real-time game events** — the engine watches games and knows when the score, lead, or
   status changes.
 - **Bots, images, and vision** — Discord/Telegram integrations, image generation, and the
   ability to read images you send it.
+
+All coverage is powered by **[sports-skills](https://sports-skills.sh)**, the open data layer
+the installer sets up for you. When you need licensed, real-time feeds, there's a premium tier —
+see [Machina](../sports-data/machina).
 
 Bring your own model — Anthropic (Claude), OpenAI, or Google (Gemini).
 

--- a/docs/sports-data/coverage.md
+++ b/docs/sports-data/coverage.md
@@ -9,8 +9,9 @@ All of this coverage comes from **[sports-skills](https://sports-skills.sh)** â€
 Python data layer that the installer sets up for you. It's what turns "who won last night?"
 into a real, sourced answer. Browse the full catalog at **[sports-skills.sh](https://sports-skills.sh)**.
 
-Need **licensed data, real-time feeds, or production SLAs**? Step up to the
-[Machina premium layer](./machina).
+Need **licensed data, real-time feeds, or production SLAs**? There's a `sports-skills premium`
+tier, and the [Machina premium layer](./machina) for licensed real-time pods â€” connect one in a
+single command with `sportsclaw machina connect`.
 
 </div>
 

--- a/docs/sports-data/coverage.md
+++ b/docs/sports-data/coverage.md
@@ -10,8 +10,8 @@ Python data layer that the installer sets up for you. It's what turns "who won l
 into a real, sourced answer. Browse the full catalog at **[sports-skills.sh](https://sports-skills.sh)**.
 
 Need **licensed data, real-time feeds, or production SLAs**? There's a `sports-skills premium`
-tier, and the [Machina premium layer](./machina) for licensed real-time pods — connect one in a
-single command with `sportsclaw machina connect`.
+tier for deeper coverage, plus the [Machina premium layer](./machina) for licensed real-time
+pods. Connect a Machina pod in one command with `sportsclaw machina connect`.
 
 </div>
 

--- a/docs/sports-data/machina.md
+++ b/docs/sports-data/machina.md
@@ -12,7 +12,7 @@ workflows**, you step up to the **[Machina Sports](https://machina.gg)** platfor
 | **Data**       | Public APIs (ESPN, Kalshi, Polymarket…), keyless  | Licensed real-time feeds, betting odds, zero-latency streams |
 | **Best for**   | Personal use, prototyping                         | Commercial / production, with SLAs and support               |
 | **Workflows**  | You build them                                    | Packaged "templates" you install                             |
-| **Access**     | Bundled with sportsclaw                            | `machina-cli` + a per-project Machina MCP server             |
+| **Access**     | Bundled with sportsclaw                            | One command: `sportsclaw machina connect` (uses `machina-cli`) |
 
 ::: tip Licensing
 The open sports-skills rely on third-party public APIs and are intended for **personal,
@@ -21,10 +21,10 @@ non-commercial** use. For commercial or production workloads with licensed data,
 
 ## The Machina skill
 
-The `machina` skill is published in the same **[sports-skills catalog](https://sports-skills.sh)**
-as the open skills — it's the gateway to the premium platform. It's **prompt-only**: it fetches
-no data itself. Instead it tells the agent how to use the separate **`machina-cli`** and how to
-connect to a per-project Machina MCP server.
+The `machina` skill ships in the same **[sports-skills catalog](https://sports-skills.sh)**
+as the open skills. It's **prompt-only**: it fetches no data itself — it points the agent at the
+premium platform and the separate **`machina-cli`**. The data itself flows through a per-project
+Machina MCP server, which you wire up with `sportsclaw machina connect` (below).
 
 ## machina-cli
 
@@ -50,15 +50,51 @@ What it covers:
 
 ## Connecting Machina to sportsclaw
 
-Premium live data is served through a per-project **Machina MCP server** that runs on Machina
-infrastructure (not by `machina-cli`). Because sportsclaw is an
-[MCP client](../advanced/mcp), you connect it directly:
+Premium data is served through a per-project **Machina MCP server** (a "pod"). The quickest way
+to wire one in is the built-in `machina connect` command — it signs you in through `machina-cli`,
+mints a durable access key, and registers the pod for you. No URLs to copy.
 
-1. **Install a template** — `machina template install <name>` provisions the workflow
-   server-side and returns the MCP URL (and any required headers) in its JSON output.
-2. **Add it to sportsclaw** — `sportsclaw mcp add <url>` (see
-   [Connecting MCP Servers](../advanced/mcp)).
-3. **Ask as usual** — the agent now reads Machina's licensed, real-time feeds through that MCP
-   server, right alongside the built-in sports-skills.
+```bash
+pip install machina-cli      # one-time: install the Machina CLI
+machina login                # browser sign-in (or --api-key <key> for CI)
+
+sportsclaw machina connect             # connect your default project's pod
+sportsclaw machina connect <project>   # …or name a specific project
+```
+
+Useful flags:
+
+- `--org <org-id>` — choose the organization when you belong to more than one.
+- `--probe` — verify the pod's endpoint is reachable before registering it.
+
+`machina connect` writes the pod to `~/.sportsclaw/mcp.json` and stores its access token
+separately in `~/.sportsclaw/.env` (never in the config file). From then on the agent reads
+Machina's licensed, real-time feeds right alongside the built-in sports-skills. Check and
+inspect connected pods with:
+
+```bash
+sportsclaw mcp list     # list connected servers
+sportsclaw doctor       # shows Machina pod + machina-cli status
+```
+
+Re-run `sportsclaw machina connect` any time a connection later returns a 401.
+
+### Connect a pod by URL (manual)
+
+Already have an MCP URL and token — or connecting a non-Machina MCP server? Add it directly:
+
+```bash
+sportsclaw mcp add <url> --name <name> --token <token>
+```
+
+See [Connecting MCP Servers](../advanced/mcp) for the full set of options.
+
+## Premium signal
+
+You don't have to go looking for the premium path — sportsclaw surfaces it for you. When a data
+tool reports that licensed or real-time data exists beyond what the free skill returned, the
+agent adds a single, optional line pointing to the upgrade (the `sports-skills premium` tier or
+`sportsclaw machina connect`). It's informational only: it never blocks an answer, never repeats
+within a conversation, and stays out of automated alerts and broadcasts.
 
 Learn more at **[machina.gg](https://machina.gg)**.

--- a/docs/sports-data/machina.md
+++ b/docs/sports-data/machina.md
@@ -1,9 +1,9 @@
 # Machina — the premium layer
 
 sportsclaw's built-in coverage comes from **[sports-skills](https://sports-skills.sh)** — the
-open, keyless data layer. It's free and ideal for development and personal use. When you need
+open, keyless data layer. It's free and ideal for development and personal use. For
 **licensed data, real-time and zero-latency feeds, production SLAs, or packaged agent
-workflows**, you step up to the **[Machina Sports](https://machina.gg)** platform.
+workflows**, the **[Machina Sports](https://machina.gg)** platform covers that.
 
 ## Open vs. premium
 
@@ -51,7 +51,7 @@ What it covers:
 ## Connecting Machina to sportsclaw
 
 Premium data is served through a per-project **Machina MCP server** (a "pod"). The quickest way
-to wire one in is the built-in `machina connect` command — it signs you in through `machina-cli`,
+to wire one in is the built-in `sportsclaw machina connect` command — it signs you in through `machina-cli`,
 mints a durable access key, and registers the pod for you. No URLs to copy.
 
 ```bash
@@ -91,10 +91,10 @@ See [Connecting MCP Servers](../advanced/mcp) for the full set of options.
 
 ## Premium signal
 
-You don't have to go looking for the premium path — sportsclaw surfaces it for you. When a data
-tool reports that licensed or real-time data exists beyond what the free skill returned, the
-agent adds a single, optional line pointing to the upgrade (the `sports-skills premium` tier or
-`sportsclaw machina connect`). It's informational only: it never blocks an answer, never repeats
-within a conversation, and stays out of automated alerts and broadcasts.
+When a tool result carries an `upgrade` field — the data layer's signal that licensed or
+real-time data exists beyond what the open skill returned — the agent adds a single, optional
+line pointing to the path (the `sports-skills premium` tier or `sportsclaw machina connect`).
+The data layer decides this, not the agent. It's informational only: it never blocks an answer,
+never repeats within a conversation, and stays out of automated alerts and broadcasts.
 
 Learn more at **[machina.gg](https://machina.gg)**.


### PR DESCRIPTION
## What

Updates the docs site to match the shipped CLI after the machina-connect wave (#102–#107) and sports-skills v0.27.1 premium-tier discovery. The docs shipped in #100, before any of that — most notably `sports-data/machina.md` documented a connect flow (`machina template install` → paste URL → `mcp add`) that no longer matches the product.

Plan: internal `009-machina-docs-update-plan.md`. Identified via a ce gap review (two parallel agents: docs auditor + shipped-surface cataloger).

## Changes (U1–U5)

- **`sports-data/machina.md`** (HIGH) — replace the stale flow with the one-command `sportsclaw machina connect` path: prereqs (`pip install machina-cli` → `machina login`), `--org`/`--probe`, durable-key note, verify via `mcp list`/`doctor`. Keep `mcp add <url>` as the documented manual fallback. New **Premium signal** note documenting the agent's optional upgrade line.
- **`cli-reference.md`** (HIGH) — add `machina connect`; show `mcp add` flags; split `mcp list`/`remove`; note `doctor`'s Machina status.
- **`advanced/mcp.md`** (MED) — document `mcp add` flags + the token model (`~/.sportsclaw/.env` `SPORTSCLAW_MCP_TOKEN_<NAME>` → injected as `X-Api-Token`); callout steering Machina pods to `machina connect`; note `provider:"machina"`.
- **coverage / configuration / introduction** (LOW) — surface the `sports-skills premium` tier + `doctor`'s Machina status for discoverability.

## Verification

`npm run docs:build` clean. Every command/flag matches the shipped surface (`src/machina.ts`, `cmdMcp`/`cmdDoctor` in `src/index.ts`, `src/mcp.ts`). Note: the site only deploys on a `v*.*.*` tag (`build-site.yml`), so this does not auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)