### PR TITLE
docs: durable task delegation + reasoning/custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ docker build -t sportsclaw .
 docker run --rm -e ANTHROPIC_API_KEY=sk-... sportsclaw "Who won the Super Bowl?"  # or pass OPENAI_API_KEY / GEMINI_API_KEY
 ```
 
+### Models & endpoints
+
+sportsclaw works with **Anthropic**, **OpenAI**, and **Google** out of the box. Set `OPENAI_BASE_URL` to point at any OpenAI-compatible endpoint and it routes correctly: reasoning models (`gpt-5*` / `o1*` / `o3*`) use the **Responses API** — required by hosted gateways like **Azure AI Foundry** — while self-hosted chat models (**NVIDIA NIM**, **vLLM**) use `/chat/completions`. For sandboxed, policy-routed inference, run inside [NVIDIA OpenShell](openshell/README.md).
+
+### Connect premium data & durable loops (Machina)
+
+When you need licensed, real-time feeds or production SLAs, connect a [Machina](https://machina.gg) pod in one command:
+
+```bash
+sportsclaw machina connect             # mints a durable key via machina-cli and wires the pod
+# or bring your own MCP URL:
+sportsclaw mcp add <url> --name machina --token <key>
+```
+
+A connected pod can also run a **durable agentic loop** — sportsclaw delegates long, multi-step, resumable tasks to it (they survive interruptions, async waits, and restarts) and reads the result back. See the [docs](https://sportsclaw.gg/sports-data/machina) for details.
+
 ### When should you use it?
 
 sportsclaw is built for:

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ docker run --rm -e ANTHROPIC_API_KEY=sk-... sportsclaw "Who won the Super Bowl?"
 
 sportsclaw works with **Anthropic**, **OpenAI**, and **Google** out of the box. Set `OPENAI_BASE_URL` to point at any OpenAI-compatible endpoint and it routes correctly: reasoning models (`gpt-5*` / `o1*` / `o3*`) use the **Responses API** — required by hosted gateways like **Azure AI Foundry** — while self-hosted chat models (**NVIDIA NIM**, **vLLM**) use `/chat/completions`. For sandboxed, policy-routed inference, run inside [NVIDIA OpenShell](openshell/README.md).
 
-### Connect premium data & durable loops (Machina)
+### Connect a Machina pod (licensed data & durable loops)
 
-When you need licensed, real-time feeds or production SLAs, connect a [Machina](https://machina.gg) pod in one command:
+A connected [Machina](https://machina.gg) pod adds licensed, real-time feeds and production SLAs alongside the built-in keyless data. Connect one in a command:
 
 ```bash
 sportsclaw machina connect             # mints a durable key via machina-cli and wires the pod
@@ -104,7 +104,7 @@ sportsclaw machina connect             # mints a durable key via machina-cli and
 sportsclaw mcp add <url> --name machina --token <key>
 ```
 
-A connected pod can also run a **durable agentic loop** — sportsclaw delegates long, multi-step, resumable tasks to it (they survive interruptions, async waits, and restarts) and reads the result back. See the [docs](https://sportsclaw.gg/sports-data/machina) for details.
+A connected pod can also run a **durable agentic loop** — sportsclaw delegates long, multi-step, resumable tasks to it (they survive interruptions, async waits, and restarts) and reads the result back. See [Durable Task Delegation](https://sportsclaw.gg/advanced/durable-loop) for details.
 
 ### When should you use it?
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -98,6 +98,7 @@ export default defineConfig({
         text: 'Advanced',
         items: [
           { text: 'Connecting MCP Servers', link: '/advanced/mcp' },
+          { text: 'Durable Task Delegation', link: '/advanced/durable-loop' },
           { text: 'Watchers & Schedules', link: '/advanced/watchers' },
           { text: 'Operator Mode', link: '/advanced/operator' },
         ],

--- a/docs/advanced/durable-loop.md
+++ b/docs/advanced/durable-loop.md
@@ -1,0 +1,47 @@
+# Durable Task Delegation
+
+A normal tool call is one-shot: sportsclaw asks, the tool answers, the turn ends. Some work is
+bigger than that — research that spans many steps, jobs that wait on async data or human input,
+tasks that should survive a restart. For those, sportsclaw can hand the work to the **Machina
+durable loop** running on a connected pod, and stay responsive while the loop grinds on.
+
+## How it works
+
+When you connect a Machina pod that runs the durable loop (the `loop-runner` agent — see
+[Machina](../sports-data/machina)), sportsclaw automatically exposes a `machina_loop` tool. The
+loop lives on the pod, not in sportsclaw: every turn is persisted as a document and resumed by
+the pod's beat, so it survives interruptions, async tools, and waiting on input. sportsclaw's own
+loop stays fast and ephemeral — it delegates the long-running work, then reads the result back.
+
+The agent drives three actions:
+
+| Action | What it does |
+| --- | --- |
+| `start` | Begin a new durable session for a task. Returns a `session_id`. |
+| `continue` | Add a follow-up message to an existing session. |
+| `read` | Fetch the current state — latest reply, status, turn count. |
+
+You don't call these yourself — the agent does, when it decides a task is better run durably. You
+just ask:
+
+```bash
+sportsclaw "Delegate a durable task: track the next match and give me the pre-game analysis"
+```
+
+Starting or continuing a durable session is gated by the same approval prompt as other
+side-effecting actions, so you stay in control of what gets delegated. The pod's reply is treated
+as untrusted external data on the way back in.
+
+## Requirements
+
+- A connected Machina pod that runs the durable loop — wire one up with
+  [`sportsclaw machina connect`](../sports-data/machina#connecting-machina-to-sportsclaw) (or
+  `sportsclaw mcp add`). The `machina_loop` tool only appears when such a pod is connected.
+- The pod must expose the loop's `execute_agent` and `search_documents` tools over MCP.
+
+Check what's connected with `sportsclaw doctor` (it lists Machina pods) and `sportsclaw mcp list`.
+
+::: tip Ephemeral vs durable
+Use direct tools for a quick, in-the-moment answer. Reach for the durable loop when the work is
+long, multi-step, or needs to outlive a single exchange.
+:::

--- a/docs/advanced/durable-loop.md
+++ b/docs/advanced/durable-loop.md
@@ -3,7 +3,8 @@
 A normal tool call is one-shot: sportsclaw asks, the tool answers, the turn ends. Some work is
 bigger than that — research that spans many steps, jobs that wait on async data or human input,
 tasks that should survive a restart. For those, sportsclaw can hand the work to the **Machina
-durable loop** running on a connected pod, and stay responsive while the loop grinds on.
+durable loop** running on a connected pod — it dispatches the long-running work and reads the
+result back when it's ready.
 
 ## How it works
 
@@ -25,7 +26,7 @@ You don't call these yourself — the agent does, when it decides a task is bett
 just ask:
 
 ```bash
-sportsclaw "Delegate a durable task: track the next match and give me the pre-game analysis"
+sportsclaw "Track this week's match series and compile a pre-game analysis for each game"
 ```
 
 Starting or continuing a durable session is gated by the same approval prompt as other

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -41,8 +41,8 @@ can't produce images. Reading images you send the bot works on any vision-capabl
 
 ### Reasoning models & custom endpoints
 
-Point sportsclaw at any OpenAI-compatible endpoint with `OPENAI_BASE_URL`, and it routes each
-request the way that endpoint expects:
+Point sportsclaw at any OpenAI-compatible endpoint with `OPENAI_BASE_URL`, and it selects the
+API path based on the model name:
 
 - **Reasoning models** (`gpt-5*`, `o1*`, `o3*`) go over the **Responses API** — what hosted
   gateways like **Azure AI Foundry** (`…/openai/v1`) require for function tools + reasoning effort.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -39,6 +39,28 @@ Generating images (matchday graphics, etc.) requires **OpenAI or Google** — An
 can't produce images. Reading images you send the bot works on any vision-capable model.
 :::
 
+### Reasoning models & custom endpoints
+
+Point sportsclaw at any OpenAI-compatible endpoint with `OPENAI_BASE_URL`, and it routes each
+request the way that endpoint expects:
+
+- **Reasoning models** (`gpt-5*`, `o1*`, `o3*`) go over the **Responses API** — what hosted
+  gateways like **Azure AI Foundry** (`…/openai/v1`) require for function tools + reasoning effort.
+- **Self-hosted chat models** (NVIDIA NIM, vLLM) go over `/chat/completions`.
+- With no `OPENAI_BASE_URL`, real OpenAI keeps its defaults.
+
+```bash
+# Azure AI Foundry — a gpt-5.5 reasoning deployment
+export OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1
+export OPENAI_API_KEY=<key>
+# then pick the OpenAI provider + your model id in `sportsclaw config`
+
+# Self-hosted (NIM / vLLM)
+export OPENAI_BASE_URL=https://inference.local/v1
+```
+
+For sandboxed, policy-routed inference, see [NVIDIA OpenShell](../deployment/openshell).
+
 ## Reuse your Claude Code session
 
 If you already use Claude Code, you can skip the API key entirely and reuse that login:

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,16 @@ curl -fsSL https://sportsclaw.gg/install.sh | bash
 │ <b>></b> _    │
 └────────┘</pre>
 <h3>Open source, runs anywhere</h3>
-<p>MIT-licensed TypeScript. Run it from the CLI, host it as a bot, or deploy in Docker. Bring your own model — Anthropic, OpenAI, or Google.</p>
+<p>MIT-licensed TypeScript. Run it from the CLI, host it as a bot, or deploy in Docker. Bring your own model — Anthropic, OpenAI, Google, reasoning models (gpt-5 / o-series), or your own endpoint (Azure AI Foundry, self-hosted NIM/vLLM).</p>
+</a>
+
+<a class="sc-card" href="/advanced/durable-loop">
+<pre class="motif">┌─────────┐
+│ turn <b>3</b>  │
+│ resumes │
+└─────────┘</pre>
+<h3>Delegate durable, resumable work</h3>
+<p>Connect a Machina pod and hand off long, multi-step tasks to its durable loop — it persists every turn and resumes after interruptions, async waits, or restarts, while sportsclaw stays responsive.</p>
 </a>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ curl -fsSL https://sportsclaw.gg/install.sh | bash
 │ <b>></b> _    │
 └────────┘</pre>
 <h3>Open source, runs anywhere</h3>
-<p>MIT-licensed TypeScript. Run it from the CLI, host it as a bot, or deploy in Docker. Bring your own model — Anthropic, OpenAI, Google, reasoning models (gpt-5 / o-series), or your own endpoint (Azure AI Foundry, self-hosted NIM/vLLM).</p>
+<p>MIT-licensed TypeScript. Run it from the CLI, host it as a bot, or deploy in Docker. Bring your own model — Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint (Azure AI Foundry, self-hosted NIM/vLLM).</p>
 </a>
 
 <a class="sc-card" href="/advanced/durable-loop">
@@ -92,7 +92,7 @@ curl -fsSL https://sportsclaw.gg/install.sh | bash
 │ resumes │
 └─────────┘</pre>
 <h3>Delegate durable, resumable work</h3>
-<p>Connect a Machina pod and hand off long, multi-step tasks to its durable loop — it persists every turn and resumes after interruptions, async waits, or restarts, while sportsclaw stays responsive.</p>
+<p>Connect a Machina pod and hand off long, multi-step tasks to its durable loop — it persists every turn and resumes after interruptions, async waits, or restarts. sportsclaw dispatches the work and reads the result back.</p>
 </a>
 
 </div>

--- a/docs/sports-data/machina.md
+++ b/docs/sports-data/machina.md
@@ -101,7 +101,7 @@ never repeats within a conversation, and stays out of automated alerts and broad
 
 A connected Machina pod can also run a **durable agentic loop**. When it does, sportsclaw can
 hand long, multi-step, or resumable tasks to it — the loop persists every turn and resumes after
-interruptions, while sportsclaw stays responsive. See
+interruptions. sportsclaw dispatches the work and reads the result back. See
 [Durable Task Delegation](../advanced/durable-loop).
 
 Learn more at **[machina.gg](https://machina.gg)**.

--- a/docs/sports-data/machina.md
+++ b/docs/sports-data/machina.md
@@ -97,4 +97,11 @@ line pointing to the path (the `sports-skills premium` tier or `sportsclaw machi
 The data layer decides this, not the agent. It's informational only: it never blocks an answer,
 never repeats within a conversation, and stays out of automated alerts and broadcasts.
 
+## Durable task delegation
+
+A connected Machina pod can also run a **durable agentic loop**. When it does, sportsclaw can
+hand long, multi-step, or resumable tasks to it — the loop persists every turn and resumes after
+interruptions, while sportsclaw stays responsive. See
+[Durable Task Delegation](../advanced/durable-loop).
+
 Learn more at **[machina.gg](https://machina.gg)**.


### PR DESCRIPTION
Surfaces the two newest capabilities across homepage + README + docs.

**Durable task delegation** (machina_loop, #113–#116): new `advanced/durable-loop.md` (how it works, start/continue/read, approval-gated, requires a connected loop-capable Machina pod) + homepage card + machina.md cross-link + sidebar + README pointer.

**Reasoning models & custom endpoints** (#116): `OPENAI_BASE_URL` routing documented — reasoning models (`gpt-5*`/`o1*`/`o3*`) via the Responses API (Azure AI Foundry), self-hosted chat (NIM/vLLM), OpenShell. Added to `configuration.md`, a README "Models & endpoints" section, and the homepage "runs anywhere" card.

Framing: neutral (capability, not funnel) and honest (durable loop gated to a connected pod). `npm run docs:build` clean; homepage screenshotted. Site goes live on the next tag + rollout (auto-deploy still gated on the Azure cred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)