### PR TITLE
docs(site): remove 'Edit this page on GitHub' link

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -114,11 +114,6 @@ export default defineConfig({
 
     search: { provider: 'local' },
 
-    editLink: {
-      pattern: 'https://github.com/machina-sports/sportsclaw/edit/main/docs/:path',
-      text: 'Edit this page on GitHub',
-    },
-
     footer: {
       message: 'Open source under the MIT License.',
       copyright: 'sportsclaw',


### PR DESCRIPTION
Drops the VitePress `editLink` config so doc pages no longer show 'Edit this page on GitHub'. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)