### PR TITLE
docs(site): tweak agent-prompt copy (credit sports-skills)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,9 +98,8 @@ Paste this into Claude Code, Cursor, or any coding agent — it reads the machin
 Build a sports AI app with sportsclaw. First read https://sportsclaw.gg/llms.txt
 for the full doc map, then follow https://sportsclaw.gg/getting-started/quickstart
 to install and scaffold. sportsclaw gives you keyless live scores, standings, odds
-(ESPN/Kalshi/Polymarket), and real-time game events, plus one-command Discord and
-Telegram bots. Use the docs at https://sportsclaw.gg for the CLI, data coverage,
-and deployment.
+and markets via sports-skills, plus one-command Discord and Telegram bots. Use the
+docs at https://sportsclaw.gg for the CLI, data coverage, and deployment.
 ```
 
 <p class="sc-section-note"><code>llms.txt</code> lists every doc page as a fetchable URL, so the agent can crawl the whole reference on its own.</p>


### PR DESCRIPTION
Updates the 'Hand it to your coding agent' prompt: the data line now reads "keyless live scores, standings, odds and markets via sports-skills" (was the ESPN/Kalshi/Polymarket parenthetical + real-time game events). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)