### PR TITLE
fix(machina): reasoning models via custom baseURL + machina_loop routable + honest dispatch

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -614,7 +614,7 @@ export class sportsclawEngine {
           n === "get_agent_config" || n === "install_sport" || n === "remove_sport" ||
           n === "upgrade_sports_skills" || n === "spawn_subagent" || n === "list_subagents" ||
           n === "schedule_task" || n === "list_scheduled_tasks" || n === "cancel_scheduled_task" ||
-          n === "consolidate_memory"
+          n === "consolidate_memory" || n === "machina_loop"
         );
         return {
           activeTools: [...internalNames, ...mcpToolNames],
@@ -737,7 +737,7 @@ export class sportsclawEngine {
       name === "upgrade_sports_skills" || name === "spawn_subagent" ||
       name === "list_subagents" || name === "schedule_task" ||
       name === "list_scheduled_tasks" || name === "cancel_scheduled_task" ||
-      name === "consolidate_memory";
+      name === "consolidate_memory" || name === "machina_loop";
     return allToolNames.filter((name) => {
       if (isInternalTool(name) || name.startsWith("mcp__")) return true;
       const skill = this.registry.getSkillName(name);

--- a/src/llm-providers.ts
+++ b/src/llm-providers.ts
@@ -240,13 +240,21 @@ export function resolveModel(
       // and 404 on /v1/responses. Real OpenAI keeps the default factory so
       // o1/o3/gpt-5 reasoning features (reasoningEffort, web_search, etc.)
       // continue to work via /v1/responses.
+      //
+      // Exception: reasoning models (gpt-5*, o1*, o3*) reject function tools +
+      // reasoning_effort on /chat/completions ("Please use /v1/responses
+      // instead") — true for OpenAI-compatible gateways like Azure AI Foundry
+      // (`…/openai/v1/responses`). For those, use the Responses API even with a
+      // custom base; self-hosted (NIM/vLLM) chat targets keep `.chat()`.
       const customBase = process.env.OPENAI_BASE_URL;
       if (customBase) {
-        return createOpenAI({
+        const provider = createOpenAI({
           baseURL: customBase,
           apiKey: process.env.OPENAI_API_KEY ?? undefined,
           fetch: nimNemotronFetch(),
-        }).chat(modelId);
+        });
+        const isReasoningModel = /^(gpt-5|o1|o3)/i.test(modelId);
+        return isReasoningModel ? provider.responses(modelId) : provider.chat(modelId);
       }
       return openai(modelId);
     }

--- a/src/tools/machina_loop.ts
+++ b/src/tools/machina_loop.ts
@@ -155,6 +155,20 @@ export const machinaLoopTool: BuiltinTool = {
       },
     });
     if (res.isError) return { content: res.content, isError: true };
+    // The pod proxies execute_agent to the REST API; an upstream failure can come
+    // back as a status:error envelope WITHOUT the MCP layer flagging isError.
+    // Surface it honestly instead of claiming the loop is "running".
+    try {
+      const parsed = JSON.parse(res.content) as Record<string, unknown>;
+      if (parsed && parsed.status === "error") {
+        return err(
+          `loop dispatch failed: ${String(parsed.message ?? "execute_agent error")}`,
+          "the pod's execute_agent returned an error — its MCP server may be outdated (agent-by-name unsupported). See machina-client-api#287."
+        );
+      }
+    } catch {
+      /* non-JSON content — treat as a successful dispatch */
+    }
 
     return {
       content: JSON.stringify({


### PR DESCRIPTION
## Context
Found while **testing the SportsClaw→durable-loop integration live** with an Azure AI Foundry **gpt-5.5** deployment (OpenAI-compatible `…/openai/v1` endpoint). Three fixes were needed before the model could actually drive `machina_loop`.

## Fixes
1. **Reasoning models via `OPENAI_BASE_URL` → Responses API.** When a custom base is set, the provider forced `.chat()` (`/chat/completions`). gpt-5.5 (and o1/o3) reject *function tools + reasoning_effort* there — the API literally says *"Please use /v1/responses instead"*, which is what Azure AI Foundry's `…/openai/v1/responses` expects. Now reasoning models (`gpt-5*`/`o1*`/`o3*`) use `.responses()` even with a custom base; self-hosted NIM/vLLM chat targets keep `.chat()`.
2. **`machina_loop` was filtered out by the skill router.** It's a built-in capability tool (no `mcp__` prefix, not a sport skill), so `resolveActiveToolsForPrompt` dropped it from `activeTools` and the model couldn't call it. Added it to the always-active allowlists (MCP-only path + both skill-routed paths).
3. **Honest dispatch errors.** An upstream `execute_agent` failure can return a `status:error` envelope *without* the MCP layer flagging `isError`; `machina_loop` now detects that and surfaces the error instead of falsely reporting the durable session as `running`.

## Verified live
With an Azure gpt-5.5 deployment configured (`OPENAI_BASE_URL=…/openai/v1`), `sportsclaw "<prompt>"` now: reasons via `/responses`, **calls `machina_loop`**, and dispatches. The durable round-trip completes once the pod's MCP server is current — see machina-client-api#287 (the deployed MCP rejects agent-by-name, which is the only remaining gap; verified separately via the agent ObjectId).

Tests green (`machina-loop`, `builtin-tools`, full suite); `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)