### PR TITLE
fix(machina): pod-capability discovery + machina_loop wiring (follow-up to #113)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -274,6 +274,37 @@ export function findLoopServer(
   return undefined;
 }
 
+/**
+ * Parse a Machina search-tool result (search_workflows / search_agents /
+ * connector_search) into `{name, description?}` entries.
+ *
+ * Machina's MCP wraps results as `{ data: { data: [...] } }` (an envelope inside
+ * the tool's own `data`), so a single `.data` unwrap leaves an object, not an
+ * array — which silently yielded an empty pod inventory. This unwraps the inner
+ * envelope as well. Pure + exported so it is unit-testable without a connection.
+ */
+export function parseEntityList(content: string): Array<{ name: string; description?: string }> {
+  try {
+    const data = JSON.parse(content);
+    let items: unknown = data?.data ?? data?.results ?? (Array.isArray(data) ? data : []);
+    // Unwrap the inner `{ data: [...] }` / `{ results: [...] }` envelope.
+    if (items && !Array.isArray(items) && typeof items === "object") {
+      const inner = items as Record<string, unknown>;
+      items = Array.isArray(inner.data) ? inner.data : Array.isArray(inner.results) ? inner.results : items;
+    }
+    if (!Array.isArray(items)) return [];
+    return items
+      .filter((item: Record<string, unknown>) => item && item.name)
+      .map((item: Record<string, unknown>) => ({
+        name: item.name as string,
+        ...(item.description ? { description: item.description as string } : {}),
+      }))
+      .slice(0, 50);
+  } catch {
+    return [];
+  }
+}
+
 interface ToolCacheEntry {
   tools: Array<{ name: string; description?: string; inputSchema?: unknown }>;
   capabilities?: PodCapabilities;
@@ -645,15 +676,18 @@ export class McpManager {
     }
 
     try {
+      // Fetch a full page so detection (e.g. of the loop-runner agent) doesn't
+      // miss entries beyond the API's small default page size.
+      const args = { page_size: 100 };
       const [wfResult, agResult, cnResult] = await Promise.allSettled([
         hasSearch("search_workflows")
-          ? this.callTool(`mcp__${serverName}__search_workflows`, {})
+          ? this.callTool(`mcp__${serverName}__search_workflows`, args)
           : Promise.resolve(null),
         hasSearch("search_agents")
-          ? this.callTool(`mcp__${serverName}__search_agents`, {})
+          ? this.callTool(`mcp__${serverName}__search_agents`, args)
           : Promise.resolve(null),
         hasSearch("connector_search")
-          ? this.callTool(`mcp__${serverName}__connector_search`, {})
+          ? this.callTool(`mcp__${serverName}__connector_search`, args)
           : Promise.resolve(null),
       ]);
 
@@ -681,20 +715,7 @@ export class McpManager {
     result: PromiseSettledResult<{ content: string; isError: boolean; errorCode?: McpErrorCode } | null>
   ): Array<{ name: string; description?: string }> {
     if (result.status !== "fulfilled" || !result.value || result.value.isError) return [];
-    try {
-      const data = JSON.parse(result.value.content);
-      const items = data?.data ?? data?.results ?? (Array.isArray(data) ? data : []);
-      if (!Array.isArray(items)) return [];
-      return items
-        .filter((item: Record<string, unknown>) => item.name)
-        .map((item: Record<string, unknown>) => ({
-          name: item.name as string,
-          ...(item.description ? { description: item.description as string } : {}),
-        }))
-        .slice(0, 30);
-    } catch {
-      return [];
-    }
+    return parseEntityList(result.value.content);
   }
 
   // -------------------------------------------------------------------------

--- a/src/tools/machina_loop.ts
+++ b/src/tools/machina_loop.ts
@@ -106,7 +106,13 @@ export const machinaLoopTool: BuiltinTool = {
       let value: Record<string, unknown> = {};
       try {
         const parsed = JSON.parse(res.content) as Record<string, unknown>;
-        const list = (parsed.data ?? parsed.results ?? parsed) as unknown;
+        let list = (parsed.data ?? parsed.results ?? parsed) as unknown;
+        // Machina's MCP wraps as { data: { data: [...] } } — unwrap the inner envelope.
+        if (list && !Array.isArray(list) && typeof list === "object") {
+          const inner = list as Record<string, unknown>;
+          if (Array.isArray(inner.data)) list = inner.data;
+          else if (Array.isArray(inner.results)) list = inner.results;
+        }
         const doc = Array.isArray(list) ? (list[0] as Record<string, unknown>) : undefined;
         if (doc) value = payloadOf(doc);
       } catch {
@@ -134,7 +140,10 @@ export const machinaLoopTool: BuiltinTool = {
     if (op === "start" && !sessionId) sessionId = `ses_${randomBytes(12).toString("hex")}`;
 
     const res = await mgr.callToolDirect(server, "execute_agent", {
-      name: RUNNER_AGENT,
+      // The pod's execute_agent requires `agent_id`; a non-ObjectId string is
+      // treated as an agent name (documented backward-compat), so this resolves
+      // `loop-runner` by name without a separate id lookup.
+      agent_id: RUNNER_AGENT,
       messages: [{ role: "user", content: prompt }],
       context: {
         "context-agent": {

--- a/test/machina-loop.test.mjs
+++ b/test/machina-loop.test.mjs
@@ -1,9 +1,29 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { findLoopServer, LOOP_RUNNER_AGENT } from "../dist/mcp.js";
+import { findLoopServer, LOOP_RUNNER_AGENT, parseEntityList } from "../dist/mcp.js";
 import { machinaLoopTool } from "../dist/tools/machina_loop.js";
 
 const caps = (agents) => ({ workflows: [], agents, connectors: [], discoveredAt: 0 });
+
+describe("parseEntityList — pod inventory parsing", () => {
+  it("unwraps Machina's double envelope { data: { data: [...] } }", () => {
+    const content = JSON.stringify({
+      status: "success",
+      data: { data: [{ name: "loop-runner" }, { name: "loop-beat" }], total_documents: 2 },
+    });
+    assert.deepEqual(parseEntityList(content).map((e) => e.name), ["loop-runner", "loop-beat"]);
+  });
+
+  it("handles the single-envelope shape { data: [...] }", () => {
+    const content = JSON.stringify({ data: [{ name: "a", description: "x" }] });
+    assert.deepEqual(parseEntityList(content), [{ name: "a", description: "x" }]);
+  });
+
+  it("returns [] for malformed or empty content", () => {
+    assert.deepEqual(parseEntityList("not json"), []);
+    assert.deepEqual(parseEntityList(JSON.stringify({ data: { data: [] } })), []);
+  });
+});
 
 describe("findLoopServer — durable loop detection", () => {
   it("detects the server exposing the loop-runner agent", () => {


### PR DESCRIPTION
## What

Follow-up to #113, found while validating the durable loop **end-to-end against a
live Machina pod over MCP**. Three fixes that make the integration actually connect:

1. **Pod-capability discovery was silently empty for Machina pods.** The search
   tools (`search_agents` / `search_workflows` / `connector_search`) return a
   **double envelope** `{ data: { data: [...] } }`, but `extractEntityNames`
   unwrapped only one level → an object, not an array → 0 entities. Extracted a pure,
   exported **`parseEntityList()`** that unwraps the inner envelope, and bumped the
   discovery `page_size` so detection doesn't miss late entries. This also restores
   the (previously empty) **pod-inventory** section of the system prompt, and is what
   makes `getMachinaLoopServer()` / the `machina_loop` tool light up.
2. **`machina_loop` execute_agent arg.** The pod's `execute_agent` requires
   `agent_id` (a non-ObjectId string is treated as a name), so pass `agent_id`, not
   `name`.
3. **`machina_loop` read parsing.** `search_documents` returns the same double
   envelope; the `read` action now unwraps it.

## Verified live (against a staging pod with the loop provisioned)
- `getMachinaLoopServer()` → the pod ✅
- `machina_loop` exposed in the tool list ✅
- `machina_loop start` builds the correct `execute_agent` call — the REST-equivalent
  `POST /agent/executor/loop-runner` succeeds and creates the durable `harness_session`.
- Tests: `parseEntityList` (single / double / malformed envelopes); full suite green; tsc clean.

## ⚠️ Separate server-side finding (NOT in this PR's scope)
The pod's **MCP `execute_agent` tool returns HTTP 500 for every agent** (verified
against `loop-runner` *and* an existing `entain-coverage-*` agent), while the
equivalent direct `POST /agent/executor/{name}` succeeds and all read tools work.
So the full MCP round-trip is currently blocked by a pod-side MCP-server bug in
`execute_agent`, independent of this code. Filed for the client-api/MCP team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)