### PR TITLE
feat(operator): operator-sync — durable-loop verification of operator decisions

### DIFF
--- a/docs/advanced/operator.md
+++ b/docs/advanced/operator.md
@@ -34,3 +34,31 @@ There's no person asking — a schedule fires "ticks." On each tick the agent re
 decides whether there's anything worth saying (it can choose to stay silent), and publishes to
 the destination its job defines. It keeps a running memory between ticks so it doesn't repeat
 itself.
+
+## Operator-sync: durable-loop verification
+
+The operator has its own broadcast-safety gate, but that gate is the same process making the
+decision. **Operator-sync** adds a *second, independent* check: each time a tick **publishes**,
+the decision is routed to the durable **Machina harness loop**, which verifies it with its own
+generator/evaluator (the loop's `loop-evaluate`, a separate model + "assume broken" posture).
+
+Because the operator tick is synchronous but the loop is asynchronous and durable, the check is
+**start-now / read-next-tick**: the tick that publishes *starts* a loop verification session, and
+the *next* tick reads that session's verdict and injects it as a directive — e.g. *"the durable
+loop flagged the previous broadcast for review: &lt;reason&gt;; correct course."* The loop persists
+and resumes on its own, so a verdict is never lost.
+
+Enable it per job (`~/.sportsclaw/operator/<jobId>.json`):
+
+```json
+{
+  "jobId": "studio",
+  "intervalMs": 90000,
+  "operatorSync": { "enabled": true, "persona": "loop-reasoning" }
+}
+```
+
+Requirements: a connected Machina pod running the `loop-runner` agent (the same one that backs the
+`machina_loop` tool — `sportsclaw mcp add <pod>/mcp/sse --token <key>`). When no loop pod is
+connected, operator-sync is inert and the tick proceeds normally. The verdict directive appears on
+the tick *after* a publish, so it needs at least two ticks to close the loop.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, and Google.",
   "type": "module",
   "main": "dist/index.js",
@@ -42,6 +42,7 @@
     "test:heartbeat": "npm run build && node --test test/heartbeat.test.mjs",
     "test:heartbeat-wake-gate": "npm run build && node --test test/heartbeat-wake-gate.test.mjs",
     "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs",
+    "test:operator-sync": "npm run build && node --test test/operator-sync.test.mjs",
     "test:operator-config": "npm run build && node --test test/operator-config.test.mjs",
     "test:operate": "npm run build && node --test test/operate.test.mjs",
     "test:daemon-operator": "npm run build && node --test test/daemon-operator.test.mjs",

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -47,6 +47,7 @@ import {
   type OperatorSinkPlugin,
   type SinkContext,
 } from "./operator-sink.js";
+import { withOperatorSync } from "./operator-sync.js";
 import {
   BROADCAST_DIRECTIVE_FRAGMENT,
   buildSystemPrompt,
@@ -652,7 +653,7 @@ async function runDryRun(jobId: string): Promise<void> {
 
 async function runOnce(jobId: string): Promise<void> {
   const { config: cfg } = loadOperatorJobConfig(jobId);
-  const sink = await resolveSink(cfg);
+  const sink = withOperatorSync(await resolveSink(cfg), cfg);
   const tools = await buildOperatorTools(cfg, false, sink);
   try {
     const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
@@ -734,7 +735,7 @@ function exitCodeFor(event: TickEvent): number {
 
 async function runForeground(jobId: string): Promise<void> {
   const { config: cfg } = loadOperatorJobConfig(jobId);
-  const sink = await resolveSink(cfg);
+  const sink = withOperatorSync(await resolveSink(cfg), cfg);
   const tools = await buildOperatorTools(cfg, false, sink);
   const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
   if (inputs.openshell?.enabled) {

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -169,6 +169,20 @@ export interface OperatorJobConfig {
     };
     fallbackManifest?: unknown;
   };
+
+  /**
+   * operator-sync — route each PUBLISHED decision through the durable Machina
+   * harness loop for independent verification. The loop's own generator/evaluator
+   * (Cap 8 / 8.2) is a SECOND safety lens on top of `broadcastSafety`. Async and
+   * durable: the verdict is read on the NEXT tick and injected as a directive.
+   * Requires a connected Machina pod running the `loop-runner` agent. Off unless
+   * `enabled`.
+   */
+  operatorSync?: {
+    enabled: boolean;
+    /** Reasoning persona the loop uses (default: "loop-reasoning"). */
+    persona?: string;
+  };
 }
 
 export interface ValidationIssue {
@@ -483,6 +497,21 @@ export function validateOperatorJobConfig(
     }
   }
 
+  // operatorSync
+  if (raw.operatorSync !== undefined) {
+    if (typeof raw.operatorSync !== "object" || raw.operatorSync === null || Array.isArray(raw.operatorSync)) {
+      push("operatorSync", "must be an object");
+    } else {
+      const os = raw.operatorSync as Record<string, unknown>;
+      if (os.enabled !== undefined && typeof os.enabled !== "boolean") {
+        push("operatorSync.enabled", "must be a boolean");
+      }
+      if (os.persona !== undefined && typeof os.persona !== "string") {
+        push("operatorSync.persona", "must be a string");
+      }
+    }
+  }
+
   if (issues.length > 0) {
     return { valid: false, issues };
   }
@@ -512,6 +541,7 @@ export function validateOperatorJobConfig(
       openshell: parsedOpenShell,
       inference: raw.inference as ModelRoleRouterConfig | undefined,
       broadcastSafety: raw.broadcastSafety as OperatorJobConfig["broadcastSafety"],
+      operatorSync: raw.operatorSync as OperatorJobConfig["operatorSync"],
     },
   };
 }

--- a/src/operator-sync.ts
+++ b/src/operator-sync.ts
@@ -1,0 +1,214 @@
+/**
+ * operator-sync — route the operator daemon's published decisions through the
+ * durable Machina **harness loop** for independent, persisted verification.
+ *
+ * The operator tick is synchronous and in-process; the harness loop is async and
+ * durable (a `start` dispatches the turn server-side, the verdict lands later).
+ * So we bridge across ticks: when a tick PUBLISHES, we start a durable loop
+ * session that reviews the decision; on the NEXT tick we read that session's
+ * verdict and inject it as a deterministic directive. The loop's own
+ * generator/evaluator verification (Cap 8 / 8.2) is a *second* safety lens, on
+ * top of the daemon's broadcast-safety gate.
+ *
+ * This is a decorator over the resolved OperatorSink — zero daemon-core change.
+ * Opt in via `cfg.operatorSync.enabled`. When disabled it returns the sink as-is.
+ *
+ * Mirrors the call shapes of the `machina_loop` tool (src/tools/machina_loop.ts):
+ *   start → execute_agent {agent_id: loop-runner, context-agent:{op:"start", …}}
+ *   read  → search_documents {filters:{name:"harness_session", value.session_id}}
+ */
+
+import { randomBytes } from "node:crypto";
+import { LOOP_RUNNER_AGENT, type McpManager } from "./mcp.js";
+import { sanitizeInput } from "./security.js";
+import type { OperatorJobConfig } from "./operator-config.js";
+import type { OperatorSinkPlugin } from "./operator-sink.js";
+import type { TickEvent } from "./operator-daemon.js";
+
+const SESSION_DOC = "harness_session";
+const SESSION_ID_RE = /^ses_[0-9a-f]{24}$/;
+const MAX_DECISION_CHARS = 4000;
+const DEFAULT_PERSONA = "loop-reasoning";
+
+export interface LoopVerdict {
+  sessionId: string;
+  /** harness_session status: idle | needs_review | pending | failed | … */
+  status: string;
+  /** the loop's verification verdict: pass | fail | skipped | null */
+  verdict: string | null;
+  /** whether the loop self-repaired the answer before this verdict (Cap 8.2) */
+  repaired: boolean;
+  reason: string;
+  /** the loop's assistant reply, sanitized (the pod LLM is untrusted) */
+  reply: string | null;
+}
+
+/** Lift the workflow-saved payload (docs nest it under `value`; REST under `content`). */
+function payloadOf(doc: Record<string, unknown>): Record<string, unknown> {
+  const v = (doc.value ?? doc.content) as Record<string, unknown> | undefined;
+  return v && typeof v === "object" ? v : {};
+}
+
+/**
+ * Start a durable loop session that reviews an operator decision.
+ * Returns the (client-minted) session id, or null if no loop is connected / the
+ * dispatch failed.
+ */
+export async function dispatchDecisionToLoop(
+  mgr: McpManager,
+  decision: string,
+  persona: string = DEFAULT_PERSONA,
+): Promise<string | null> {
+  const server = mgr.getMachinaLoopServer?.();
+  if (!server) return null;
+  const text = decision.trim().slice(0, MAX_DECISION_CHARS);
+  if (!text) return null;
+  const sessionId = `ses_${randomBytes(12).toString("hex")}`;
+  const prompt =
+    "You are an INDEPENDENT reviewer of an automated sports-broadcast operator. " +
+    "Assess whether the following published decision is on-topic, internally consistent, " +
+    "and safe to broadcast. Call out anything wrong, unsupported, or unsafe; otherwise say it is sound.\n\n" +
+    "OPERATOR DECISION:\n" +
+    text;
+  const res = await mgr.callToolDirect(server, "execute_agent", {
+    agent_id: LOOP_RUNNER_AGENT,
+    messages: [{ role: "user", content: prompt }],
+    context: {
+      "context-agent": { op: "start", session_id: sessionId, input_message: prompt, persona_agent: persona },
+    },
+  });
+  if (res.isError) return null;
+  // The pod proxies execute_agent to REST; an upstream failure can return a
+  // status:error envelope WITHOUT the MCP layer flagging isError.
+  try {
+    const parsed = JSON.parse(res.content) as Record<string, unknown>;
+    if (parsed && parsed.status === "error") return null;
+  } catch {
+    /* non-JSON content — treat as a successful dispatch */
+  }
+  return sessionId;
+}
+
+/** Read a durable loop session's current verdict. Returns null if unreadable. */
+export async function readLoopVerdict(mgr: McpManager, sessionId: string): Promise<LoopVerdict | null> {
+  if (!SESSION_ID_RE.test(sessionId)) return null;
+  const server = mgr.getMachinaLoopServer?.();
+  if (!server) return null;
+  const res = await mgr.callToolDirect(server, "search_documents", {
+    filters: { name: SESSION_DOC, "value.session_id": sessionId },
+    page_size: 1,
+  });
+  if (res.isError) return null;
+  let value: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(res.content) as Record<string, unknown>;
+    let list = (parsed.data ?? parsed.results ?? parsed) as unknown;
+    // Machina's MCP wraps as { data: { data: [...] } } — unwrap the inner envelope.
+    if (list && !Array.isArray(list) && typeof list === "object") {
+      const inner = list as Record<string, unknown>;
+      if (Array.isArray(inner.data)) list = inner.data;
+      else if (Array.isArray(inner.results)) list = inner.results;
+    }
+    const doc = Array.isArray(list) ? (list[0] as Record<string, unknown>) : undefined;
+    if (doc) value = payloadOf(doc);
+  } catch {
+    return null;
+  }
+  // No document yet → the loop is still spinning up this session.
+  if (!value.session_id) {
+    return { sessionId, status: "pending", verdict: null, repaired: false, reason: "", reply: null };
+  }
+  const verification = (value.verification ?? {}) as Record<string, unknown>;
+  const entries = Array.isArray(value.entries) ? (value.entries as Array<Record<string, unknown>>) : [];
+  const lastAssistant = [...entries].reverse().find((e) => e.role === "assistant" && e.type === "message");
+  const rawReply = lastAssistant?.content;
+  const reply = typeof rawReply === "string" ? sanitizeInput(rawReply).sanitized : null;
+  return {
+    sessionId,
+    status: String(value.status ?? "unknown"),
+    verdict: verification.verdict != null ? String(verification.verdict) : null,
+    repaired: verification.repaired === true,
+    reason: typeof verification.reason === "string" ? verification.reason : "",
+    reply,
+  };
+}
+
+/**
+ * Render a loop verdict as a deterministic directive to prepend to the next tick.
+ * Returns null when there's nothing actionable yet (e.g. still pending).
+ */
+export function formatVerdictDirective(v: LoopVerdict): string | null {
+  if (v.status === "pending") return null;
+  if (v.status === "needs_review") {
+    return (
+      "[loop-verification] The durable loop flagged the PREVIOUS broadcast for review" +
+      (v.reason ? `: ${v.reason}` : "") +
+      ". Treat that decision as suspect and correct course this tick."
+    );
+  }
+  if (v.verdict === "pass") {
+    return (
+      "[loop-verification] The durable loop independently verified the previous broadcast (pass" +
+      (v.repaired ? ", after self-repair" : "") +
+      "). No correction required."
+    );
+  }
+  return null;
+}
+
+/** Extract a textual decision from a published TickEvent (prefers free text, falls back to structured output). */
+export function decisionTextFrom(evt: TickEvent): string {
+  if (typeof evt.text === "string" && evt.text.trim()) return evt.text;
+  if (evt.output != null) {
+    try {
+      return JSON.stringify(evt.output);
+    } catch {
+      /* unserializable — fall through */
+    }
+  }
+  return "";
+}
+
+/**
+ * Decorate a resolved sink with operator-sync. On a `tick_published`, start a
+ * durable loop verification session; on the next tick, read its verdict and
+ * inject it as a directive. The wrapped sink's own hooks still run.
+ *
+ * Returns the sink unchanged when `cfg.operatorSync` is disabled.
+ */
+export function withOperatorSync(sink: OperatorSinkPlugin, cfg: OperatorJobConfig): OperatorSinkPlugin {
+  if (!cfg.operatorSync?.enabled) return sink;
+  const persona = cfg.operatorSync.persona ?? DEFAULT_PERSONA;
+  // Cross-tick state: the session_id awaiting a verdict (start-now / read-next-tick).
+  let pendingSessionId: string | null = null;
+
+  return {
+    ...sink,
+    name: sink.name === "noop" ? "operator-sync" : `${sink.name}+operator-sync`,
+
+    async composeTickContext(args) {
+      const base = sink.composeTickContext ? await sink.composeTickContext(args) : null;
+      let directive: string | null = null;
+      if (pendingSessionId && args.mcpManager) {
+        const verdict = await readLoopVerdict(args.mcpManager, pendingSessionId).catch(() => null);
+        if (verdict) directive = formatVerdictDirective(verdict);
+        // Consume the link only once the loop has actually produced a verdict;
+        // keep polling it on subsequent ticks while it's still pending.
+        if (verdict && verdict.status !== "pending") pendingSessionId = null;
+      }
+      const parts = [base, directive].filter((s): s is string => Boolean(s));
+      return parts.length ? parts.join("\n\n") : null;
+    },
+
+    async onTickEvent(evt, ctx) {
+      if (sink.onTickEvent) await sink.onTickEvent(evt, ctx);
+      if (evt.type === "tick_published" && ctx.mcpManager) {
+        const decision = decisionTextFrom(evt);
+        if (decision) {
+          const sid = await dispatchDecisionToLoop(ctx.mcpManager, decision, persona).catch(() => null);
+          if (sid) pendingSessionId = sid;
+        }
+      }
+    },
+  };
+}

--- a/test/operator-sync.test.mjs
+++ b/test/operator-sync.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  dispatchDecisionToLoop,
+  readLoopVerdict,
+  formatVerdictDirective,
+  decisionTextFrom,
+  withOperatorSync,
+} from "../dist/operator-sync.js";
+
+const SID = "ses_0123456789abcdef01234567"; // ses_ + 24 hex
+
+// Fake McpManager: `server` defaults to a connected loop ("machina"); pass
+// server:null to simulate no loop. `tools` maps toolName -> result|fn(args).
+function fakeMgr({ server = "machina", tools = {} } = {}) {
+  const calls = [];
+  return {
+    _calls: calls,
+    getMachinaLoopServer: () => server,
+    callToolDirect: async (srv, tool, args) => {
+      calls.push({ tool, args });
+      const h = tools[tool];
+      const r = typeof h === "function" ? h(args) : h;
+      return r ?? { content: "{}", isError: false };
+    },
+  };
+}
+
+const ok = (obj) => ({ content: JSON.stringify(obj), isError: false });
+// Machina's MCP double envelope { data: { data: [...] } }
+const docEnvelope = (value) => ok({ status: "success", data: { data: value ? [{ value }] : [] } });
+
+describe("dispatchDecisionToLoop", () => {
+  it("mints a ses_ id and calls execute_agent on success", async () => {
+    const mgr = fakeMgr({ tools: { execute_agent: ok({ status: true }) } });
+    const sid = await dispatchDecisionToLoop(mgr, "publish block A");
+    assert.match(sid, /^ses_[0-9a-f]{24}$/);
+    assert.equal(mgr._calls[0].tool, "execute_agent");
+    assert.equal(mgr._calls[0].args.agent_id, "loop-runner");
+    assert.equal(mgr._calls[0].args.context["context-agent"].op, "start");
+  });
+
+  it("returns null when no loop server is connected", async () => {
+    const mgr = fakeMgr({ server: null });
+    assert.equal(await dispatchDecisionToLoop(mgr, "x"), null);
+    assert.equal(mgr._calls.length, 0);
+  });
+
+  it("returns null on an empty decision", async () => {
+    const mgr = fakeMgr({ tools: { execute_agent: ok({ status: true }) } });
+    assert.equal(await dispatchDecisionToLoop(mgr, "   "), null);
+  });
+
+  it("returns null when execute_agent flags isError", async () => {
+    const mgr = fakeMgr({ tools: { execute_agent: { content: "boom", isError: true } } });
+    assert.equal(await dispatchDecisionToLoop(mgr, "x"), null);
+  });
+
+  it("returns null on a status:error envelope (no isError flag)", async () => {
+    const mgr = fakeMgr({ tools: { execute_agent: ok({ status: "error", message: "stale MCP" }) } });
+    assert.equal(await dispatchDecisionToLoop(mgr, "x"), null);
+  });
+});
+
+describe("readLoopVerdict", () => {
+  it("parses the double envelope and surfaces the verdict + sanitized reply", async () => {
+    const value = {
+      session_id: SID,
+      status: "idle",
+      verification: { verdict: "pass", repaired: false, reason: "sound" },
+      entries: [{ role: "assistant", type: "message", content: "Looks sound." }],
+    };
+    const mgr = fakeMgr({ tools: { search_documents: docEnvelope(value) } });
+    const v = await readLoopVerdict(mgr, SID);
+    assert.equal(v.status, "idle");
+    assert.equal(v.verdict, "pass");
+    assert.equal(v.repaired, false);
+    assert.equal(v.reply, "Looks sound.");
+  });
+
+  it("reports repaired=true when the loop self-repaired (Cap 8.2)", async () => {
+    const value = { session_id: SID, status: "idle", verification: { verdict: "pass", repaired: true, reason: "" }, entries: [] };
+    const mgr = fakeMgr({ tools: { search_documents: docEnvelope(value) } });
+    const v = await readLoopVerdict(mgr, SID);
+    assert.equal(v.repaired, true);
+  });
+
+  it("returns pending when the session doc does not exist yet", async () => {
+    const mgr = fakeMgr({ tools: { search_documents: docEnvelope(null) } });
+    const v = await readLoopVerdict(mgr, SID);
+    assert.equal(v.status, "pending");
+    assert.equal(v.verdict, null);
+  });
+
+  it("rejects a malformed session_id without hitting the pod", async () => {
+    const mgr = fakeMgr({ tools: { search_documents: docEnvelope(null) } });
+    assert.equal(await readLoopVerdict(mgr, "not-a-session"), null);
+    assert.equal(mgr._calls.length, 0);
+  });
+
+  it("returns null when search flags isError", async () => {
+    const mgr = fakeMgr({ tools: { search_documents: { content: "err", isError: true } } });
+    assert.equal(await readLoopVerdict(mgr, SID), null);
+  });
+});
+
+describe("formatVerdictDirective", () => {
+  it("pass → a 'verified' directive", () => {
+    const d = formatVerdictDirective({ sessionId: SID, status: "idle", verdict: "pass", repaired: false, reason: "", reply: null });
+    assert.match(d, /verified/i);
+  });
+  it("pass + repaired → notes the self-repair", () => {
+    const d = formatVerdictDirective({ sessionId: SID, status: "idle", verdict: "pass", repaired: true, reason: "", reply: null });
+    assert.match(d, /self-repair/i);
+  });
+  it("needs_review → a review directive carrying the reason", () => {
+    const d = formatVerdictDirective({ sessionId: SID, status: "needs_review", verdict: "fail", repaired: false, reason: "off-topic", reply: null });
+    assert.match(d, /review/i);
+    assert.match(d, /off-topic/);
+  });
+  it("pending → null (nothing to inject yet)", () => {
+    assert.equal(formatVerdictDirective({ sessionId: SID, status: "pending", verdict: null, repaired: false, reason: "", reply: null }), null);
+  });
+});
+
+describe("decisionTextFrom", () => {
+  it("prefers free text", () => {
+    assert.equal(decisionTextFrom({ type: "tick_published", text: "hello" }), "hello");
+  });
+  it("falls back to structured output as JSON", () => {
+    assert.equal(decisionTextFrom({ type: "tick_published", output: { a: 1 } }), '{"a":1}');
+  });
+  it("returns empty string when there is nothing", () => {
+    assert.equal(decisionTextFrom({ type: "tick_silent" }), "");
+  });
+});
+
+describe("withOperatorSync — sink decorator", () => {
+  it("returns the sink unchanged when disabled", () => {
+    const sink = { name: "noop" };
+    assert.equal(withOperatorSync(sink, { operatorSync: { enabled: false } }), sink);
+    assert.equal(withOperatorSync(sink, {}), sink);
+  });
+
+  it("start-now / read-next-tick: dispatches on publish, injects the verdict next tick, and keeps base hooks", async () => {
+    const log = [];
+    const base = {
+      name: "noop",
+      composeTickContext: () => "BASE-DIRECTIVE",
+      onTickEvent: (evt) => { log.push(`base:${evt.type}`); },
+    };
+    const value = { session_id: SID, status: "idle", verification: { verdict: "pass", repaired: false, reason: "" }, entries: [] };
+    const mgr = fakeMgr({ tools: { execute_agent: ok({ status: true }), search_documents: docEnvelope(value) } });
+    const ctx = { jobId: "j", mcpManager: mgr, cfg: {} };
+
+    const wrapped = withOperatorSync(base, { operatorSync: { enabled: true } });
+    assert.match(wrapped.name, /operator-sync/);
+
+    // Tick N publishes → base hook fires + a loop session is dispatched.
+    await wrapped.onTickEvent({ type: "tick_published", text: "publish block A" }, ctx);
+    assert.deepEqual(log, ["base:tick_published"]);
+    assert.ok(mgr._calls.some((c) => c.tool === "execute_agent"));
+
+    // Tick N+1 composes → base directive AND the loop verdict are both injected.
+    const directive = await wrapped.composeTickContext({ jobId: "j", tickId: "t2", timestamp: "now", cfg: {}, mcpManager: mgr });
+    assert.match(directive, /BASE-DIRECTIVE/);
+    assert.match(directive, /loop-verification/);
+    assert.match(directive, /verified/i);
+    assert.ok(mgr._calls.some((c) => c.tool === "search_documents"));
+  });
+
+  it("does not dispatch on a non-published tick", async () => {
+    const mgr = fakeMgr({ tools: { execute_agent: ok({ status: true }) } });
+    const wrapped = withOperatorSync({ name: "noop" }, { operatorSync: { enabled: true } });
+    await wrapped.onTickEvent({ type: "tick_silent" }, { jobId: "j", mcpManager: mgr, cfg: {} });
+    assert.equal(mgr._calls.length, 0);
+  });
+});


### PR DESCRIPTION
## What
**Operator-sync (Phase 2):** an opt-in *second* safety lens on the operator daemon. Each time a tick **publishes**, the decision is routed to the durable **Machina harness loop** for independent verification — the loop's own generator/evaluator (Cap 8 / 8.2) on top of the daemon's broadcast-safety gate. Builds on the `machina_loop` durable-loop integration (#113–#116).

## The async bridge
The operator tick is **synchronous/in-process**; the harness loop is **async/durable**. So verification is **start-now / read-next-tick**:
1. The publishing tick **starts** a loop session that reviews the decision (`execute_agent` → `loop-runner`).
2. The **next** tick **reads** that session's verdict (`search_documents` on `harness_session`) and injects it as a deterministic directive — e.g. *"the durable loop flagged the previous broadcast for review: &lt;reason&gt;; correct course."*

The loop persists/resumes on its own, so a verdict is never lost; waiting on it in-tick (watchdog ~240s) would be structurally wrong.

## How it's wired
- **Decorator over the resolved `OperatorSink`** (`withOperatorSync`) — **zero daemon-core change**. Augments `onTickEvent` (dispatch on `tick_published`) and `composeTickContext` (inject the prior verdict); the wrapped sink's hooks still run. Cross-tick state is a closure (`pendingSessionId`).
- **Opt-in**: `cfg.operatorSync.enabled` (per-job `~/.sportsclaw/operator/<jobId>.json`). Inert when no loop pod is connected.
- Reuses the exact `machina_loop` `execute_agent` / `search_documents` shapes (incl. the `{data:{data:[…]}}` double-envelope unwrap and `sanitizeInput` on the untrusted pod reply). sportsclaw holds no loop state.

```json
{ "jobId": "studio", "intervalMs": 90000, "operatorSync": { "enabled": true, "persona": "loop-reasoning" } }
```

## Tests
`test/operator-sync.test.mjs` — **20 unit tests** (CI globs `test/*.test.mjs`):
- `dispatchDecisionToLoop`: mints `ses_…`, no-server / empty / isError / `status:error`-envelope → null
- `readLoopVerdict`: double-envelope parse, `repaired` (Cap 8.2), pending, malformed id, isError
- `formatVerdictDirective`: pass / pass+repaired / needs_review+reason / pending
- `withOperatorSync`: disabled → identity; **start-now/read-next-tick** end-to-end (dispatch on publish, inject verdict next tick, base hooks preserved); no dispatch on non-published ticks

Build clean (`tsc`); neighboring suites (operator-config / operate / operator-sink / operator-daemon / machina-loop) green — no regressions. The loop MCP round-trip these calls wrap is already live-verified.

## Files
- `src/operator-sync.ts` (new) · `src/operate.ts` · `src/operator-config.ts` · `test/operator-sync.test.mjs` (new) · `docs/advanced/operator.md` · `package.json` (v0.29.0)

## Follow-ups (not in scope)
- fs-persist `pendingSessionId` so a restart doesn't drop one in-flight verification
- a structured-output schema for the loop verdict + re-running `validateManifestCoverage` on loop output as a manifest-level lens

🤖 Generated with [Claude Code](https://claude.com/claude-code)