### PR TITLE
feat(machina): detect + delegate to the Machina durable loop (harness)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -250,6 +250,30 @@ export interface PodCapabilities {
   discoveredAt: number;
 }
 
+/**
+ * The Machina "harness" durable agentic turn loop is provisioned on a pod as an
+ * agent named `loop-runner` (driven via `execute_agent`, state in `harness_session`
+ * documents). Its presence is how we know a connected pod can run durable,
+ * resumable, multi-turn tasks on our behalf.
+ */
+export const LOOP_RUNNER_AGENT = "loop-runner";
+
+/**
+ * Find the first server whose discovered pod inventory exposes the Machina
+ * durable loop (the `loop-runner` agent). Pure over already-discovered
+ * capabilities so it is unit-testable without a live connection.
+ */
+export function findLoopServer(
+  podCaps: Map<string, PodCapabilities>
+): string | undefined {
+  for (const [server, caps] of podCaps) {
+    if (caps.agents.some((a) => a.name === LOOP_RUNNER_AGENT)) {
+      return server;
+    }
+  }
+  return undefined;
+}
+
 interface ToolCacheEntry {
   tools: Array<{ name: string; description?: string; inputSchema?: unknown }>;
   capabilities?: PodCapabilities;
@@ -856,6 +880,15 @@ export class McpManager {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Find a connected Machina pod that exposes the durable agentic loop
+   * (the `loop-runner` agent, discovered in the pod inventory). Returns
+   * undefined if no such pod is connected.
+   */
+  getMachinaLoopServer(): string | undefined {
+    return findLoopServer(this.podCaps);
   }
 
   /** Disconnect all MCP clients */

--- a/src/prompts/system.ts
+++ b/src/prompts/system.ts
@@ -330,6 +330,17 @@ function capabilitiesSection(ctx: SystemPromptContext): string | null {
         );
       }
     }
+
+    if (ctx.mcpManager.getMachinaLoopServer()) {
+      parts.push(
+        "",
+        "### Durable loop available",
+        "This pod runs the Machina durable agentic loop. For a long, multi-step, or resumable task — " +
+          "especially autonomous/background work that should survive interruptions — delegate it with the " +
+          "`machina_loop` tool (action: start → returns a session_id; read → fetch the result; continue → follow up). " +
+          "It persists every turn server-side, unlike a one-shot tool call. Prefer direct tools for quick answers."
+      );
+    }
   }
 
   return parts.join("\n");

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,7 +17,7 @@ import type {
 import type { McpManager } from "./mcp.js";
 import { buildSportsSkillsRepairCommand } from "./python.js";
 import { isBlockedTool, logSecurityEvent } from "./security.js";
-import { BUILTIN_TOOLS } from "./tools/index.js";
+import { BUILTIN_TOOLS, machinaLoopTool } from "./tools/index.js";
 
 export {
   ToolCallInput,
@@ -253,6 +253,11 @@ export class ToolRegistry {
     this.mcpRouteMap = manager.getRouteMap();
   }
 
+  /** The connected MCP manager, if any. Used by built-in tools that bridge to MCP. */
+  getMcpManager(): McpManager | null {
+    return this.mcpManager;
+  }
+
   /**
    * Get cache statistics for debugging.
    */
@@ -292,7 +297,8 @@ export class ToolRegistry {
       toolName === "get_agent_config" ||
       toolName === "install_sport" ||
       toolName === "remove_sport" ||
-      toolName === "upgrade_sports_skills"
+      toolName === "upgrade_sports_skills" ||
+      toolName === "machina_loop"
     );
   }
 
@@ -385,8 +391,15 @@ export class ToolRegistry {
    * hide the legacy generic `sports_query` tool to reduce ambiguous routing.
    */
   getAllToolSpecs(): ToolSpec[] {
-    const base =
+    let base =
       this.dynamicSpecs.length > 0 ? [...this.dynamicSpecs] : [...TOOL_SPECS];
+    // `machina_loop` is a conditional capability: expose it only when a Machina
+    // pod running the durable loop (`loop-runner`) is connected — regardless of
+    // whether sport schemas are loaded. Strip any default copy, then re-add.
+    base = base.filter((s) => s.name !== machinaLoopTool.spec.name);
+    if (this.mcpManager?.getMachinaLoopServer()) {
+      base.push(machinaLoopTool.spec);
+    }
     // Append MCP tools after Python bridge tools
     if (this.mcpSpecs.length > 0) {
       base.push(...this.mcpSpecs);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,12 +1,15 @@
 import { sportsQueryTool } from "./sports_query.js";
 import { sportsIntelligenceSnapshotTool } from "./sports_intelligence_snapshot.js";
+import { machinaLoopTool } from "./machina_loop.js";
 import type { BuiltinTool } from "./builtin-tool.js";
 
 export { BuiltinTool } from "./builtin-tool.js";
 export { sportsQueryTool } from "./sports_query.js";
 export { sportsIntelligenceSnapshotTool } from "./sports_intelligence_snapshot.js";
+export { machinaLoopTool } from "./machina_loop.js";
 
 export const BUILTIN_TOOLS: BuiltinTool[] = [
   sportsQueryTool,
   sportsIntelligenceSnapshotTool,
+  machinaLoopTool,
 ];

--- a/src/tools/machina_loop.ts
+++ b/src/tools/machina_loop.ts
@@ -1,0 +1,161 @@
+/**
+ * sportsclaw built-in tool: `machina_loop`
+ *
+ * Delegates a long-running, multi-turn task to the Machina **durable agentic
+ * loop** (the "harness") running on a connected Machina MCP pod. Where a normal
+ * tool call is one-shot and ephemeral, the Machina loop persists every turn as a
+ * `harness_session` document and is resumed by the pod's beat — so it survives
+ * interruptions, async tools, and waiting on input.
+ *
+ * This tool is only exposed when a pod exposing the `loop-runner` agent is
+ * connected (see ToolRegistry.getAllToolSpecs + McpManager.getMachinaLoopServer).
+ * It is a thin bridge over the pod's already-connected MCP tools
+ * (`execute_agent`, `search_documents`); sportsclaw never holds loop state itself.
+ */
+
+import { randomBytes } from "node:crypto";
+import type { sportsclawConfig } from "../types.js";
+import type { ToolRegistry } from "../tools.js";
+import type { ToolCallInput, ToolCallResult } from "../bridge.js";
+import type { BuiltinTool } from "./builtin-tool.js";
+
+const RUNNER_AGENT = "loop-runner";
+const SESSION_DOC = "harness_session";
+const DEFAULT_PERSONA = "loop-reasoning";
+
+function err(error: string, hint?: string): ToolCallResult {
+  return {
+    content: JSON.stringify({ error, error_code: "machina_loop", ...(hint ? { hint } : {}) }),
+    isError: true,
+  };
+}
+
+/** Lift the workflow-saved payload (docs nest it under `value`; REST under `content`). */
+function payloadOf(doc: Record<string, unknown>): Record<string, unknown> {
+  const value = (doc.value ?? doc.content) as Record<string, unknown> | undefined;
+  return value && typeof value === "object" ? value : {};
+}
+
+export const machinaLoopTool: BuiltinTool = {
+  spec: {
+    name: "machina_loop",
+    description: [
+      "Delegate a long, multi-step, or resumable task to the Machina durable agentic loop",
+      "(the 'harness') on the connected Machina pod. Unlike a normal tool call, the loop",
+      "persists every turn server-side and resumes across interruptions.",
+      "",
+      "Actions:",
+      "- start: begin a new durable session for a task. Returns a session_id.",
+      "- continue: add a follow-up message to an existing session (needs session_id).",
+      "- read: fetch the current state of a session — latest reply, status, turn count.",
+      "",
+      "The loop runs asynchronously: after start/continue, call read with the session_id to",
+      "get the result. Use this for autonomous/background work; use direct tools for a quick answer.",
+    ].join("\n"),
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["start", "continue", "read"],
+          description: "start a new durable session, continue one, or read its current state",
+        },
+        prompt: {
+          type: "string",
+          description: "the task or follow-up message (required for start and continue)",
+        },
+        session_id: {
+          type: "string",
+          description: "the session id (required for continue and read; returned by start)",
+        },
+        persona: {
+          type: "string",
+          description: `optional reasoning persona prompt the loop uses (default: ${DEFAULT_PERSONA})`,
+        },
+      },
+      required: ["action"],
+    },
+  },
+
+  async execute(
+    input: ToolCallInput,
+    _config?: Partial<sportsclawConfig>,
+    registry?: ToolRegistry
+  ): Promise<ToolCallResult> {
+    const mgr = registry?.getMcpManager();
+    const server = mgr?.getMachinaLoopServer();
+    if (!mgr || !server) {
+      return err(
+        "No Machina durable loop is connected.",
+        "Connect a Machina pod that has the loop-runner agent: `sportsclaw mcp add <pod>/mcp/sse --token <key>`."
+      );
+    }
+
+    const action = String(input.action ?? "start").toLowerCase();
+    const prompt = typeof input.prompt === "string" ? input.prompt.trim() : "";
+    const persona = typeof input.persona === "string" && input.persona.trim() ? input.persona.trim() : DEFAULT_PERSONA;
+    let sessionId = typeof input.session_id === "string" ? input.session_id.trim() : "";
+
+    if (action === "read") {
+      if (!sessionId) return err("read requires session_id.");
+      const res = await mgr.callToolDirect(server, "search_documents", {
+        filters: { name: SESSION_DOC, "value.session_id": sessionId },
+        page_size: 1,
+      });
+      if (res.isError) return { content: res.content, isError: true };
+      let value: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(res.content) as Record<string, unknown>;
+        const list = (parsed.data ?? parsed.results ?? parsed) as unknown;
+        const doc = Array.isArray(list) ? (list[0] as Record<string, unknown>) : undefined;
+        if (doc) value = payloadOf(doc);
+      } catch {
+        return err("Could not parse the loop session.", "The pod returned a non-JSON document payload.");
+      }
+      if (!value.session_id) return err(`No loop session found for "${sessionId}".`);
+      const entries = Array.isArray(value.entries) ? (value.entries as Array<Record<string, unknown>>) : [];
+      const lastAssistant = [...entries].reverse().find((e) => e.role === "assistant" && e.type === "message");
+      return {
+        content: JSON.stringify({
+          session_id: value.session_id,
+          status: value.status ?? "unknown",
+          turn: value.turn ?? entries.length,
+          latest_reply: lastAssistant?.content ?? null,
+          entries: entries.length,
+        }),
+        isError: false,
+      };
+    }
+
+    // start | continue
+    const op = action === "continue" ? "say" : "start";
+    if (!prompt) return err(`${action} requires a prompt.`);
+    if (op === "say" && !sessionId) return err("continue requires session_id.");
+    if (op === "start" && !sessionId) sessionId = `ses_${randomBytes(12).toString("hex")}`;
+
+    const res = await mgr.callToolDirect(server, "execute_agent", {
+      name: RUNNER_AGENT,
+      messages: [{ role: "user", content: prompt }],
+      context: {
+        "context-agent": {
+          op,
+          session_id: sessionId,
+          input_message: prompt,
+          persona_agent: persona,
+        },
+      },
+    });
+    if (res.isError) return { content: res.content, isError: true };
+
+    return {
+      content: JSON.stringify({
+        session_id: sessionId,
+        status: "running",
+        note:
+          "Durable loop turn dispatched server-side. Call machina_loop with " +
+          `{action:"read", session_id:"${sessionId}"} to get the result; it persists and resumes across interruptions.`,
+      }),
+      isError: false,
+    };
+  },
+};

--- a/test/builtin-tools.test.mjs
+++ b/test/builtin-tools.test.mjs
@@ -2,7 +2,7 @@
  * Builtin Tools Modular Structure — Test Suite
  *
  * Verifies that:
- *  1. BUILTIN_TOOLS array correctly registers and exposes sports_query and sports_intelligence_snapshot.
+ *  1. BUILTIN_TOOLS array correctly registers and exposes sports_query, sports_intelligence_snapshot, and machina_loop.
  *  2. Each tool conforms to the BuiltinTool interface and carries a valid ToolSpec.
  */
 
@@ -13,11 +13,12 @@ import { BUILTIN_TOOLS } from "../dist/tools/index.js";
 
 describe("Builtin Tools Modular Registry", () => {
   it("should have correct builtin tools registered", () => {
-    assert.strictEqual(BUILTIN_TOOLS.length, 2, "Should have exactly two builtin tools registered");
+    assert.strictEqual(BUILTIN_TOOLS.length, 3, "Should have exactly three builtin tools registered");
 
     const names = BUILTIN_TOOLS.map(t => t.spec.name);
     assert.ok(names.includes("sports_query"), "Should register sports_query");
     assert.ok(names.includes("sports_intelligence_snapshot"), "Should register sports_intelligence_snapshot");
+    assert.ok(names.includes("machina_loop"), "Should register machina_loop");
   });
 
   it("should carry valid specifications and executable handlers", () => {

--- a/test/machina-loop.test.mjs
+++ b/test/machina-loop.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { findLoopServer, LOOP_RUNNER_AGENT } from "../dist/mcp.js";
+import { machinaLoopTool } from "../dist/tools/machina_loop.js";
+
+const caps = (agents) => ({ workflows: [], agents, connectors: [], discoveredAt: 0 });
+
+describe("findLoopServer — durable loop detection", () => {
+  it("detects the server exposing the loop-runner agent", () => {
+    const pods = new Map([
+      ["other", caps([{ name: "some-agent" }])],
+      ["machina", caps([{ name: LOOP_RUNNER_AGENT }])],
+    ]);
+    assert.equal(findLoopServer(pods), "machina");
+  });
+
+  it("returns undefined when no server has the loop-runner agent", () => {
+    const pods = new Map([["pod", caps([{ name: "copilot-executor" }])]]);
+    assert.equal(findLoopServer(pods), undefined);
+  });
+
+  it("returns undefined for empty capabilities", () => {
+    assert.equal(findLoopServer(new Map()), undefined);
+  });
+});
+
+describe("machinaLoopTool spec", () => {
+  it("exposes a machina_loop tool with start/continue/read actions", () => {
+    assert.equal(machinaLoopTool.spec.name, "machina_loop");
+    assert.deepEqual(machinaLoopTool.spec.input_schema.properties.action.enum, [
+      "start",
+      "continue",
+      "read",
+    ]);
+    assert.deepEqual(machinaLoopTool.spec.input_schema.required, ["action"]);
+  });
+
+  it("errors clearly when no Machina loop is connected", async () => {
+    // No registry / no mcpManager → tool must fail safe, not throw.
+    const res = await machinaLoopTool.execute({ action: "start", prompt: "hi" }, {}, undefined);
+    assert.equal(res.isError, true);
+    const body = JSON.parse(res.content);
+    assert.equal(body.error_code, "machina_loop");
+    assert.match(body.error, /No Machina durable loop/i);
+  });
+
+  it("requires session_id for read", async () => {
+    // Registry whose mcpManager reports a connected loop server.
+    const registry = { getMcpManager: () => ({ getMachinaLoopServer: () => "machina" }) };
+    const res = await machinaLoopTool.execute({ action: "read" }, {}, registry);
+    assert.equal(res.isError, true);
+    assert.match(JSON.parse(res.content).error, /read requires session_id/i);
+  });
+});


### PR DESCRIPTION
## What

sportsclaw already connects to Machina pods over MCP and auto-detects them (`getMachinaServerName`, pod-capability discovery). This makes the **Machina durable agentic loop** (the "harness") a **first-class delegation target**: when a connected pod runs the `loop-runner` agent, sportsclaw can hand it long, multi-step, **resumable** tasks instead of forcing them into one ephemeral tool call.

The loop is durable — it persists every turn as a `harness_session` document and is resumed by the pod's beat, surviving interruptions / async tools / waiting on input. sportsclaw's own loop is ephemeral; this lets it offload the durable work.

## How (all over the already-connected MCP — no new transport, no loop state in sportsclaw)

- **`src/mcp.ts`** — `findLoopServer()` (pure, unit-tested) + `McpManager.getMachinaLoopServer()`: detect a connected pod whose discovered inventory exposes the `loop-runner` agent.
- **`src/tools/machina_loop.ts`** — new built-in tool `machina_loop` with `action: start | continue | read`:
  - `start` / `continue` → `execute_agent` (`loop-runner`, `context-agent.op` = `start`/`say`); `start` mints a `session_id`.
  - `read` → `search_documents` on `harness_session` → returns status, turn, latest reply.
- **`src/tools.ts`** — expose `machina_loop` **only when** a loop-capable pod is connected (`getAllToolSpecs` gate), add a public `getMcpManager()` accessor, and skip caching it (stateful).
- **`src/prompts/system.ts`** — when the loop is available, tell the model it can delegate durable/background work via `machina_loop`.

## Tests
- `test/machina-loop.test.mjs` — detection logic (`findLoopServer`), tool spec shape, and fail-safe guards (no loop connected, missing `session_id`).
- `test/builtin-tools.test.mjs` — updated registry count (2 → 3) + asserts `machina_loop` is registered.
- Full suite green; `tsc` build clean.

## Notes for reviewers
- This is the **sportsclaw → Machina-loop** direction (sportsclaw is the MCP client; the loop lives in the pod). It composes with the existing `machina connect` flow — once a pod is connected, the tool appears automatically.
- Verified end-to-end against a staging pod where the harness loop (`loop-runner` + `loop-turn` + `loop-tools`) is provisioned: `execute_agent`/`search_documents` are exactly the MCP tools the pod exposes.
- The tool is intentionally conditional — it never appears (and never confuses the model) unless a `loop-runner`-capable pod is connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)