### PR TITLE
fix(openshell): allow world-cup-2 MCP egress in sandbox policy

### DIFF
--- a/openshell/policy.yaml
+++ b/openshell/policy.yaml
@@ -39,6 +39,11 @@ network_policies:
         protocol: rest
         enforcement: enforce
         access: full
+      - host: machina-drops-world-cup-2.org.machina.gg
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
     binaries:
       - path: /usr/local/bin/node
 


### PR DESCRIPTION
The operator daemon connects to both tv-mcp and world-cup-mcp, but the sandbox
egress policy only allowed the tv-mcp host — so world-cup-mcp failed with
`Proxy response (403) when HTTP Tunneling` and the daemon couldn't ground
broadcasts in the WC pod.

Adds `machina-drops-world-cup-2.org.machina.gg:443` to the `mcp_server` egress
endpoints. Verified live: MCP connects clean, broadcasts pull WC news/markets/
scores with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)