### PR TITLE
fix(operator-sync): inject the loop's actual assessment, not a bare verdict stamp

### DIFF
--- a/docs/advanced/operator.md
+++ b/docs/advanced/operator.md
@@ -44,9 +44,11 @@ generator/evaluator (the loop's `loop-evaluate`, a separate model + "assume brok
 
 Because the operator tick is synchronous but the loop is asynchronous and durable, the check is
 **start-now / read-next-tick**: the tick that publishes *starts* a loop verification session, and
-the *next* tick reads that session's verdict and injects it as a directive — e.g. *"the durable
-loop flagged the previous broadcast for review: &lt;reason&gt;; correct course."* The loop persists
-and resumes on its own, so a verdict is never lost.
+the *next* tick reads that session's result and injects the reviewer's **actual assessment** as a
+directive — e.g. *"[loop-review] an independent reviewer assessed the previous broadcast: the
+broadcast claims a fixture not present in the data."* (When the loop's own review is itself
+unreliable it injects a "double-check" caution instead of trusting it.) The loop persists and
+resumes on its own, so a verdict is never lost.
 
 Enable it per job (`~/.sportsclaw/operator/<jobId>.json`):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, and Google.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/operator-sync.ts
+++ b/src/operator-sync.ts
@@ -136,22 +136,27 @@ export async function readLoopVerdict(mgr: McpManager, sessionId: string): Promi
 /**
  * Render a loop verdict as a deterministic directive to prepend to the next tick.
  * Returns null when there's nothing actionable yet (e.g. still pending).
+ *
+ * The verdict (`pass`/`needs_review`) judges whether the loop's *review* is sound —
+ * NOT whether the decision is safe. So when the review is trustworthy (`pass`) we
+ * surface the loop's actual ASSESSMENT (`reply`), which may itself flag a problem
+ * with the broadcast; a bare "verified" stamp would hide that. When the review is
+ * unreliable (`needs_review`) we caution rather than trust its content.
  */
 export function formatVerdictDirective(v: LoopVerdict): string | null {
   if (v.status === "pending") return null;
   if (v.status === "needs_review") {
     return (
-      "[loop-verification] The durable loop flagged the PREVIOUS broadcast for review" +
-      (v.reason ? `: ${v.reason}` : "") +
-      ". Treat that decision as suspect and correct course this tick."
+      "[loop-verification] The independent review of the previous broadcast was inconclusive" +
+      (v.reason ? ` (${v.reason})` : "") +
+      " — double-check that decision before continuing."
     );
   }
   if (v.verdict === "pass") {
-    return (
-      "[loop-verification] The durable loop independently verified the previous broadcast (pass" +
-      (v.repaired ? ", after self-repair" : "") +
-      "). No correction required."
-    );
+    const reply = v.reply?.trim();
+    return reply
+      ? `[loop-review] An independent reviewer assessed the previous broadcast: ${reply}`
+      : "[loop-verification] The previous broadcast passed independent review; no concerns raised.";
   }
   return null;
 }

--- a/test/operator-sync.test.mjs
+++ b/test/operator-sync.test.mjs
@@ -105,18 +105,20 @@ describe("readLoopVerdict", () => {
 });
 
 describe("formatVerdictDirective", () => {
-  it("pass → a 'verified' directive", () => {
+  it("pass WITH a reply → surfaces the loop's actual assessment (not a bare 'verified' stamp)", () => {
+    const d = formatVerdictDirective({ sessionId: SID, status: "idle", verdict: "pass", repaired: false, reason: "", reply: "The broadcast claims a fixture not in the data." });
+    assert.match(d, /loop-review/);
+    assert.match(d, /fixture not in the data/);
+  });
+  it("pass WITHOUT a reply → falls back to a passed-review note", () => {
     const d = formatVerdictDirective({ sessionId: SID, status: "idle", verdict: "pass", repaired: false, reason: "", reply: null });
-    assert.match(d, /verified/i);
+    assert.match(d, /passed independent review/i);
   });
-  it("pass + repaired → notes the self-repair", () => {
-    const d = formatVerdictDirective({ sessionId: SID, status: "idle", verdict: "pass", repaired: true, reason: "", reply: null });
-    assert.match(d, /self-repair/i);
-  });
-  it("needs_review → a review directive carrying the reason", () => {
-    const d = formatVerdictDirective({ sessionId: SID, status: "needs_review", verdict: "fail", repaired: false, reason: "off-topic", reply: null });
-    assert.match(d, /review/i);
+  it("needs_review → an inconclusive caution carrying the reason, and does NOT trust the reply", () => {
+    const d = formatVerdictDirective({ sessionId: SID, status: "needs_review", verdict: "fail", repaired: false, reason: "off-topic", reply: "junk review" });
+    assert.match(d, /inconclusive/i);
     assert.match(d, /off-topic/);
+    assert.doesNotMatch(d, /loop-review/);
   });
   it("pending → null (nothing to inject yet)", () => {
     assert.equal(formatVerdictDirective({ sessionId: SID, status: "pending", verdict: null, repaired: false, reason: "", reply: null }), null);
@@ -149,7 +151,12 @@ describe("withOperatorSync — sink decorator", () => {
       composeTickContext: () => "BASE-DIRECTIVE",
       onTickEvent: (evt) => { log.push(`base:${evt.type}`); },
     };
-    const value = { session_id: SID, status: "idle", verification: { verdict: "pass", repaired: false, reason: "" }, entries: [] };
+    const value = {
+      session_id: SID,
+      status: "idle",
+      verification: { verdict: "pass", repaired: false, reason: "" },
+      entries: [{ role: "assistant", type: "message", content: "Broadcast looks sound." }],
+    };
     const mgr = fakeMgr({ tools: { execute_agent: ok({ status: true }), search_documents: docEnvelope(value) } });
     const ctx = { jobId: "j", mcpManager: mgr, cfg: {} };
 
@@ -164,8 +171,8 @@ describe("withOperatorSync — sink decorator", () => {
     // Tick N+1 composes → base directive AND the loop verdict are both injected.
     const directive = await wrapped.composeTickContext({ jobId: "j", tickId: "t2", timestamp: "now", cfg: {}, mcpManager: mgr });
     assert.match(directive, /BASE-DIRECTIVE/);
-    assert.match(directive, /loop-verification/);
-    assert.match(directive, /verified/i);
+    assert.match(directive, /loop-review/);
+    assert.match(directive, /Broadcast looks sound/);
     assert.ok(mgr._calls.some((c) => c.tool === "search_documents"));
   });
 


### PR DESCRIPTION
## Why
Follow-up to #118, **found by the live E2E** against staging. operator-sync routed a broadcast decision to the durable loop; the loop's reviewer correctly caught a factual inconsistency (*"the broadcast claims a Senegal vs Iraq fixture, but no such fixture is in the data"*) — yet the injected directive read **"verified, no correction required."**

Root cause: the loop verdict (`pass` / `needs_review`) judges whether the loop's **review** is well-formed, **not** whether the **decision** is safe. So a bare "verified" stamp hid the reviewer's actual finding.

## Fix
`formatVerdictDirective` now treats the verdict as a *trust gate on the review*, and surfaces the review's content:
- **`pass`** (review trustworthy) → inject the reviewer's **actual assessment** (`reply`): `[loop-review] An independent reviewer assessed the previous broadcast: …`
- **`needs_review`** (review itself unreliable) → a `inconclusive … double-check` caution; **do not** trust the reply
- **`pending`** → nothing yet

This makes the second lens actually convey what the loop found.

## Tests
`test/operator-sync.test.mjs` updated (20 pass): pass-with-reply surfaces the assessment, pass-without-reply falls back, needs_review cautions and does **not** echo the reply, and the start-now/read-next-tick integration test asserts the reply is injected. Build clean.

`v0.29.1` · `src/operator-sync.ts` · `test/operator-sync.test.mjs` · `docs/advanced/operator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)