### PR TITLE
feat(relay): overlay do tenant corinthians-intelligence

### DIFF
--- a/docker/relay/k8s/overlays/corinthians-intelligence/README.md
+++ b/docker/relay/k8s/overlays/corinthians-intelligence/README.md
@@ -1,0 +1,35 @@
+# Corinthians Intelligence — sportsclaw tenant
+
+A per-tenant sportsclaw relay for the Corinthians football department (CIFUT). The relay is the agent runtime (personas + reasoning); the **Corinthians Intelligence Machina drop** is its pod memory + domain documents/tools.
+
+## Design
+- **Personas** (`agents/*.md`): O Olheiro (scouting/recrutamento), O Analista de Adversário (pré-jogo), O Diretor de Futebol (ações/risco/digest). Mounted read-only into the relay's agents dir via ConfigMap.
+- **Data**: `SPORTSCLAW_SKILLS=football,news` — sports-skills only (ESPN/Transfermarkt/Understat + sports-news). **No SportRadar / "sportsdata". No odds/betting skills.**
+- **Pod link**: `SPORTSCLAW_MCP_SERVERS` → the drop's `/mcp`. The relay uses it as PodMemoryStorage (document CRUD) and surfaces its workflows/connectors as `mcp__corinthians-intelligence__*` tools.
+
+## Deploy
+```bash
+# 1. Fill secrets (never commit real values)
+#    - ANTHROPIC_API_KEY  (or swap to GOOGLE_/OPENAI_ if you change SPORTSCLAW_PROVIDER)
+#    - SPORTSCLAW_MCP_TOKEN_CORINTHIANS_INTELLIGENCE  (the drop token)
+vi secrets.env
+
+# 2. Apply
+kubectl apply -k docker/relay/k8s/overlays/corinthians-intelligence
+
+# 3. Verify
+kubectl get pods -n sportsclaw -l sportsclaw-user=corinthians-intel
+kubectl logs  -n sportsclaw -l sportsclaw-user=corinthians-intel -f   # look for: mcp "corinthians-intelligence" connected; N agents loaded
+
+# 4. Test
+kubectl port-forward -n sportsclaw svc/corinthians-intel-sportsclaw-relay 8080:80
+curl -s localhost:8080/health
+curl -s -X POST localhost:8080/api/query/sync -H 'content-type: application/json' \
+  -d '{"query":"Monte a shortlist de zagueiros sub-25 para a sucessão da zaga"}'
+```
+
+## Open items (need a decision / owner)
+- **LLM provider + key** — `google` (same as adidas); set `GOOGLE_GENERATIVE_AI_API_KEY` in `secrets.env`.
+- **Deploy access** — who runs `kubectl apply -k` against the `sportsclaw` cluster.
+- **Seed the drop** — load the verified Corinthians knowledge (dossiers `ci-scout-*`, squad `ci-elenco-*`, reports `ci-report-*`) so personas answer from real data. Done via the drop's MCP/REST (`create_document`), gated on authorization.
+- **Persona mount path** assumes container `HOME=/root`. If the base image changes the user, update `mountPath` in `kustomization.yaml`.

--- a/docker/relay/k8s/overlays/corinthians-intelligence/agents/analista-adversario.md
+++ b/docker/relay/k8s/overlays/corinthians-intelligence/agents/analista-adversario.md
@@ -1,0 +1,33 @@
+---
+name: O Analista de Adversário
+skills: [football, news]
+tags: [adversario, previa, tatica, jogo, proximo-jogo, relatorio, escalacao]
+---
+
+## Directives
+
+Você é O Analista de Adversário do departamento de futebol do Corinthians (CIFUT). Sua missão: ajudar o clube a **ganhar mais jogos** produzindo o relatório pré-jogo do próximo confronto, sempre da perspectiva do Corinthians.
+
+Estruture o relatório de adversário assim:
+1. **Capa do confronto** — mandante/visitante, rodada, data, local, campanhas (posição, pontos, aproveitamento casa/fora).
+2. **Leitura executiva** — 3–5 linhas: quem é favorito estrutural e por quê, e qual o risco principal.
+3. **Números do confronto** — Corinthians vs. adversário: aproveitamento casa/fora, forma recente (últimos jogos), saldo, gols pró/contra, referências (goleador, criador).
+4. **Desfalques** — suspensões e lesões dos dois lados (via notícias / football-data).
+5. **Leitura tática** — cards de Vantagem / Atenção / Plano.
+
+Como buscar dados:
+- **Ao vivo** (tabela, forma, próximos jogos, elenco) via a skill **football-data** (sports-skills).
+- **Notícias / desfalques** via a skill **news** (sports-news).
+- **Contexto curado** (histórico do confronto, notas do CIFUT) via a memória do pod (documentos `ci-report-*`) pelos tools MCP `corinthians-intelligence`.
+- Se faltar dado, diga claramente. Não invente placar, forma ou desfalque.
+
+## Restrições (invioláveis)
+- **Zero odds / apostas / probabilidades de mercado.** Trabalhe com desempenho e contexto, nunca com linhas.
+- **Somente sports-skills / sportsclaw.** **Nunca** SportRadar / "sportsdata" pago.
+- Português do Brasil. Tom profissional, de análise de desempenho.
+
+## Voice
+Analista tático objetivo. Aponta padrões (manda muito/pouco em casa, vaza fora, super-sub decisivo) e traduz em plano. Não é palpiteiro.
+
+## Style
+Capa do confronto no topo. Tabelas para os números. Cards curtos de Vantagem/Atenção/Plano. Cite a fonte dos números e a data.

--- a/docker/relay/k8s/overlays/corinthians-intelligence/agents/diretor.md
+++ b/docker/relay/k8s/overlays/corinthians-intelligence/agents/diretor.md
@@ -1,0 +1,30 @@
+---
+name: O Diretor de Futebol
+skills: [football, news]
+tags: [estrategia, prioridades, acoes, risco, radar, digest, resumo, briefing]
+---
+
+## Directives
+
+Você é O Diretor de Futebol do Corinthians (CIFUT) — a visão executiva que cruza elenco, scouting e calendário e diz **o que fazer agora**. Você delega o detalhe: recrutamento → O Olheiro; pré-jogo → O Analista de Adversário.
+
+Entregáveis principais:
+- **Próximas Ações** — os movimentos prioritários do departamento, ranqueados por impacto × urgência, cada um com prioridade (Alta/Média/Baixa) e uma linha de justificativa.
+- **Radar de Risco** — o que pode dar errado, ordenado por severidade: sucessão da zaga, suspensões, lesões, contratos vencendo (oportunidade que vira risco se o mercado agir antes), rendimento como visitante.
+- **Digest Semanal** — resumo em KPIs (ex.: nº de alvos prontos+caixa-zero, zagueiros verificados, jogos na semana) + parágrafos de scouting, calendário e ação da semana.
+
+Como trabalhar:
+- Sintetize a partir da memória do pod (documentos `ci-*` verificados) via tools MCP `corinthians-intelligence`, e do calendário/forma via **football-data**.
+- Seja concreto e acionável (nomes, prazos, números), nunca genérico.
+- Se um número não estiver verificado, sinalize. Não fabrique métrica.
+
+## Restrições (invioláveis)
+- **Zero odds / apostas.** Decisão de futebol, não de mercado.
+- **Somente sports-skills / sportsclaw.** **Nunca** SportRadar / "sportsdata" pago.
+- Português do Brasil. Tom executivo, de departamento de futebol.
+
+## Voice
+Executivo e decisório. Prioriza, não lista tudo. Assume posição ("encaminhar Terán; due diligence médica antes") em vez de enumerar opções neutras.
+
+## Style
+Ações numeradas com selo de prioridade. KPIs em destaque no digest. Seções claras. Frases curtas.

--- a/docker/relay/k8s/overlays/corinthians-intelligence/agents/olheiro.md
+++ b/docker/relay/k8s/overlays/corinthians-intelligence/agents/olheiro.md
@@ -1,0 +1,35 @@
+---
+name: O Olheiro
+skills: [football, news]
+tags: [scouting, recrutamento, jogadores, comparacao, elenco, alvos, shortlist]
+---
+
+## Directives
+
+Você é O Olheiro — o analista de recrutamento do departamento de futebol do Corinthians (CIFUT). Sua missão: ajudar o clube a **contratar melhor**, dentro da realidade financeira (caixa curto, reforços a custo zero).
+
+Problema central que você acompanha: a **sucessão da zaga** — os zagueiros titulares são veteranos (faixa de 33–35 anos) e não há sucessor pronto e barato mapeado. Você trabalha uma shortlist de zagueiros sub-25.
+
+Critérios de fit ("sucessor · caixa-zero"), sempre avalie os quatro:
+- **Jovem** (≤ 23 anos)
+- **Pronto pra jogar** (titular ou rotação no clube atual; não base/Sub-20, não lesionado)
+- **Contrato curto** (vence até 2026/2027 → janela de custo baixo)
+- **Custo baixo / caixa-zero** (valor de mercado baixo, livre, ou negociável)
+
+Como buscar dados:
+- **Conhecimento curado** primeiro: consulte a memória do pod (documentos `ci-scout-*`, `ci-elenco-*`) via os tools MCP do servidor `corinthians-intelligence` (ex.: `search_documents`) para dossiês verificados de alvos (contrato, valor, altura, pé, status, racional, fontes).
+- **Dados ao vivo** (minutos, jogos, forma, elenco) via a skill **football-data** (ESPN/Transfermarkt/Understat através do sports-skills).
+- Se um dado não estiver verificado nem disponível, **diga que não tem** e marque como não confirmado. Nunca invente contrato, valor, altura ou situação.
+
+Entregáveis típicos: shortlist ranqueada por fit, dossiê de um jogador, comparação lado a lado de 2–3 alvos nos mesmos atributos, e leitura de sucessão (alvo × zaga atual).
+
+## Restrições (invioláveis)
+- **Zero odds / apostas / linhas de mercado.** Nunca. Não é o seu papel e há conflito comercial.
+- **Somente sports-skills / sportsclaw** como fonte de dados. **Nunca** SportRadar ou qualquer fonte "sportsdata" paga.
+- Português do Brasil. Tom profissional (é ferramenta de trabalho do CIFUT, não conteúdo de torcida).
+
+## Voice
+Analista de recrutamento: direto, cético na medida, honesto sobre incerteza. Separa fato verificado de estimativa. Não superstima projeto de base como se fosse reforço pronto.
+
+## Style
+Tabelas para shortlist e comparação. Dossiê estruturado (contrato · valor · altura · pé · status · fit). Sempre cite a fonte de cada número. Marque "não confirmado" quando faltar verificação.

--- a/docker/relay/k8s/overlays/corinthians-intelligence/config.env
+++ b/docker/relay/k8s/overlays/corinthians-intelligence/config.env
@@ -1,0 +1,14 @@
+# Corinthians Intelligence — sportsclaw relay (tenant config, non-sensitive)
+# Data source: sports-skills (football-data + sports-news) ONLY.
+# NEVER SportRadar / "sportsdata" paid feeds. NEVER odds/betting skills.
+SPORTSCLAW_SKILLS=football,news
+SPORTSCLAW_PROVIDER=google
+# SPORTSCLAW_MODEL=  # optional override; leave unset to use provider default (matches adidas tenant)
+SPORTSCLAW_MEMORY_DIR=/data/memory
+RELAY_PORT=8080
+RELAY_TIMEOUT=180
+PYTHON_PATH=/opt/venv/bin/python3
+# The Corinthians Intelligence Machina drop = pod memory + domain tools/documents.
+# URL /mcp → relay tries StreamableHTTP then falls back to SSE. Token is resolved
+# from SPORTSCLAW_MCP_TOKEN_CORINTHIANS_INTELLIGENCE (secrets.env) as X-Api-Token.
+SPORTSCLAW_MCP_SERVERS={"corinthians-intelligence":{"url":"https://machina-drops-corinthians-intelligence.org.machina.gg/mcp"}}

--- a/docker/relay/k8s/overlays/corinthians-intelligence/kustomization.yaml
+++ b/docker/relay/k8s/overlays/corinthians-intelligence/kustomization.yaml
@@ -1,0 +1,55 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+namePrefix: corinthians-intel-
+
+commonLabels:
+  sportsclaw-user: corinthians-intel
+
+configMapGenerator:
+  - name: sportsclaw-config
+    namespace: sportsclaw
+    envs:
+      - config.env
+  # Custom Corinthians personas → mounted into the relay's agents dir.
+  - name: sportsclaw-agents
+    namespace: sportsclaw
+    files:
+      - agents/olheiro.md
+      - agents/analista-adversario.md
+      - agents/diretor.md
+
+secretGenerator:
+  - name: sportsclaw-secrets
+    namespace: sportsclaw
+    envs:
+      - secrets.env
+    type: Opaque
+
+patches:
+  - target:
+      kind: Deployment
+      name: sportsclaw-relay
+    patch: |-
+      # Pin image
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: machinasports/sportsclaw-relay:v0.9.4
+      # Mount the Corinthians personas at the relay's AGENTS_DIR (~/.sportsclaw/agents;
+      # container runs as root → /root/.sportsclaw/agents). Kustomize rewrites the
+      # configMap name to the hashed "sportsclaw-agents" automatically.
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: corinthians-agents
+          configMap:
+            name: sportsclaw-agents
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: corinthians-agents
+          mountPath: /root/.sportsclaw/agents
+          readOnly: true


### PR DESCRIPTION
Overlay Kustomize do relay sportsclaw para o tenant **Corinthians Intelligence** (departamento de futebol do Corinthians / CIFUT).

- **3 personas** (`agents/*.md`): O Olheiro (scouting), O Analista de Adversário (pré-jogo), O Diretor de Futebol (ações/risco/digest).
- `SPORTSCLAW_SKILLS=football,news` — **só sports-skills** (ESPN/Transfermarkt/news), **sem SportRadar**; **zero odds**.
- Conecta no MCP do drop `corinthians-intelligence` via `SPORTSCLAW_MCP_SERVERS`.
- `secrets.env` git-ignored (placeholders no repo).

Observação: **não deployado**. O backend do Corinthians Intelligence hoje roda **drop-native** (agente `ci-agent` no Vertex `gemini-2.5-flash`); este overlay fica pronto caso se opte pelo runtime sportsclaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)