### PR TITLE
feat: reliability and intelligence upgrade

### DIFF
--- a/docs/superpowers/plans/2026-07-07-sportsclaw-reliability-intelligence.md
+++ b/docs/superpowers/plans/2026-07-07-sportsclaw-reliability-intelligence.md
@@ -1,0 +1,1429 @@
+# sportsclaw Reliability + Intelligence Upgrade — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add generic, non-proprietary reliability plumbing to the sportsclaw engine (failure classification + clean user messages, a `selftest` command, persistent entity cache, complexity-aware routing, and a consolidated safe-execute wrapper with redacted logs), plus one gated server-side fix for the World Cup market-state workflow.
+
+**Architecture:** Extend existing modules rather than fork them. Failure classification composes `bridge.ts::classifyBridgeError` and `mcp.ts::classifyError`. Entity persistence sits behind the existing in-memory `EntityResolver`. Complexity routing layers onto `router.ts`. The safe-execute wrapper consolidates the sanitize→cache→bridge→circuit-breaker chain already present in `ToolRegistry`. Proprietary market-ID normalization stays out of the MIT client and lives server-side in the hosted `worldcup-get-market-state` MCP workflow.
+
+**Tech Stack:** Node.js / TypeScript / ESM, `discord.js`, Vercel AI SDK, `node:test` + `node:assert/strict` for tests (run against compiled `dist/`), Python `sports-skills` backend via subprocess bridge.
+
+## Global Constraints
+
+- Language: TypeScript / ESM only. Local imports MUST use explicit `.js` extensions. No new Python. No SQLite dependency.
+- Files: kebab-case. Variables/functions: camelCase. Types/classes: PascalCase.
+- License is MIT and `dist/` ships publicly to npm — NO proprietary kalshi/polymarket normalization logic in `src/`.
+- Tests: `node:test` (`describe`/`it`) + `node:assert/strict`, importing from `../dist/<module>.js`. Each test gets a `test:<name>` script in `package.json` of the exact form `npm run build && node --test test/<name>.test.mjs`.
+- Follow house style: prefer `export type X = "a" | "b"` string unions over TS `enum` (see `BridgeErrorCode` in `src/bridge.ts:29`).
+- Build success = `npm run build` (tsc, no emit errors).
+- Commit after each task; do not push.
+
+## Existing types (verbatim, do not redefine)
+
+```typescript
+// src/bridge.ts
+export interface ToolCallInput { [key: string]: any; }
+export interface ToolCallResult { content: string; isError?: boolean; }
+export type BridgeErrorCode =
+  | "timeout" | "dependency_missing" | "network_dns" | "rate_limited"
+  | "python_version_incompatible" | "circuit_open" | "tool_execution_failed";
+export function classifyBridgeError(error?: string, stderr?: string):
+  { errorCode: BridgeErrorCode; hint: string };
+```
+
+## File Structure
+
+- Create `src/failures/types.ts` — `FailureCategory`, `ClassifiedFailure` (Phase 1b).
+- Create `src/failures/classifier.ts` — `classifyFailure()`, `renderUserMessage()` (Phase 1b/§8).
+- Create `src/selftest/cases.ts` — `SmokeTestCase`, `SMOKE_TESTS` (Phase 2).
+- Create `src/selftest/runner.ts` — `runSelftest()`, `SelfTestReport` (Phase 2).
+- Create `src/selftest/report.ts` — markdown/JSON rendering (Phase 2).
+- Modify `src/index.ts` — add `cmdSelftest` + arg dispatch (Phase 2).
+- Create `src/cache/entity-store.ts` — JSON persistence + TTL (Phase 3).
+- Modify `src/intelligence/entity-resolver.ts` — load/save hooks (Phase 3).
+- Create `src/routing/complexity.ts` — `classifyQueryComplexity()`, `planSkillCaps()` (Phase 4).
+- Modify `src/router.ts` — consume complexity plan (Phase 4).
+- Create `src/tools/executor.ts` — `executeToolSafely()` (Phase 5).
+- Modify `src/analytics.ts` — `logToolExecution()` with redaction (Phase 5).
+
+---
+
+### Task 1: Failure classification types + classifier (Phase 1b)
+
+**Files:**
+- Create: `src/failures/types.ts`
+- Create: `src/failures/classifier.ts`
+- Test: `test/failure-classifier.test.mjs`
+
+**Interfaces:**
+- Consumes: `classifyBridgeError` from `src/bridge.ts`.
+- Produces:
+  - `type FailureCategory = "user_input" | "data_not_ready" | "provider_error" | "rate_limited" | "permission_config" | "auth_error" | "tool_contract" | "agent_planning" | "unknown"`
+  - `interface ClassifiedFailure { category: FailureCategory; severity: "low" | "medium" | "high"; retryable: boolean; userMessage: string; developerMessage: string; suggestedFix?: string; rawError?: string; }`
+  - `function classifyFailure(error: string | { message?: string } | undefined, toolName?: string): ClassifiedFailure`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/failure-classifier.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyFailure } from "../dist/failures/classifier.js";
+
+describe("classifyFailure", () => {
+  it("classifies a rate-limit error as retryable rate_limited", () => {
+    const f = classifyFailure("HTTP 429 Too Many Requests");
+    assert.equal(f.category, "rate_limited");
+    assert.equal(f.retryable, true);
+  });
+
+  it("classifies a storage permission error as non-retryable permission_config", () => {
+    const f = classifyFailure("403 storage.objects.create denied");
+    assert.equal(f.category, "permission_config");
+    assert.equal(f.retryable, false);
+  });
+
+  it("classifies a not-ready fixture error as retryable data_not_ready", () => {
+    const f = classifyFailure("Not enough knockout matches to build a bracket (0).");
+    assert.equal(f.category, "data_not_ready");
+    assert.equal(f.retryable, true);
+  });
+
+  it("classifies a 401 as non-retryable auth_error", () => {
+    const f = classifyFailure("401 Unauthorized");
+    assert.equal(f.category, "auth_error");
+    assert.equal(f.retryable, false);
+  });
+
+  it("always produces a non-empty userMessage and developerMessage", () => {
+    const f = classifyFailure("some totally unknown failure");
+    assert.equal(f.category, "unknown");
+    assert.ok(f.userMessage.length > 0);
+    assert.ok(f.developerMessage.length > 0);
+  });
+
+  it("accepts an object with a message field", () => {
+    const f = classifyFailure({ message: "circuit breaker open" });
+    assert.equal(f.category, "provider_error");
+    assert.equal(f.retryable, true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/failure-classifier.test.mjs`
+Expected: FAIL — build error / `Cannot find module '../dist/failures/classifier.js'`.
+
+- [ ] **Step 3: Write `src/failures/types.ts`**
+
+```typescript
+// src/failures/types.ts
+
+/** Structured failure categories for tool/workflow errors. */
+export type FailureCategory =
+  | "user_input"
+  | "data_not_ready"
+  | "provider_error"
+  | "rate_limited"
+  | "permission_config"
+  | "auth_error"
+  | "tool_contract"
+  | "agent_planning"
+  | "unknown";
+
+export interface ClassifiedFailure {
+  category: FailureCategory;
+  severity: "low" | "medium" | "high";
+  retryable: boolean;
+  /** Clean, human-facing explanation: what failed, why, whether retry helps, what to do next. */
+  userMessage: string;
+  /** Technical detail for logs/developers. */
+  developerMessage: string;
+  suggestedFix?: string;
+  rawError?: string;
+}
+```
+
+- [ ] **Step 4: Write `src/failures/classifier.ts`**
+
+```typescript
+// src/failures/classifier.ts
+import { classifyBridgeError } from "../bridge.js";
+import type { ClassifiedFailure, FailureCategory } from "./types.js";
+
+interface Rule {
+  category: FailureCategory;
+  severity: "low" | "medium" | "high";
+  retryable: boolean;
+  match: (h: string) => boolean;
+  userMessage: string;
+  suggestedFix?: string;
+}
+
+// Generic, non-proprietary pattern rules. Order matters: first match wins.
+const RULES: Rule[] = [
+  {
+    category: "rate_limited",
+    severity: "low",
+    retryable: true,
+    match: (h) => h.includes("429") || h.includes("rate limit") || h.includes("too many requests"),
+    userMessage: "The data provider rate-limited the request. Retrying shortly should work.",
+    suggestedFix: "Honor retry_after if present; otherwise back off and retry.",
+  },
+  {
+    category: "permission_config",
+    severity: "high",
+    retryable: false,
+    match: (h) =>
+      h.includes("storage.objects.create denied") ||
+      (h.includes("403") && h.includes("storage")) ||
+      h.includes("permission denied"),
+    userMessage: "The action ran but a storage/permission check rejected it (403). Retrying won't help.",
+    suggestedFix: "Grant the missing permission to the service account or use a writable target.",
+  },
+  {
+    category: "auth_error",
+    severity: "high",
+    retryable: false,
+    match: (h) => h.includes("401") || h.includes("unauthorized") || h.includes("invalid api key"),
+    userMessage: "Authentication failed for this provider. Retrying won't help until credentials are fixed.",
+    suggestedFix: "Check the provider API key / auth configuration.",
+  },
+  {
+    category: "data_not_ready",
+    severity: "low",
+    retryable: true,
+    match: (h) =>
+      h.includes("not enough") ||
+      h.includes("not ready") ||
+      h.includes("no fixtures") ||
+      h.includes("no data available yet"),
+    userMessage: "The underlying data isn't populated yet, so the result would be unreliable.",
+    suggestedFix: "Wait until the required data is available, then retry.",
+  },
+  {
+    category: "user_input",
+    severity: "medium",
+    retryable: false,
+    match: (h) =>
+      h.includes("must be prefixed") ||
+      h.includes("looks like a name, not a valid") ||
+      h.includes("invalid argument") ||
+      h.includes("required parameter"),
+    userMessage: "The request needs a corrected or resolved input before it can run.",
+    suggestedFix: "Resolve/normalize the offending argument, then retry.",
+  },
+];
+
+function toHaystack(error: string | { message?: string } | undefined): string {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  return String(error.message ?? "");
+}
+
+/**
+ * Turn a raw tool/workflow error into a structured, user-safe classification.
+ * Composes the generic pattern rules above with the bridge classifier for
+ * Python-subprocess-specific codes (timeout, dependency_missing, circuit_open, …).
+ */
+export function classifyFailure(
+  error: string | { message?: string } | undefined,
+  toolName?: string,
+): ClassifiedFailure {
+  const raw = toHaystack(error);
+  const h = raw.toLowerCase();
+
+  for (const rule of RULES) {
+    if (rule.match(h)) {
+      return {
+        category: rule.category,
+        severity: rule.severity,
+        retryable: rule.retryable,
+        userMessage: rule.userMessage,
+        developerMessage: toolName ? `[${toolName}] ${raw}` : raw,
+        suggestedFix: rule.suggestedFix,
+        rawError: raw,
+      };
+    }
+  }
+
+  // Fall back to the bridge classifier for subprocess-specific codes.
+  const { errorCode, hint } = classifyBridgeError(raw);
+  const mapping: Record<string, { category: FailureCategory; retryable: boolean; severity: "low" | "medium" | "high" }> = {
+    timeout: { category: "provider_error", retryable: true, severity: "medium" },
+    dependency_missing: { category: "permission_config", retryable: false, severity: "high" },
+    network_dns: { category: "provider_error", retryable: true, severity: "medium" },
+    rate_limited: { category: "rate_limited", retryable: true, severity: "low" },
+    python_version_incompatible: { category: "permission_config", retryable: false, severity: "high" },
+    circuit_open: { category: "provider_error", retryable: true, severity: "medium" },
+    tool_execution_failed: { category: "unknown", retryable: false, severity: "medium" },
+  };
+  const m = mapping[errorCode] ?? { category: "unknown" as FailureCategory, retryable: false, severity: "medium" as const };
+
+  return {
+    category: m.category,
+    severity: m.severity,
+    retryable: m.retryable,
+    userMessage: hint,
+    developerMessage: toolName ? `[${toolName}] ${raw}` : raw,
+    suggestedFix: hint,
+    rawError: raw,
+  };
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run build && node --test test/failure-classifier.test.mjs`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 6: Add the test script**
+
+In `package.json` scripts, add:
+```json
+"test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/failures/ test/failure-classifier.test.mjs package.json
+git commit -m "feat(failures): generic failure classifier composing bridge/mcp classifiers"
+```
+
+---
+
+### Task 2: Wire `classifyFailure` into the tool execution failure path
+
+**Files:**
+- Modify: `src/tools.ts` (the `ToolRegistry.execute` failure branch — locate the `catch`/`isError` return that currently surfaces raw bridge errors)
+- Test: `test/tool-failure-classification.test.mjs`
+
+**Interfaces:**
+- Consumes: `classifyFailure` from `src/failures/classifier.js`; `ToolCallResult` from `src/bridge.js`.
+- Produces: on failure, `ToolCallResult.content` is the classified `userMessage` (falls back to raw when classification is `unknown` with an empty hint). No signature change to `execute`.
+
+- [ ] **Step 1: Locate the failure return site**
+
+Run: `grep -n "isError: true" src/tools.ts`
+Read the surrounding function so the edit targets the real failure branch (do not invent a new one).
+
+- [ ] **Step 2: Write the failing test**
+
+```javascript
+// test/tool-failure-classification.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyFailure } from "../dist/failures/classifier.js";
+
+// Behavioral contract used by ToolRegistry.execute's failure branch:
+// a raw provider error is turned into a clean, actionable user message.
+describe("tool failure classification contract", () => {
+  it("produces an actionable message for a rate limit", () => {
+    const f = classifyFailure("429 too many requests", "nba_get_scoreboard");
+    assert.equal(f.category, "rate_limited");
+    assert.ok(/retry/i.test(f.userMessage));
+    assert.ok(f.developerMessage.includes("nba_get_scoreboard"));
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it passes at the contract level**
+
+Run: `npm run build && node --test test/tool-failure-classification.test.mjs`
+Expected: PASS (this asserts the classifier contract the wiring relies on).
+
+- [ ] **Step 4: Edit the failure branch in `src/tools.ts`**
+
+Add the import at the top with the other local imports:
+```typescript
+import { classifyFailure } from "./failures/classifier.js";
+```
+
+In the failure return branch identified in Step 1, replace the raw-content return with:
+```typescript
+const classified = classifyFailure(errorText, toolName);
+return {
+  content: classified.userMessage || errorText,
+  isError: true,
+};
+```
+Use the branch's existing error variable in place of `errorText` (rename to match — do NOT introduce a new variable that isn't in scope).
+
+- [ ] **Step 5: Run the broader tool tests to confirm no regression**
+
+Run: `npm run build && node --test test/consumer-tool-failure-ux.test.mjs test/builtin-tools.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 6: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:tool-failure-classification": "npm run build && node --test test/tool-failure-classification.test.mjs"
+```
+```bash
+git add src/tools.ts test/tool-failure-classification.test.mjs package.json
+git commit -m "feat(tools): surface classified failure messages from tool execution"
+```
+
+---
+
+### Task 3: selftest cases + runner + report (Phase 2)
+
+**Files:**
+- Create: `src/selftest/cases.ts`
+- Create: `src/selftest/report.ts`
+- Create: `src/selftest/runner.ts`
+- Test: `test/selftest-runner.test.mjs`
+
+**Interfaces:**
+- Consumes: `classifyFailure` from `src/failures/classifier.js`.
+- Produces:
+  - `interface SmokeTestCase { sport: string; name: string; toolName: string; args: Record<string, unknown>; live?: boolean; required?: boolean; }`
+  - `const SMOKE_TESTS: SmokeTestCase[]`
+  - `interface SmokeResult { sport: string; check: string; status: "pass" | "fail" | "skip"; latencyMs: number; notes: string; }`
+  - `interface SelfTestReport { version: string; passed: number; failed: number; skipped: number; results: SmokeResult[]; toJSON(): Record<string, unknown>; }`
+  - `function runSelftest(opts: { sports?: string[]; live?: boolean; execute?: (c: SmokeTestCase) => Promise<{ ok: boolean; note?: string; latencyMs: number }> }): Promise<SelfTestReport>`
+  - `renderMarkdown(report: SelfTestReport): string`
+
+The `execute` callback is injected so `runSelftest` is testable without a live bridge. The CLI (Task 4) supplies the real executor.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/selftest-runner.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { runSelftest } from "../dist/selftest/runner.js";
+import { renderMarkdown } from "../dist/selftest/report.js";
+
+describe("runSelftest", () => {
+  it("returns one result per case for the requested sport (offline)", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: false,
+      execute: async () => ({ ok: true, latencyMs: 1, note: "stub" }),
+    });
+    assert.ok(report.results.length >= 1);
+    assert.equal(report.results[0].sport, "metadata");
+    assert.equal(report.failed, 0);
+  });
+
+  it("produces a JSON-serializable report", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: false,
+      execute: async () => ({ ok: true, latencyMs: 1 }),
+    });
+    const json = JSON.stringify(report.toJSON());
+    assert.ok(json.includes("passed"));
+  });
+
+  it("marks a failing case as fail with a note", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: true,
+      execute: async () => ({ ok: false, latencyMs: 2, note: "401 auth" }),
+    });
+    assert.equal(report.failed >= 1, true);
+    assert.equal(report.results.some((r) => r.status === "fail"), true);
+  });
+
+  it("renders a markdown table with a header row", () => {
+    const md = renderMarkdown({
+      version: "0.29.1", passed: 1, failed: 0, skipped: 0,
+      results: [{ sport: "nba", check: "scoreboard", status: "pass", latencyMs: 431, notes: "6 games" }],
+      toJSON() { return {}; },
+    });
+    assert.ok(md.includes("Sport"));
+    assert.ok(md.includes("nba"));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/selftest-runner.test.mjs`
+Expected: FAIL — `Cannot find module '../dist/selftest/runner.js'`.
+
+- [ ] **Step 3: Write `src/selftest/cases.ts`**
+
+```typescript
+// src/selftest/cases.ts
+
+export interface SmokeTestCase {
+  sport: string;
+  name: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  live?: boolean;
+  required?: boolean;
+}
+
+// Tool names verified against sports-skills v0.28.0 (`<module>_<command>`).
+export const SMOKE_TESTS: SmokeTestCase[] = [
+  { sport: "nba", name: "scoreboard", toolName: "nba_get_scoreboard", args: {} },
+  { sport: "nba", name: "standings", toolName: "nba_get_standings", args: {} },
+  { sport: "nfl", name: "scoreboard", toolName: "nfl_get_scoreboard", args: {} },
+  { sport: "mlb", name: "scoreboard", toolName: "mlb_get_scoreboard", args: {} },
+  { sport: "football", name: "competitions", toolName: "football_get_competitions", args: {} },
+  { sport: "metadata", name: "team search", toolName: "metadata_search_teams", args: { query: "Lakers" } },
+  { sport: "kalshi", name: "exchange status", toolName: "kalshi_get_exchange_status", args: {} },
+  { sport: "polymarket", name: "sports config", toolName: "polymarket_get_sports_config", args: {} },
+];
+```
+
+- [ ] **Step 4: Write `src/selftest/report.ts`**
+
+```typescript
+// src/selftest/report.ts
+
+export interface SmokeResult {
+  sport: string;
+  check: string;
+  status: "pass" | "fail" | "skip";
+  latencyMs: number;
+  notes: string;
+}
+
+export interface SelfTestReport {
+  version: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  results: SmokeResult[];
+  toJSON(): Record<string, unknown>;
+}
+
+export function renderMarkdown(report: SelfTestReport): string {
+  const lines = [
+    "| Sport | Check | Status | Latency | Notes |",
+    "| --- | --- | --- | --- | --- |",
+  ];
+  for (const r of report.results) {
+    lines.push(`| ${r.sport} | ${r.check} | ${r.status} | ${r.latencyMs}ms | ${r.notes} |`);
+  }
+  lines.push("");
+  lines.push(`**${report.passed} passed, ${report.failed} failed, ${report.skipped} skipped**`);
+  return lines.join("\n");
+}
+```
+
+- [ ] **Step 5: Write `src/selftest/runner.ts`**
+
+```typescript
+// src/selftest/runner.ts
+import { SMOKE_TESTS, type SmokeTestCase } from "./cases.js";
+import type { SelfTestReport, SmokeResult } from "./report.js";
+
+interface RunOptions {
+  sports?: string[];
+  live?: boolean;
+  version?: string;
+  execute?: (c: SmokeTestCase) => Promise<{ ok: boolean; note?: string; latencyMs: number }>;
+}
+
+export async function runSelftest(opts: RunOptions): Promise<SelfTestReport> {
+  const version = opts.version ?? "0.0.0";
+  const live = opts.live ?? false;
+  const cases = SMOKE_TESTS.filter((c) => !opts.sports || opts.sports.includes(c.sport));
+
+  const results: SmokeResult[] = [];
+  for (const c of cases) {
+    if (c.live !== false && !live) {
+      results.push({ sport: c.sport, check: c.name, status: "skip", latencyMs: 0, notes: "offline (use --live)" });
+      continue;
+    }
+    if (!opts.execute) {
+      results.push({ sport: c.sport, check: c.name, status: "skip", latencyMs: 0, notes: "no executor" });
+      continue;
+    }
+    const r = await opts.execute(c);
+    results.push({
+      sport: c.sport,
+      check: c.name,
+      status: r.ok ? "pass" : "fail",
+      latencyMs: r.latencyMs,
+      notes: r.note ?? "",
+    });
+  }
+
+  const passed = results.filter((r) => r.status === "pass").length;
+  const failed = results.filter((r) => r.status === "fail").length;
+  const skipped = results.filter((r) => r.status === "skip").length;
+
+  return {
+    version, passed, failed, skipped, results,
+    toJSON() {
+      return { version, passed, failed, skipped, results };
+    },
+  };
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npm run build && node --test test/selftest-runner.test.mjs`
+Expected: PASS — 4 tests. (Note: the offline test's cases have `live` undefined → treated as live-required → skipped unless `live:true`; the first test passes because `execute` returns ok and the assertion only checks `results.length >= 1` and `failed === 0` — skipped cases are neither. Verify this holds; if the first test needs a pass result, set `live: true` in that test call.)
+
+- [ ] **Step 7: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:selftest-runner": "npm run build && node --test test/selftest-runner.test.mjs"
+```
+```bash
+git add src/selftest/ test/selftest-runner.test.mjs package.json
+git commit -m "feat(selftest): schema smoke-test runner + report (offline-testable)"
+```
+
+---
+
+### Task 4: `sportsclaw selftest` CLI command (Phase 2)
+
+**Files:**
+- Modify: `src/index.ts` (add `cmdSelftest`, wire into the top-level arg dispatch and `printHelp`)
+- Test: manual CLI verification (this task's deliverable is the wired command; logic is covered by Task 3)
+
+**Interfaces:**
+- Consumes: `runSelftest`, `renderMarkdown` from `src/selftest/*.js`; the existing engine/tool-execution entry used by `cmdQuery`/`cmdHealth` to run a single tool by name; `resolveConfig()` and the package version already read in `cmdDoctor`/`cmdHealth`.
+- Produces: `sportsclaw selftest [--quick] [--sport <s>] [--json] [--live]`.
+
+- [ ] **Step 1: Read the existing command dispatch + a real tool-invocation call site**
+
+Run: `grep -n "cmdHealth\|cmdDoctor\|case \"doctor\"\|case \"health\"\|selftest" src/index.ts`
+Read `cmdHealth` and the top-level dispatch (where `doctor`/`health` route) to copy the exact wiring pattern and the real single-tool execution path.
+
+- [ ] **Step 2: Add `cmdSelftest` in `src/index.ts`**
+
+```typescript
+async function cmdSelftest(args: string[]): Promise<void> {
+  const json = args.includes("--json");
+  const live = args.includes("--live");
+  const quick = args.includes("--quick");
+  const sportIdx = args.indexOf("--sport");
+  const sports = sportIdx >= 0 && args[sportIdx + 1] ? [args[sportIdx + 1]] : undefined;
+
+  const { runSelftest } = await import("./selftest/runner.js");
+  const { renderMarkdown } = await import("./selftest/report.js");
+
+  // quick = first case per sport only
+  const seen = new Set<string>();
+  const executor = async (c: { sport: string; toolName: string; args: Record<string, unknown> }) => {
+    if (quick) {
+      if (seen.has(c.sport)) return { ok: true, latencyMs: 0, note: "skipped (quick)" };
+      seen.add(c.sport);
+    }
+    const started = Date.now();
+    try {
+      // Reuse the real single-tool path used by cmdQuery/cmdHealth.
+      const result = await runSingleTool(c.toolName, c.args); // <-- replace with the actual helper found in Step 1
+      const latencyMs = Date.now() - started;
+      const ok = !result.isError;
+      return { ok, latencyMs, note: ok ? summarize(result.content) : result.content.slice(0, 60) };
+    } catch (err) {
+      return { ok: false, latencyMs: Date.now() - started, note: String(err).slice(0, 60) };
+    }
+  };
+
+  const version = getPackageVersion(); // <-- reuse whatever cmdDoctor/cmdHealth uses
+  const report = await runSelftest({ sports, live, version, execute: executor });
+
+  if (json) {
+    console.log(JSON.stringify(report.toJSON(), null, 2));
+  } else {
+    console.log(renderMarkdown(report));
+  }
+  process.exit(report.failed > 0 ? 1 : 0);
+}
+```
+Replace `runSingleTool`, `summarize`, and `getPackageVersion` with the actual helpers discovered in Step 1 (do not invent them — `cmdHealth` already runs tools and reads the version). Keep `summarize` to a one-line note (e.g. count of events) or inline it.
+
+- [ ] **Step 3: Wire into dispatch + help**
+
+In the top-level command switch (same place `doctor`/`health` are handled), add:
+```typescript
+case "selftest":
+  await cmdSelftest(args.slice(1));
+  break;
+```
+Add a line to `printHelp()` next to `doctor`/`health`:
+```
+  selftest [--quick] [--sport <s>] [--json] [--live]   Run schema smoke tests
+```
+
+- [ ] **Step 4: Verify the command runs**
+
+Run: `npm run build && node dist/index.js selftest --json`
+Expected: valid JSON with `passed`/`failed`/`skipped`/`results` (offline → cases skipped). Then:
+Run: `node dist/index.js selftest --quick --live --sport metadata`
+Expected: a markdown table with the metadata team-search row (pass/fail depending on network).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(cli): add sportsclaw selftest command"
+```
+
+---
+
+### Task 5: Persistent entity store + TTL (Phase 3)
+
+**Files:**
+- Create: `src/cache/entity-store.ts`
+- Test: `test/entity-store.test.mjs`
+
+**Interfaces:**
+- Produces:
+  - `type EntityType = "team" | "player" | "competition" | "season" | "market"`
+  - `interface CachedEntity { id: string; entityType: EntityType; sport: string | null; league: string | null; canonicalName: string; aliases: string[]; providerIds: Record<string, string>; metadata: Record<string, unknown>; confidence: number; firstSeenAt: string; lastVerifiedAt: string; mentionCount: number; }`
+  - `function entityIsStale(entity: CachedEntity, now?: number): boolean`
+  - `class EntityStore { constructor(filePath?: string); load(): Promise<void>; get(query: string, entityType?: EntityType, sport?: string): CachedEntity | undefined; upsert(entity: CachedEntity): Promise<void>; }`
+- TTLs (days): team 180, player 90, competition 365, season 30, market 1.
+- Storage: `~/.sportsclaw/entity-cache.json` (default path). Follows the atomic-write pattern used elsewhere in the repo.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/entity-store.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EntityStore, entityIsStale } from "../dist/cache/entity-store.js";
+
+function nowISO() { return new Date().toISOString(); }
+function daysAgoISO(d) { return new Date(Date.now() - d * 86400000).toISOString(); }
+
+describe("EntityStore", () => {
+  it("upserts and gets an entity by alias", async () => {
+    const store = new EntityStore(join(tmpdir(), `ec-${process.pid}-${Math.floor(process.hrtime()[1])}.json`));
+    await store.load();
+    await store.upsert({
+      id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Los Angeles Lakers", aliases: ["Lakers", "LA Lakers"],
+      providerIds: { espn: "13" }, metadata: {}, confidence: 1.0,
+      firstSeenAt: nowISO(), lastVerifiedAt: nowISO(), mentionCount: 1,
+    });
+    const found = store.get("Lakers", "team", "nba");
+    assert.equal(found?.providerIds.espn, "13");
+  });
+
+  it("treats a 2-day-old market entity as stale (1-day TTL)", () => {
+    const market = {
+      id: "kalshi:KX", entityType: "market", sport: null, league: null,
+      canonicalName: "KX", aliases: [], providerIds: {}, metadata: {},
+      confidence: 1.0, firstSeenAt: daysAgoISO(2), lastVerifiedAt: daysAgoISO(2), mentionCount: 1,
+    };
+    assert.equal(entityIsStale(market), true);
+  });
+
+  it("treats a 2-day-old team entity as fresh (180-day TTL)", () => {
+    const team = {
+      id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Los Angeles Lakers", aliases: [], providerIds: {}, metadata: {},
+      confidence: 1.0, firstSeenAt: daysAgoISO(2), lastVerifiedAt: daysAgoISO(2), mentionCount: 1,
+    };
+    assert.equal(entityIsStale(team), false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/entity-store.test.mjs`
+Expected: FAIL — `Cannot find module '../dist/cache/entity-store.js'`.
+
+- [ ] **Step 3: Write `src/cache/entity-store.ts`**
+
+```typescript
+// src/cache/entity-store.ts
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type EntityType = "team" | "player" | "competition" | "season" | "market";
+
+export interface CachedEntity {
+  id: string;
+  entityType: EntityType;
+  sport: string | null;
+  league: string | null;
+  canonicalName: string;
+  aliases: string[];
+  providerIds: Record<string, string>;
+  metadata: Record<string, unknown>;
+  confidence: number;
+  firstSeenAt: string;
+  lastVerifiedAt: string;
+  mentionCount: number;
+}
+
+const TTL_DAYS: Record<EntityType, number> = {
+  team: 180, player: 90, competition: 365, season: 30, market: 1,
+};
+
+export function entityIsStale(entity: CachedEntity, now: number = Date.now()): boolean {
+  const ttlMs = TTL_DAYS[entity.entityType] * 86_400_000;
+  const verified = Date.parse(entity.lastVerifiedAt);
+  if (Number.isNaN(verified)) return true;
+  return now - verified > ttlMs;
+}
+
+const DEFAULT_PATH = join(homedir(), ".sportsclaw", "entity-cache.json");
+
+export class EntityStore {
+  private byId = new Map<string, CachedEntity>();
+  private loaded = false;
+
+  constructor(private filePath: string = DEFAULT_PATH) {}
+
+  async load(): Promise<void> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const arr = JSON.parse(raw) as CachedEntity[];
+      for (const e of arr) this.byId.set(e.id, e);
+    } catch {
+      // Missing/corrupt file → start empty.
+    }
+    this.loaded = true;
+  }
+
+  get(query: string, entityType?: EntityType, sport?: string): CachedEntity | undefined {
+    const q = query.trim().toLowerCase();
+    for (const e of this.byId.values()) {
+      if (entityType && e.entityType !== entityType) continue;
+      if (sport && (e.sport ?? "").toLowerCase() !== sport.toLowerCase()) continue;
+      if (entityIsStale(e)) continue;
+      const names = [e.canonicalName, ...e.aliases].map((n) => n.toLowerCase());
+      if (names.includes(q)) return e;
+    }
+    return undefined;
+  }
+
+  async upsert(entity: CachedEntity): Promise<void> {
+    if (!this.loaded) await this.load();
+    const existing = this.byId.get(entity.id);
+    if (existing) {
+      entity.mentionCount = existing.mentionCount + 1;
+      entity.firstSeenAt = existing.firstSeenAt;
+    }
+    this.byId.set(entity.id, entity);
+    await this.persist();
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const tmp = `${this.filePath}.tmp`;
+    await writeFile(tmp, JSON.stringify([...this.byId.values()], null, 2), "utf8");
+    await rename(tmp, this.filePath); // atomic replace
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/entity-store.test.mjs`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:entity-store": "npm run build && node --test test/entity-store.test.mjs"
+```
+```bash
+git add src/cache/ test/entity-store.test.mjs package.json
+git commit -m "feat(cache): persistent entity store with per-type TTL"
+```
+
+---
+
+### Task 6: Back the in-memory `EntityResolver` with the persistent store (Phase 3)
+
+**Files:**
+- Modify: `src/intelligence/entity-resolver.ts`
+- Test: `test/entity-resolver-persistence.test.mjs`
+
+**Interfaces:**
+- Consumes: `EntityStore`, `CachedEntity` from `src/cache/entity-store.js`.
+- Produces: `EntityResolver.getInstance()` gains `async hydrate(store?: EntityStore): Promise<void>` (loads persisted entities into the in-memory registry) and `async remember(entity: CachedEntity): Promise<void>` (upserts to store + registers in memory). Existing sync methods (`resolveTeam`, `resolvePlayer`, `mapToProviderId`) are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/entity-resolver-persistence.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EntityResolver } from "../dist/intelligence/entity-resolver.js";
+import { EntityStore } from "../dist/cache/entity-store.js";
+
+describe("EntityResolver persistence", () => {
+  it("remembers an entity to the store and maps its provider id", async () => {
+    const path = join(tmpdir(), `er-${process.pid}.json`);
+    const store = new EntityStore(path);
+    const r = EntityResolver.getInstance();
+    await r.hydrate(store);
+    await r.remember({
+      id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Los Angeles Lakers", aliases: ["Lakers"],
+      providerIds: { espn: "13" }, metadata: {}, confidence: 1,
+      firstSeenAt: new Date().toISOString(), lastVerifiedAt: new Date().toISOString(), mentionCount: 1,
+    });
+    // Fresh store instance sees the persisted row.
+    const store2 = new EntityStore(path);
+    await store2.load();
+    assert.equal(store2.get("Lakers", "team", "nba")?.providerIds.espn, "13");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/entity-resolver-persistence.test.mjs`
+Expected: FAIL — `r.hydrate is not a function`.
+
+- [ ] **Step 3: Add `hydrate` + `remember` to `src/intelligence/entity-resolver.ts`**
+
+Add the import at the top:
+```typescript
+import { EntityStore, type CachedEntity } from "../cache/entity-store.js";
+```
+Add a private field and two methods to the class (place after the constructor):
+```typescript
+  private store: EntityStore | null = null;
+
+  public async hydrate(store?: EntityStore): Promise<void> {
+    this.store = store ?? new EntityStore();
+    await this.store.load();
+  }
+
+  public async remember(entity: CachedEntity): Promise<void> {
+    if (this.store) await this.store.upsert(entity);
+    if (entity.sport && (entity.entityType === "team" || entity.entityType === "player")) {
+      this.register(entity.sport, entity.entityType, {
+        canonicalId: entity.id,
+        aliases: [entity.canonicalName, ...entity.aliases],
+        providerIds: entity.providerIds,
+      });
+    }
+  }
+```
+(`register`'s third arg accepts `event` too, but the `CachedEntity` types map cleanly for team/player; competitions/seasons/markets persist to the store without in-memory registration.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/entity-resolver-persistence.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:entity-resolver-persistence": "npm run build && node --test test/entity-resolver-persistence.test.mjs"
+```
+```bash
+git add src/intelligence/entity-resolver.ts test/entity-resolver-persistence.test.mjs package.json
+git commit -m "feat(intelligence): back EntityResolver with persistent store"
+```
+
+---
+
+### Task 7: Query complexity classifier + skill-cap planner (Phase 4)
+
+**Files:**
+- Create: `src/routing/complexity.ts`
+- Test: `test/routing-complexity.test.mjs`
+
+**Interfaces:**
+- Produces:
+  - `type QueryComplexity = "simple" | "compound" | "research" | "betting" | "live_game"`
+  - `interface SkillCapPlan { complexity: QueryComplexity; maxSkills: number; addSkills: string[]; reason: string; }`
+  - `function classifyQueryComplexity(query: string): QueryComplexity`
+  - `function planSkillCaps(query: string, base: { routingMaxSkills: number; routingAllowSpillover: number }): SkillCapPlan`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/routing-complexity.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyQueryComplexity, planSkillCaps } from "../dist/routing/complexity.js";
+
+const base = { routingMaxSkills: 2, routingAllowSpillover: 1 };
+
+describe("query complexity planning", () => {
+  it("keeps a simple score query at <= 2 skills", () => {
+    const plan = planSkillCaps("lakers score", base);
+    assert.ok(plan.maxSkills <= 2);
+  });
+
+  it("expands a betting query to >= 3 skills with a market skill", () => {
+    const plan = planSkillCaps("best Lakers bets tonight", base);
+    assert.ok(plan.maxSkills >= 3);
+    assert.ok(plan.addSkills.some((s) => ["betting", "markets", "kalshi", "polymarket"].includes(s)));
+  });
+
+  it("expands a multi-sport query to >= 4 skills", () => {
+    const plan = planSkillCaps("what's happening tonight across sports", base);
+    assert.ok(plan.maxSkills >= 4);
+  });
+
+  it("classifies an injury/news query as compound", () => {
+    assert.equal(classifyQueryComplexity("any injury news for the lakers?"), "compound");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/routing-complexity.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write `src/routing/complexity.ts`**
+
+```typescript
+// src/routing/complexity.ts
+
+export type QueryComplexity = "simple" | "compound" | "research" | "betting" | "live_game";
+
+export interface SkillCapPlan {
+  complexity: QueryComplexity;
+  maxSkills: number;
+  addSkills: string[];
+  reason: string;
+}
+
+const BETTING_KW = ["bet", "bets", "odds", "line", "spread", "total", "over", "under", "market", "price", "edge", "kelly"];
+const LIVE_KW = ["live", "right now", "score", "winning", "quarter", "period", "inning"];
+const NEWS_KW = ["injury", "injuries", "out", "questionable", "news", "report"];
+const MULTISPORT_KW = ["across sports", "what's happening", "whats happening", "everything", "all sports", "tonight across"];
+const RESEARCH_KW = ["audit", "deep dive", "analyze", "research", "compare", "breakdown"];
+
+function hasAny(h: string, kws: string[]): boolean {
+  return kws.some((k) => h.includes(k));
+}
+
+export function classifyQueryComplexity(query: string): QueryComplexity {
+  const h = query.toLowerCase();
+  if (hasAny(h, MULTISPORT_KW)) return "research";
+  if (hasAny(h, RESEARCH_KW)) return "research";
+  if (hasAny(h, BETTING_KW)) return "betting";
+  if (hasAny(h, NEWS_KW)) return "compound";
+  if (hasAny(h, LIVE_KW)) return "live_game";
+  return "simple";
+}
+
+export function planSkillCaps(
+  query: string,
+  base: { routingMaxSkills: number; routingAllowSpillover: number },
+): SkillCapPlan {
+  const complexity = classifyQueryComplexity(query);
+  const h = query.toLowerCase();
+  const addSkills: string[] = [];
+  let maxSkills = base.routingMaxSkills;
+  let reason = "simple query — default caps";
+
+  switch (complexity) {
+    case "betting":
+      maxSkills = Math.max(maxSkills, 3);
+      addSkills.push("betting", "markets", "kalshi", "polymarket");
+      reason = "betting intent — added market skills";
+      break;
+    case "research":
+      maxSkills = Math.max(maxSkills, 4);
+      reason = "multi-sport/research — widened skill budget";
+      break;
+    case "compound":
+      maxSkills = Math.max(maxSkills, 3);
+      if (hasAny(h, NEWS_KW)) addSkills.push("news");
+      reason = "compound (injury/news) — added news";
+      break;
+    case "live_game":
+      maxSkills = Math.max(maxSkills, 3);
+      reason = "live-game intent";
+      break;
+    case "simple":
+    default:
+      break;
+  }
+  return { complexity, maxSkills, addSkills, reason };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/routing-complexity.test.mjs`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:routing-complexity": "npm run build && node --test test/routing-complexity.test.mjs"
+```
+```bash
+git add src/routing/ test/routing-complexity.test.mjs package.json
+git commit -m "feat(routing): query-complexity classifier + skill-cap planner"
+```
+
+---
+
+### Task 8: Integrate the skill-cap planner into `router.ts` (Phase 4)
+
+**Files:**
+- Modify: `src/router.ts` (inside `routePromptToSkills`, before the LLM route call at `:304`)
+- Test: `test/router-complexity-integration.test.mjs`
+
+**Interfaces:**
+- Consumes: `planSkillCaps` from `src/routing/complexity.js`; the existing `RouteInput.config` (`routingMaxSkills`, `routingAllowSpillover`) and `RouteInput.prompt`.
+- Produces: `routePromptToSkills` uses an effective `maxSkills = max(config.routingMaxSkills, planSkillCaps(prompt).maxSkills)` and seeds the planner's `addSkills` (intersected with `installedSkills`) into the candidate set. No signature change.
+
+- [ ] **Step 1: Read `routePromptToSkills` to find where `routingMaxSkills` is consumed**
+
+Run: `grep -n "routingMaxSkills\|routingAllowSpillover\|installedSkills" src/router.ts`
+Read that region so the edit uses the real local variables (do not introduce parallel state).
+
+- [ ] **Step 2: Write the integration test**
+
+```javascript
+// test/router-complexity-integration.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// The planner is the unit under test at the routing boundary; this guards the
+// contract router.ts relies on so a future refactor can't silently narrow it.
+import { planSkillCaps } from "../dist/routing/complexity.js";
+
+describe("router complexity integration contract", () => {
+  it("a betting prompt raises the effective max above the base of 2", () => {
+    const plan = planSkillCaps("best bets for lakers tonight", { routingMaxSkills: 2, routingAllowSpillover: 1 });
+    const effective = Math.max(2, plan.maxSkills);
+    assert.ok(effective >= 3);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it passes at the contract level**
+
+Run: `npm run build && node --test test/router-complexity-integration.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 4: Edit `src/router.ts`**
+
+Add the import with the other local imports:
+```typescript
+import { planSkillCaps } from "./routing/complexity.js";
+```
+Inside `routePromptToSkills`, immediately after `input` is destructured/available and before the max-skills value is used, compute:
+```typescript
+  const capPlan = planSkillCaps(input.prompt, {
+    routingMaxSkills: input.config.routingMaxSkills,
+    routingAllowSpillover: input.config.routingAllowSpillover,
+  });
+  const effectiveMaxSkills = Math.max(input.config.routingMaxSkills, capPlan.maxSkills);
+  const seededSkills = capPlan.addSkills.filter((s) => input.installedSkills.includes(s));
+```
+Then use `effectiveMaxSkills` wherever `input.config.routingMaxSkills` currently caps the final selection, and union `seededSkills` into the candidate list the LLM router considers (respecting `effectiveMaxSkills`). Keep the existing spillover logic intact.
+
+- [ ] **Step 5: Run the routing tests to confirm no regression**
+
+Run: `npm run build && node --test test/model-role-router.test.mjs test/router-complexity-integration.test.mjs`
+Expected: PASS. (If `model-role-router.test.mjs` covers a different router, also run any `test:*router*` script found via `grep -n router package.json`.)
+
+- [ ] **Step 6: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:router-complexity-integration": "npm run build && node --test test/router-complexity-integration.test.mjs"
+```
+```bash
+git add src/router.ts test/router-complexity-integration.test.mjs package.json
+git commit -m "feat(router): expand skill caps for compound/betting/multi-sport queries"
+```
+
+---
+
+### Task 9: `executeToolSafely` wrapper (Phase 5)
+
+**Files:**
+- Create: `src/tools/executor.ts`
+- Test: `test/safe-executor.test.mjs`
+
+**Interfaces:**
+- Consumes: `sanitizeToolInput` from `src/tools.js`; `classifyFailure` from `src/failures/classifier.js`; `ClassifiedFailure` from `src/failures/types.js`; `ToolCallInput` from `src/bridge.js`.
+- Produces:
+  - `interface ToolExecutionResult { ok: boolean; toolName: string; args: Record<string, unknown>; data?: unknown; warnings: string[]; failure?: ClassifiedFailure; latencyMs?: number; normalized: boolean; }`
+  - `function executeToolSafely(toolName: string, args: Record<string, unknown>, run: (name: string, a: Record<string, unknown>) => Promise<{ content: string; isError?: boolean }>, nowFn?: () => number): Promise<ToolExecutionResult>`
+
+The real tool executor (`ToolRegistry.execute`) is injected as `run` so this composition unit is testable without a live bridge. This wrapper is the seam Task 2's inline classification will migrate to; keep both consistent.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/safe-executor.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { executeToolSafely } from "../dist/tools/executor.js";
+
+describe("executeToolSafely", () => {
+  it("returns ok with data on success and reports normalized args", async () => {
+    const res = await executeToolSafely(
+      "nba_get_standings",
+      { season: "2026" }, // bare year → sanitizeToolInput normalizes to espn.nba.2026
+      async (_n, a) => ({ content: JSON.stringify({ season: a.season }) }),
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.normalized, true);
+    assert.ok(String(res.data).includes("espn.nba.2026"));
+  });
+
+  it("classifies a failing run into a structured failure", async () => {
+    const res = await executeToolSafely(
+      "kalshi_get_exchange_status",
+      {},
+      async () => ({ content: "429 too many requests", isError: true }),
+    );
+    assert.equal(res.ok, false);
+    assert.equal(res.failure?.category, "rate_limited");
+    assert.equal(res.failure?.retryable, true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/safe-executor.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write `src/tools/executor.ts`**
+
+```typescript
+// src/tools/executor.ts
+import { sanitizeToolInput } from "../tools.js";
+import { classifyFailure } from "../failures/classifier.js";
+import type { ClassifiedFailure } from "../failures/types.js";
+
+export interface ToolExecutionResult {
+  ok: boolean;
+  toolName: string;
+  args: Record<string, unknown>;
+  data?: unknown;
+  warnings: string[];
+  failure?: ClassifiedFailure;
+  latencyMs?: number;
+  normalized: boolean;
+}
+
+export async function executeToolSafely(
+  toolName: string,
+  args: Record<string, unknown>,
+  run: (name: string, a: Record<string, unknown>) => Promise<{ content: string; isError?: boolean }>,
+  nowFn: () => number = Date.now,
+): Promise<ToolExecutionResult> {
+  const started = nowFn();
+  const normalizedArgs = { ...args };
+  const before = JSON.stringify(normalizedArgs);
+  sanitizeToolInput(toolName, normalizedArgs);
+  const normalized = JSON.stringify(normalizedArgs) !== before;
+
+  try {
+    const result = await run(toolName, normalizedArgs);
+    if (result.isError) {
+      return {
+        ok: false, toolName, args: normalizedArgs, warnings: [], normalized,
+        failure: classifyFailure(result.content, toolName),
+        latencyMs: nowFn() - started,
+      };
+    }
+    return {
+      ok: true, toolName, args: normalizedArgs, data: result.content, warnings: [], normalized,
+      latencyMs: nowFn() - started,
+    };
+  } catch (err) {
+    return {
+      ok: false, toolName, args: normalizedArgs, warnings: [], normalized,
+      failure: classifyFailure(err instanceof Error ? err.message : String(err), toolName),
+      latencyMs: nowFn() - started,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/safe-executor.test.mjs`
+Expected: PASS — 2 tests. (Confirms `sanitizeToolInput` mutates in place — it does; see `src/tools.ts:132`.)
+
+- [ ] **Step 5: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:safe-executor": "npm run build && node --test test/safe-executor.test.mjs"
+```
+```bash
+git add src/tools/executor.ts test/safe-executor.test.mjs package.json
+git commit -m "feat(tools): executeToolSafely wrapper composing sanitize + classify"
+```
+
+---
+
+### Task 10: Structured `tool_execution` log with credential redaction (Phase 5)
+
+**Files:**
+- Modify: `src/analytics.ts` (add `logToolExecution` + `redactArgs`)
+- Test: `test/tool-execution-log.test.mjs`
+
+**Interfaces:**
+- Consumes: `ToolExecutionResult` from `src/tools/executor.js`.
+- Produces:
+  - `function redactArgs(args: Record<string, unknown>): Record<string, unknown>`
+  - `function buildToolExecutionEvent(result: ToolExecutionResult, timestamp: string): Record<string, unknown>` — shape `{ event: "tool_execution", tool_name, ok, latency_ms, failure_category, normalized, args_hash, timestamp }`.
+
+- [ ] **Step 1: Read `src/analytics.ts` to match its logging/export style**
+
+Run: `grep -n "export function\|export const\|createHash\|sha256" src/analytics.ts | head`
+Follow the existing pattern (how events are shaped/emitted).
+
+- [ ] **Step 2: Write the failing test**
+
+```javascript
+// test/tool-execution-log.test.mjs
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { redactArgs, buildToolExecutionEvent } from "../dist/analytics.js";
+
+describe("tool_execution logging", () => {
+  it("redacts credential-like keys and never leaks their values", () => {
+    const out = redactArgs({ api_key: "secret", token: "abc", team: "Lakers" });
+    const json = JSON.stringify(out);
+    assert.ok(!json.includes("secret"));
+    assert.ok(!json.includes("abc"));
+    assert.ok(json.includes("Lakers"));
+    assert.ok(!("api_key" in out));
+  });
+
+  it("builds an event with a hashed args field and no raw secrets", () => {
+    const event = buildToolExecutionEvent({
+      ok: false, toolName: "worldcup-get-market-state",
+      args: { api_key: "secret", market_id: "kalshi:KX" },
+      warnings: [], normalized: false, latencyMs: 122,
+      failure: { category: "user_input", severity: "medium", retryable: false, userMessage: "x", developerMessage: "y" },
+    }, "2026-07-07T00:00:00Z");
+    const json = JSON.stringify(event);
+    assert.ok(!json.includes("secret"));
+    assert.equal(event.event, "tool_execution");
+    assert.equal(event.failure_category, "user_input");
+    assert.ok(String(event.args_hash).startsWith("sha256:"));
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run build && node --test test/tool-execution-log.test.mjs`
+Expected: FAIL — `redactArgs is not a function`.
+
+- [ ] **Step 4: Add to `src/analytics.ts`**
+
+Add at the top if not already imported:
+```typescript
+import { createHash } from "node:crypto";
+```
+Add the exports:
+```typescript
+const REDACT_KEYS = ["api_key", "apikey", "token", "authorization", "auth", "password", "secret", "private_key", "wallet", "credential"];
+
+export function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (REDACT_KEYS.some((r) => k.toLowerCase().includes(r))) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+export function buildToolExecutionEvent(
+  result: import("./tools/executor.js").ToolExecutionResult,
+  timestamp: string,
+): Record<string, unknown> {
+  const argsHash = "sha256:" + createHash("sha256").update(JSON.stringify(redactArgs(result.args))).digest("hex");
+  return {
+    event: "tool_execution",
+    tool_name: result.toolName,
+    ok: result.ok,
+    latency_ms: result.latencyMs ?? null,
+    failure_category: result.failure?.category ?? null,
+    normalized: result.normalized,
+    args_hash: argsHash,
+    timestamp,
+  };
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run build && node --test test/tool-execution-log.test.mjs`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 6: Add the test script + commit**
+
+Add to `package.json`:
+```json
+"test:tool-execution-log": "npm run build && node --test test/tool-execution-log.test.mjs"
+```
+```bash
+git add src/analytics.ts test/tool-execution-log.test.mjs package.json
+git commit -m "feat(analytics): structured tool_execution log with credential redaction"
+```
+
+---
+
+### Task 11 (GATED — server-side, requires explicit user approval before running): World Cup market-state normalization
+
+**This task does not touch the sportsclaw repo.** It hardens the hosted `worldcup-get-market-state` MCP workflow so a bare ticker/id is normalized to the `{source}:` prefix inside the workflow, before the `startswith('kalshi:'/'polymarket:')` branches. This keeps proprietary market logic off the MIT client and fixes all clients at once.
+
+**Do NOT execute without the user's explicit go-ahead** — it edits a production workflow (`update_workflow_id`) and is a separate deploy. Confirm first.
+
+- [ ] **Step 1: Confirm with the user** that server-side editing of the production `worldcup-get-market-state` workflow is approved for this session.
+
+- [ ] **Step 2: Fetch the current workflow definition** via the World Cup MCP `retrieve_workflow_id` / `search_workflow` (name `worldcup-get-market-state`) and save the exact current `tasks`/`inputs` as a backup before any change.
+
+- [ ] **Step 3: Add a leading normalization step** that rewrites `requested_id`: if it already contains `:` leave it; else if it matches a Kalshi shape (`^KX` / uppercase-hyphenated series) set `kalshi:<id>`; else if it matches a Polymarket shape (numeric / `0x…` token / slug) set `polymarket:<id>`; append a `state_warnings` entry noting the coercion. Prefer a dedicated `normalize_market_state`-adjacent connector so the logic is server-side and reusable.
+
+- [ ] **Step 4: Verify** by executing the workflow with a bare ticker (`KXWCGAME-26JUL04PARFRA-FRA`) and confirming the kalshi branch now fires and `market` is non-empty, with a coercion warning present. Re-run with an already-prefixed id to confirm no double-prefixing.
+
+- [ ] **Step 5: Record** the change (backup + new definition) in the WC MCP/ops notes. No sportsclaw commit.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Preflight — season/player already exist (noted in spec); market normalization → Task 11 (server-side). Client preflight is exercised via Task 9 (`sanitizeToolInput` composition). ✓
+- §2 Failure classification — Task 1. ✓
+- §3 Readiness — reframed to failure classification (`data_not_ready`) in Task 1; no client gate (per spec non-goal). ✓
+- §4 selftest — Tasks 3–4. ✓
+- §5 Dynamic routing — Tasks 7–8. ✓
+- §6 Entity cache — Tasks 5–6. ✓
+- §7 executeToolSafely — Task 9. ✓
+- §8 User-facing errors — Task 1 (`userMessage`) + Task 2 (wiring). ✓
+- §9 Observability — Task 10. ✓
+
+**Placeholder scan:** Task 4 intentionally references real helpers (`runSingleTool`, `getPackageVersion`, `summarize`) to be resolved against `cmdHealth`/`cmdDoctor` in Step 1 — flagged explicitly as "replace with the actual helper," not silent TODOs, because the CLI's private tool-invocation helper name can only be read at execution time. All other steps contain complete code.
+
+**Type consistency:** `ClassifiedFailure`/`FailureCategory` (Task 1) are reused verbatim in Tasks 9–10. `CachedEntity`/`EntityType` (Task 5) reused in Task 6. `ToolExecutionResult` (Task 9) reused in Task 10. `planSkillCaps` signature (Task 7) matches its call in Task 8. Consistent. ✓
+
+**Ordering:** Task 2 depends on Task 1; Task 4 on Task 3; Task 6 on Task 5; Task 8 on Task 7; Tasks 9–10 on Task 1. Phase order (1→5) respects this. Task 11 is independent and gated.

--- a/docs/superpowers/specs/2026-07-07-sportsclaw-reliability-intelligence-design.md
+++ b/docs/superpowers/specs/2026-07-07-sportsclaw-reliability-intelligence-design.md
@@ -1,0 +1,175 @@
+# Spec: sportsclaw Reliability + Intelligence Upgrade (revised)
+
+**Date:** 2026-07-07
+**Status:** Design — awaiting review
+**Supersedes:** the original Python-authored spec (see "Corrections" below)
+
+## Goal
+
+Make sportsclaw smarter and harder to break: fewer failed tool calls, cleaner
+recovery when tools fail, faster answers, and smarter multi-dimensional queries.
+
+## Corrections to the original spec (evidence-grounded)
+
+The original spec was written in **Python**. sportsclaw-engine-core is
+**Node.js / TypeScript / ESM** (`package.json` v0.29.1, `type: module`). The only
+Python in the repo is `docker/relay/relay_server.py`; Python lives in the separate
+`sports-skills` backend the engine shells out to. **Everything here is TypeScript**,
+kebab-case files, `camelCase`/`PascalCase`, `.js` import extensions, tested via the
+existing `npm test` / `test:*` script harness (not pytest).
+
+Verified against the live repo, the `sports-skills` source (v0.28.0), and the hosted
+World Cup MCP:
+
+1. **Tool names are real, not invented.** sportsclaw builds them `${sport}_${command}`
+   (`src/tools.ts:85`); `sports-skills` schema emits the same (`cli.py:828`). So
+   `football_get_player_profile`, `nba_get_scoreboard`, `metadata_search_teams`,
+   `kalshi_get_exchange_status`, `polymarket_get_sports_config` all exist.
+
+2. **Preflight §1 already largely exists in TS:**
+   - `sanitizeToolInput()` (`src/tools.ts:132`) normalizes bare-year seasons
+     (`2026` → `espn.mlb.2026`, football → `premier-league-2026`).
+   - `detectGuessedId()` (`:102`) + `buildLookupSuggestion()` (`:76`) detect a
+     name-as-ID and emit "Call `football_search_player(query=…)`".
+   - The original spec's season example `2025-26` is **wrong**: `sports-skills`
+     `_resolve_season` (`football/_connector.py:1228`) rejects `2025-26`; the
+     canonical form is `{competition-slug}-{single-year}` (e.g. `premier-league-2025`),
+     which the existing `sanitizeToolInput` already produces.
+
+3. **Market-ID prefixing is World-Cup-MCP-specific, NOT global.** `sports-skills`
+   `kalshi_*` / `polymarket_*` tools take **bare** tickers/ids (`cli.py:141`, no
+   prefix requirement anywhere in source). The `kalshi:` / `polymarket:` scheme
+   exists **only** in the hosted `worldcup-get-market-state` MCP workflow
+   (`world-cup/SKILL.md:153`, workflow branches on `requested_id.startswith('kalshi:')`).
+   A global "prefix all market IDs" rule would **break** direct kalshi/polymarket calls.
+
+4. **Failure classification §2 partially exists:** `bridge.ts::classifyBridgeError`
+   (`src/bridge.ts:47`, handles 429/retry) and `mcp.ts::classifyError` (`:944`).
+
+5. **Readiness §3 is server-side data.** "Not enough knockout matches" exists in
+   **neither** sportsclaw nor sports-skills — it is raised inside the WC MCP
+   `wcbracket-engine`. `wcbracket-simulate` is a live workflow (100% / 37 runs) that
+   already guards simulation on `bracket.rounds`. The client has no
+   `knockout_events_count` in context, so it cannot gate this pre-call. Reframed below.
+
+6. **Entity cache §6 exists in-memory:** `EntityResolver` singleton
+   (`src/intelligence/entity-resolver.ts`) with `providerIds`/`aliases`/
+   `mapToProviderId`. Missing: persistence + TTL. No SQLite dependency exists;
+   persistence will use JSON under `~/.sportsclaw/` (matches tasks/memory patterns).
+
+7. **Routing §5 exists:** `router.ts` + config `routingMode`/`routingMaxSkills:2`/
+   `routingAllowSpillover:1` (`src/types.ts:345`), with spillover + skill aliases.
+   Missing: query-complexity-driven cap expansion.
+
+8. **`executeToolSafely` §7:** `ToolRegistry.execute` already chains sanitize → cache →
+   bridge → circuit-breaker. This is consolidation, not a new system.
+
+9. **selftest §4:** genuinely new. `cmdDoctor` (env/versions) and `cmdHealth`
+   (connectivity) exist but neither runs representative per-schema tool calls.
+
+## Open-source constraint (drives Phase 1 split)
+
+sportsclaw is **MIT** and `files: ["dist", ...]` — all of `src/` ships publicly to npm.
+The kalshi/polymarket market-normalization logic is **proprietary** and must **not**
+land in the client. It therefore lives **server-side** in the hosted, metered
+`worldcup-get-market-state` workflow (the established "world-cup premium, no local
+code, server-side" pattern). The open client gets only generic reliability plumbing.
+
+## Phases
+
+### Phase 1 — Fix the World Cup market-state bug + generic failure classification
+
+**1a — Server-side (WC MCP, closed, separate deploy):**
+Harden `worldcup-get-market-state` so a bare ticker/id normalizes to the prefixed
+form *inside the workflow* before the `startswith('kalshi:'/'polymarket:')` branches.
+Detection: Kalshi tickers match `^KX` / uppercase-hyphenated series; Polymarket ids
+are numeric / `0x…` token / slug. Emit a `warnings` entry when a bare id was coerced.
+**Requires explicit user confirmation before editing the production workflow.**
+
+**1b — Client-side (sportsclaw, open):**
+Extend the existing classifiers into one `classifyFailure(error, toolName?)` returning
+a `ClassifiedFailure { category, severity, retryable, userMessage, developerMessage,
+suggestedFix? }`. Categories: `USER_INPUT`, `DATA_NOT_READY`, `PROVIDER_ERROR`,
+`RATE_LIMITED`, `PERMISSION_CONFIG`, `AUTH_ERROR`, `TOOL_CONTRACT`, `AGENT_PLANNING`,
+`UNKNOWN`. Rules are **generic pattern matches** (429 → RATE_LIMITED; 401/403 → AUTH /
+PERMISSION_CONFIG; "not enough … matches"/"not ready" → DATA_NOT_READY; storage 403 →
+PERMISSION_CONFIG) — **no proprietary market rules**. Compose `classifyBridgeError` /
+`mcp.classifyError` rather than replace them. Pair with §8 user-facing messages:
+*what failed → why → whether retry helps → what to do next.* Never "tool failed" alone.
+
+- **Files:** `src/failures/classifier.ts`, `src/failures/types.ts`; wire into
+  `ToolRegistry.execute` / `bridge.ts`.
+- **Verify:** unit tests map each known error string to the right category/retryable;
+  a market-state DATA_NOT_READY/USER_INPUT failure renders a clean user message.
+
+### Phase 2 — `sportsclaw selftest`
+
+New `cmdSelftest(args)` in `src/index.ts` + `src/selftest/{runner,cases,report}.ts`.
+Reuses `cmdDoctor`'s env preconditions. Flags: `--quick`, `--sport <s>`, `--json`,
+`--live`. Cases use **confirmed** `${module}_${command}` names (nba_get_scoreboard,
+nfl_get_scoreboard, mlb_get_scoreboard, football_get_competitions,
+metadata_search_teams, kalshi_get_exchange_status, polymarket_get_sports_config, …).
+Output: a markdown table (sport/check/status/latency/notes) and a serializable JSON
+report `{ version, passed, failed, skipped, results[] }`. Failures run through
+`classifyFailure` (Phase 1b).
+
+- **Verify:** `run_selftest(sports:["metadata"], live:false)` yields ≥1 result;
+  `JSON.stringify(report.toJSON())` succeeds; `selftest --quick --json` is valid.
+
+### Phase 3 — Entity cache persistence
+
+Add a JSON-backed store + TTL behind the existing `EntityResolver` (no new module tree,
+no SQLite). `~/.sportsclaw/entity-cache.json`. `CachedEntity` fields per original spec
+(entity_type, sport, canonicalName, aliases, providerIds, confidence, timestamps,
+mentionCount). TTLs: team 180d, player 90d, competition 365d, season 30d, market 1d;
+never cache injury/roster status. `getEntity` precedes resolver tools; `upsertEntity`
+after successful lookups.
+
+- **Verify:** upsert→get round-trips providerIds; a 2-day-old market entity is stale.
+
+### Phase 4 — Complexity-aware routing
+
+Add `src/routing/complexity.ts` (`classifyQueryComplexity(query)` →
+`SIMPLE|COMPOUND|RESEARCH|BETTING|LIVE_GAME`) and a small planner that raises the
+existing `routingMaxSkills`/`routingAllowSpillover` caps per complexity (simple 1–2,
+team overview 3, betting 3–4, multi-sport 4, research 3–5). Keyword sets per the
+original spec (betting → betting/markets/kalshi/polymarket; live → scoreboard;
+injury/news → news). Integrates into `router.ts`; does not replace it.
+
+- **Verify:** "lakers score" ≤2 skills; "best Lakers bets tonight" ≥3 incl. a
+  betting/markets skill; "what's happening tonight across sports" ≥4.
+
+### Phase 5 — Wrapper consolidation + observability
+
+Consolidate the execute path into one `executeToolSafely(toolName, args, context)` →
+`ToolExecutionResult { ok, toolName, args, data?, warnings, failure?, latencyMs,
+normalized }`, composing existing sanitize/cache/bridge/circuit-breaker + Phase 1b
+classification. Add a structured `tool_execution` log event
+(`{ event, toolName, ok, latencyMs, failureCategory, normalized, argsHash, timestamp }`)
+via the existing `analytics.ts`/`incident-log.ts`, with **credential redaction**
+(drop `api_key`, tokens, auth headers, wallet keys; hash args).
+
+- **Verify:** redaction test asserts secrets never appear in the serialized event;
+  existing raw tool execution still passes its current tests.
+
+## Non-goals
+
+- No client-side kalshi/polymarket normalization (proprietary → server-side).
+- No client-side bracket readiness gate (server-side data).
+- No new Python packages; no SQLite dependency.
+- No refactor of modules not listed above.
+
+## Test surface (TS, mirrors original checklist)
+
+`test/failures/*`, `test/selftest/*`, `test/cache/*`, `test/routing/*`,
+`test/tools/*` (safe executor), `test/logging/*` (redaction), wired as `test:*`
+npm scripts consistent with existing ones.
+
+## Definition of Done
+
+- Bare World Cup market IDs resolve (server-side) instead of silently returning empty.
+- Known failures classify into structured categories with clean user messages.
+- `sportsclaw selftest --quick --json` returns a valid health report.
+- Compound betting/team queries activate ≥3 relevant skills.
+- Entity IDs persist and are reused with per-type TTLs.
+- Logs redact credentials.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test:game-alerts": "npm run build && node --test test/game-alerts.test.mjs",
     "test:game-alert-tools": "npm run build && node --test test/game-alert-tools.test.mjs",
     "test:selftest-runner": "npm run build && node --test test/selftest-runner.test.mjs",
+    "test:tool-execution-log": "npm run build && node --test test/tool-execution-log.test.mjs",
     "bench:moment-to-air": "npm run build && node scripts/bench-moment-to-air.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:bridge-retry-plan": "npm run build && node --test test/bridge-retry-plan.test.mjs",
     "test:circuit-breaker": "npm run build && node --test test/circuit-breaker.test.mjs",
     "test:bridge-resilience": "npm run build && node --test test/bridge-resilience.test.mjs",
+    "test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs",
     "test:session-store": "npm run build && node --test test/session-store.test.mjs",
     "test:file-memory-atomic": "npm run build && node --test test/file-memory-atomic.test.mjs",
     "test:analytics-tokens": "npm run build && node --test test/analytics-tokens.test.mjs",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:model-role-router": "npm run build && node --test test/model-role-router.test.mjs",
     "test:bridge-retry-plan": "npm run build && node --test test/bridge-retry-plan.test.mjs",
     "test:circuit-breaker": "npm run build && node --test test/circuit-breaker.test.mjs",
+    "test:entity-store": "npm run build && node --test test/entity-store.test.mjs",
     "test:bridge-resilience": "npm run build && node --test test/bridge-resilience.test.mjs",
     "test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs",
     "test:tool-failure-classification": "npm run build && node --test test/tool-failure-classification.test.mjs",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs",
     "test:tool-failure-classification": "npm run build && node --test test/tool-failure-classification.test.mjs",
     "test:tool-failure-wiring": "npm run build && node --test test/tool-failure-wiring.test.mjs",
+    "test:safe-executor": "npm run build && node --test test/safe-executor.test.mjs",
     "test:session-store": "npm run build && node --test test/session-store.test.mjs",
     "test:file-memory-atomic": "npm run build && node --test test/file-memory-atomic.test.mjs",
     "test:analytics-tokens": "npm run build && node --test test/analytics-tokens.test.mjs",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:bridge-resilience": "npm run build && node --test test/bridge-resilience.test.mjs",
     "test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs",
     "test:tool-failure-classification": "npm run build && node --test test/tool-failure-classification.test.mjs",
+    "test:tool-failure-wiring": "npm run build && node --test test/tool-failure-wiring.test.mjs",
     "test:session-store": "npm run build && node --test test/session-store.test.mjs",
     "test:file-memory-atomic": "npm run build && node --test test/file-memory-atomic.test.mjs",
     "test:analytics-tokens": "npm run build && node --test test/analytics-tokens.test.mjs",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:circuit-breaker": "npm run build && node --test test/circuit-breaker.test.mjs",
     "test:bridge-resilience": "npm run build && node --test test/bridge-resilience.test.mjs",
     "test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs",
+    "test:tool-failure-classification": "npm run build && node --test test/tool-failure-classification.test.mjs",
     "test:session-store": "npm run build && node --test test/session-store.test.mjs",
     "test:file-memory-atomic": "npm run build && node --test test/file-memory-atomic.test.mjs",
     "test:analytics-tokens": "npm run build && node --test test/analytics-tokens.test.mjs",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:bridge-retry-plan": "npm run build && node --test test/bridge-retry-plan.test.mjs",
     "test:circuit-breaker": "npm run build && node --test test/circuit-breaker.test.mjs",
     "test:entity-store": "npm run build && node --test test/entity-store.test.mjs",
+    "test:entity-resolver-persistence": "npm run build && node --test test/entity-resolver-persistence.test.mjs",
     "test:bridge-resilience": "npm run build && node --test test/bridge-resilience.test.mjs",
     "test:failure-classifier": "npm run build && node --test test/failure-classifier.test.mjs",
     "test:tool-failure-classification": "npm run build && node --test test/tool-failure-classification.test.mjs",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test:game-subscriptions": "npm run build && node --test test/game-subscriptions.test.mjs",
     "test:game-alerts": "npm run build && node --test test/game-alerts.test.mjs",
     "test:game-alert-tools": "npm run build && node --test test/game-alert-tools.test.mjs",
+    "test:selftest-runner": "npm run build && node --test test/selftest-runner.test.mjs",
     "bench:moment-to-air": "npm run build && node scripts/bench-moment-to-air.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:heartbeat-wake-gate": "npm run build && node --test test/heartbeat-wake-gate.test.mjs",
     "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs",
     "test:operator-sync": "npm run build && node --test test/operator-sync.test.mjs",
+    "test:routing-complexity": "npm run build && node --test test/routing-complexity.test.mjs",
     "test:operator-config": "npm run build && node --test test/operator-config.test.mjs",
     "test:llm-providers": "npm run build && node --test test/llm-providers.test.mjs",
     "test:operate": "npm run build && node --test test/operate.test.mjs",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:operator-daemon": "npm run build && node --test test/operator-daemon.test.mjs",
     "test:operator-sync": "npm run build && node --test test/operator-sync.test.mjs",
     "test:routing-complexity": "npm run build && node --test test/routing-complexity.test.mjs",
+    "test:router-complexity-integration": "npm run build && node --test test/router-complexity-integration.test.mjs",
     "test:operator-config": "npm run build && node --test test/operator-config.test.mjs",
     "test:llm-providers": "npm run build && node --test test/llm-providers.test.mjs",
     "test:operate": "npm run build && node --test test/operate.test.mjs",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -111,15 +111,35 @@ export function generateSessionId(): string {
 const REDACT_KEYS = ["api_key", "apikey", "token", "authorization", "auth", "password", "secret", "private_key", "wallet", "credential"];
 
 /**
+ * Recursively redact credential-like keys (at any depth) from a value before
+ * it is logged. Walks plain objects and arrays; other values pass through
+ * unchanged. A seen-set guards against cycles.
+ */
+function redactValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return value;
+    seen.add(value);
+    return value.map((v) => redactValue(v, seen));
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    if (seen.has(obj)) return obj;
+    seen.add(obj);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (REDACT_KEYS.some((r) => k.toLowerCase().includes(r))) continue;
+      out[k] = redactValue(v, seen);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
  * Strip credential-like keys from a tool args object before it is logged.
  */
 export function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(args)) {
-    if (REDACT_KEYS.some((r) => k.toLowerCase().includes(r))) continue;
-    out[k] = v;
-  }
-  return out;
+  return redactValue(args, new WeakSet<object>()) as Record<string, unknown>;
 }
 
 /**

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -105,6 +105,45 @@ export function generateSessionId(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Tool Execution Logging (credential redaction)
+// ---------------------------------------------------------------------------
+
+const REDACT_KEYS = ["api_key", "apikey", "token", "authorization", "auth", "password", "secret", "private_key", "wallet", "credential"];
+
+/**
+ * Strip credential-like keys from a tool args object before it is logged.
+ */
+export function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (REDACT_KEYS.some((r) => k.toLowerCase().includes(r))) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Build a structured tool_execution log event from a ToolExecutionResult.
+ * Args are redacted before hashing, so no secret value is ever hashed or leaked.
+ */
+export function buildToolExecutionEvent(
+  result: import("./tools/executor.js").ToolExecutionResult,
+  timestamp: string,
+): Record<string, unknown> {
+  const argsHash = "sha256:" + createHash("sha256").update(JSON.stringify(redactArgs(result.args))).digest("hex");
+  return {
+    event: "tool_execution",
+    tool_name: result.toolName,
+    ok: result.ok,
+    latency_ms: result.latencyMs ?? null,
+    failure_category: result.failure?.category ?? null,
+    normalized: result.normalized,
+    args_hash: argsHash,
+    timestamp,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Query Logging
 // ---------------------------------------------------------------------------
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -14,7 +14,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -25,6 +25,7 @@ const QUERY_LOG = join(ANALYTICS_DIR, "queries.jsonl");
 const TOOL_METRICS = join(ANALYTICS_DIR, "tool_metrics.json");
 const AGGREGATE_STATS = join(ANALYTICS_DIR, "aggregate.json");
 const SESSION_LOG = join(ANALYTICS_DIR, "sessions.jsonl");
+const TOOL_EXEC_LOG = join(ANALYTICS_DIR, "tool_executions.jsonl");
 
 function ensureDir(): void {
   if (!existsSync(ANALYTICS_DIR)) {
@@ -161,6 +162,31 @@ export function buildToolExecutionEvent(
     args_hash: argsHash,
     timestamp,
   };
+}
+
+/**
+ * Log a redacted tool_execution event to disk. Called from the tool dispatch
+ * path so credential redaction is enforced at runtime, not just in tests.
+ * A logging failure must never break a tool call, so all errors are swallowed.
+ */
+export function logToolExecution(
+  result: import("./tools/executor.js").ToolExecutionResult,
+  logPath: string = TOOL_EXEC_LOG,
+): void {
+  try {
+    if (logPath === TOOL_EXEC_LOG) {
+      ensureDir();
+    } else {
+      const dir = dirname(logPath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+    }
+    const event = buildToolExecutionEvent(result, new Date().toISOString());
+    appendFileSync(logPath, JSON.stringify(event) + "\n", "utf-8");
+  } catch {
+    // Analytics failures must never break a tool call.
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cache/entity-store.ts
+++ b/src/cache/entity-store.ts
@@ -45,7 +45,11 @@ export class EntityStore {
     try {
       const raw = await readFile(this.filePath, "utf8");
       const arr = JSON.parse(raw) as CachedEntity[];
-      for (const e of arr) this.byId.set(e.id, e);
+      for (const e of arr) {
+        if (e && typeof e === "object" && typeof e.canonicalName === "string") {
+          this.byId.set(e.id, e);
+        }
+      }
     } catch {
       // Missing/corrupt file → start empty.
     }
@@ -58,7 +62,8 @@ export class EntityStore {
       if (entityType && e.entityType !== entityType) continue;
       if (sport && (e.sport ?? "").toLowerCase() !== sport.toLowerCase()) continue;
       if (entityIsStale(e)) continue;
-      const names = [e.canonicalName, ...e.aliases].map((n) => n.toLowerCase());
+      const aliases = Array.isArray(e.aliases) ? e.aliases : [];
+      const names = [e.canonicalName, ...aliases].map((n) => n.toLowerCase());
       if (names.includes(q)) return e;
     }
     return undefined;

--- a/src/cache/entity-store.ts
+++ b/src/cache/entity-store.ts
@@ -56,6 +56,10 @@ export class EntityStore {
     this.loaded = true;
   }
 
+  all(): CachedEntity[] {
+    return [...this.byId.values()];
+  }
+
   get(query: string, entityType?: EntityType, sport?: string): CachedEntity | undefined {
     const q = query.trim().toLowerCase();
     for (const e of this.byId.values()) {

--- a/src/cache/entity-store.ts
+++ b/src/cache/entity-store.ts
@@ -1,0 +1,81 @@
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type EntityType = "team" | "player" | "competition" | "season" | "market";
+
+export interface CachedEntity {
+  id: string;
+  entityType: EntityType;
+  sport: string | null;
+  league: string | null;
+  canonicalName: string;
+  aliases: string[];
+  providerIds: Record<string, string>;
+  metadata: Record<string, unknown>;
+  confidence: number;
+  firstSeenAt: string;
+  lastVerifiedAt: string;
+  mentionCount: number;
+}
+
+const TTL_DAYS: Record<EntityType, number> = {
+  team: 180, player: 90, competition: 365, season: 30, market: 1,
+};
+
+export function entityIsStale(entity: CachedEntity, now: number = Date.now()): boolean {
+  const ttlMs = TTL_DAYS[entity.entityType] * 86_400_000;
+  const verified = Date.parse(entity.lastVerifiedAt);
+  if (Number.isNaN(verified)) return true;
+  return now - verified > ttlMs;
+}
+
+const DEFAULT_PATH = join(homedir(), ".sportsclaw", "entity-cache.json");
+
+export class EntityStore {
+  private byId = new Map<string, CachedEntity>();
+  private loaded = false;
+
+  constructor(private filePath: string = DEFAULT_PATH) {}
+
+  async load(): Promise<void> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const arr = JSON.parse(raw) as CachedEntity[];
+      for (const e of arr) this.byId.set(e.id, e);
+    } catch {
+      // Missing/corrupt file → start empty.
+    }
+    this.loaded = true;
+  }
+
+  get(query: string, entityType?: EntityType, sport?: string): CachedEntity | undefined {
+    const q = query.trim().toLowerCase();
+    for (const e of this.byId.values()) {
+      if (entityType && e.entityType !== entityType) continue;
+      if (sport && (e.sport ?? "").toLowerCase() !== sport.toLowerCase()) continue;
+      if (entityIsStale(e)) continue;
+      const names = [e.canonicalName, ...e.aliases].map((n) => n.toLowerCase());
+      if (names.includes(q)) return e;
+    }
+    return undefined;
+  }
+
+  async upsert(entity: CachedEntity): Promise<void> {
+    if (!this.loaded) await this.load();
+    const existing = this.byId.get(entity.id);
+    if (existing) {
+      entity.mentionCount = existing.mentionCount + 1;
+      entity.firstSeenAt = existing.firstSeenAt;
+    }
+    this.byId.set(entity.id, entity);
+    await this.persist();
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const tmp = `${this.filePath}.tmp`;
+    await writeFile(tmp, JSON.stringify([...this.byId.values()], null, 2), "utf8");
+    await rename(tmp, this.filePath); // atomic replace
+  }
+}

--- a/src/cache/entity-store.ts
+++ b/src/cache/entity-store.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -24,7 +25,9 @@ const TTL_DAYS: Record<EntityType, number> = {
 };
 
 export function entityIsStale(entity: CachedEntity, now: number = Date.now()): boolean {
-  const ttlMs = TTL_DAYS[entity.entityType] * 86_400_000;
+  const ttlDays = TTL_DAYS[entity.entityType];
+  if (ttlDays === undefined) return true;
+  const ttlMs = ttlDays * 86_400_000;
   const verified = Date.parse(entity.lastVerifiedAt);
   if (Number.isNaN(verified)) return true;
   return now - verified > ttlMs;
@@ -74,7 +77,7 @@ export class EntityStore {
 
   private async persist(): Promise<void> {
     await mkdir(dirname(this.filePath), { recursive: true });
-    const tmp = `${this.filePath}.tmp`;
+    const tmp = `${this.filePath}.${randomUUID()}.tmp`;
     await writeFile(tmp, JSON.stringify([...this.byId.values()], null, 2), "utf8");
     await rename(tmp, this.filePath); // atomic replace
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -614,7 +614,7 @@ export class sportsclawEngine {
           n === "get_agent_config" || n === "install_sport" || n === "remove_sport" ||
           n === "upgrade_sports_skills" || n === "spawn_subagent" || n === "list_subagents" ||
           n === "schedule_task" || n === "list_scheduled_tasks" || n === "cancel_scheduled_task" ||
-          n === "consolidate_memory" || n === "machina_loop"
+          n === "consolidate_memory" || n === "machina_loop" || n === "run_selftest"
         );
         return {
           activeTools: [...internalNames, ...mcpToolNames],
@@ -673,7 +673,8 @@ export class sportsclawEngine {
       name === "schedule_task" ||
       name === "list_scheduled_tasks" ||
       name === "cancel_scheduled_task" ||
-      name === "consolidate_memory";
+      name === "consolidate_memory" ||
+      name === "run_selftest";
     const active = toolNames.filter((name) => {
       if (isInternalTool(name)) return true;
       if (name.startsWith("mcp__")) return true; // MCP tools always active
@@ -737,7 +738,7 @@ export class sportsclawEngine {
       name === "upgrade_sports_skills" || name === "spawn_subagent" ||
       name === "list_subagents" || name === "schedule_task" ||
       name === "list_scheduled_tasks" || name === "cancel_scheduled_task" ||
-      name === "consolidate_memory" || name === "machina_loop";
+      name === "consolidate_memory" || name === "machina_loop" || name === "run_selftest";
     return allToolNames.filter((name) => {
       if (isInternalTool(name) || name.startsWith("mcp__")) return true;
       const skill = this.registry.getSkillName(name);
@@ -1161,6 +1162,73 @@ export class sportsclawEngine {
           null,
           2
         );
+      },
+    });
+
+    toolMap["run_selftest"] = defineTool({
+      description:
+        "Run sportsclaw's built-in self-test suite: live smoke-checks against installed " +
+        "sport data feeds (scoreboards, standings, market status, etc). Use this to answer " +
+        "questions like 'are the feeds working?' or to diagnose a suspected outage. " +
+        "Checks are live by default.",
+      inputSchema: jsonSchema({
+        type: "object",
+        properties: {
+          sport: {
+            type: "string",
+            description: "Restrict the check to a single installed sport (e.g. \"nba\"). Omit to check all installed sports.",
+          },
+          quick: {
+            type: "boolean",
+            description: "Run only one check per sport instead of the full suite. Defaults to false.",
+          },
+        },
+      }),
+      execute: async (args: Record<string, unknown>) => {
+        const { runSelftest } = await import("./selftest/runner.js");
+        const { classifyFailure } = await import("./failures/classifier.js");
+        const sport = typeof args.sport === "string" ? args.sport : undefined;
+        const quick = args.quick === true;
+
+        const seen = new Set<string>();
+        const executor = async (c: { sport: string; toolName: string; args: Record<string, unknown> }) => {
+          if (quick) {
+            if (seen.has(c.sport)) return { ok: true, skip: true, latencyMs: 0, note: "skipped (quick)" };
+            seen.add(c.sport);
+          }
+          const started = Date.now();
+          try {
+            const result = await registry.dispatchToolCall(c.toolName, c.args as ToolCallInput, config);
+            const latencyMs = Date.now() - started;
+            if (result.isError) {
+              // result.content is already-classified JSON (handleDynamicTool embeds a
+              // `hint` via classifyFailure) — parse it instead of re-classifying the
+              // rendered JSON string as if it were raw error text.
+              let note = result.content.slice(0, 200);
+              try {
+                const parsed = JSON.parse(result.content) as { hint?: string };
+                if (parsed.hint) note = parsed.hint;
+              } catch {
+                // not JSON — fall back to the raw (truncated) content above
+              }
+              return { ok: false, latencyMs, note };
+            }
+            return { ok: true, latencyMs };
+          } catch (err) {
+            const latencyMs = Date.now() - started;
+            const raw = err instanceof Error ? err.message : String(err);
+            const classified = classifyFailure(raw, c.toolName);
+            return { ok: false, latencyMs, note: classified.userMessage || raw.slice(0, 200) };
+          }
+        };
+
+        const report = await runSelftest({
+          sports: sport ? [sport] : undefined,
+          live: true,
+          version: _packageVersion,
+          execute: executor,
+        });
+        return JSON.stringify(report.toJSON());
       },
     });
 

--- a/src/failures/classifier.ts
+++ b/src/failures/classifier.ts
@@ -1,0 +1,122 @@
+import { classifyBridgeError } from "../bridge.js";
+import type { ClassifiedFailure, FailureCategory } from "./types.js";
+
+interface Rule {
+  category: FailureCategory;
+  severity: "low" | "medium" | "high";
+  retryable: boolean;
+  match: (h: string) => boolean;
+  userMessage: string;
+  suggestedFix?: string;
+}
+
+// Generic, non-proprietary pattern rules. Order matters: first match wins.
+const RULES: Rule[] = [
+  {
+    category: "rate_limited",
+    severity: "low",
+    retryable: true,
+    match: (h) => h.includes("429") || h.includes("rate limit") || h.includes("too many requests"),
+    userMessage: "The data provider rate-limited the request. Retrying shortly should work.",
+    suggestedFix: "Honor retry_after if present; otherwise back off and retry.",
+  },
+  {
+    category: "permission_config",
+    severity: "high",
+    retryable: false,
+    match: (h) =>
+      h.includes("storage.objects.create denied") ||
+      (h.includes("403") && h.includes("storage")) ||
+      h.includes("permission denied"),
+    userMessage: "The action ran but a storage/permission check rejected it (403). Retrying won't help.",
+    suggestedFix: "Grant the missing permission to the service account or use a writable target.",
+  },
+  {
+    category: "auth_error",
+    severity: "high",
+    retryable: false,
+    match: (h) => h.includes("401") || h.includes("unauthorized") || h.includes("invalid api key"),
+    userMessage: "Authentication failed for this provider. Retrying won't help until credentials are fixed.",
+    suggestedFix: "Check the provider API key / auth configuration.",
+  },
+  {
+    category: "data_not_ready",
+    severity: "low",
+    retryable: true,
+    match: (h) =>
+      h.includes("not enough") ||
+      h.includes("not ready") ||
+      h.includes("no fixtures") ||
+      h.includes("no data available yet"),
+    userMessage: "The underlying data isn't populated yet, so the result would be unreliable.",
+    suggestedFix: "Wait until the required data is available, then retry.",
+  },
+  {
+    category: "user_input",
+    severity: "medium",
+    retryable: false,
+    match: (h) =>
+      h.includes("must be prefixed") ||
+      h.includes("looks like a name, not a valid") ||
+      h.includes("invalid argument") ||
+      h.includes("required parameter"),
+    userMessage: "The request needs a corrected or resolved input before it can run.",
+    suggestedFix: "Resolve/normalize the offending argument, then retry.",
+  },
+];
+
+function toHaystack(error: string | { message?: string } | undefined): string {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  return String(error.message ?? "");
+}
+
+/**
+ * Turn a raw tool/workflow error into a structured, user-safe classification.
+ * Composes the generic pattern rules above with the bridge classifier for
+ * Python-subprocess-specific codes (timeout, dependency_missing, circuit_open, …).
+ */
+export function classifyFailure(
+  error: string | { message?: string } | undefined,
+  toolName?: string,
+): ClassifiedFailure {
+  const raw = toHaystack(error);
+  const h = raw.toLowerCase();
+
+  for (const rule of RULES) {
+    if (rule.match(h)) {
+      return {
+        category: rule.category,
+        severity: rule.severity,
+        retryable: rule.retryable,
+        userMessage: rule.userMessage,
+        developerMessage: toolName ? `[${toolName}] ${raw}` : raw,
+        suggestedFix: rule.suggestedFix,
+        rawError: raw,
+      };
+    }
+  }
+
+  // Fall back to the bridge classifier for subprocess-specific codes.
+  const { errorCode, hint } = classifyBridgeError(raw);
+  const mapping: Record<string, { category: FailureCategory; retryable: boolean; severity: "low" | "medium" | "high" }> = {
+    timeout: { category: "provider_error", retryable: true, severity: "medium" },
+    dependency_missing: { category: "permission_config", retryable: false, severity: "high" },
+    network_dns: { category: "provider_error", retryable: true, severity: "medium" },
+    rate_limited: { category: "rate_limited", retryable: true, severity: "low" },
+    python_version_incompatible: { category: "permission_config", retryable: false, severity: "high" },
+    circuit_open: { category: "provider_error", retryable: true, severity: "medium" },
+    tool_execution_failed: { category: "unknown", retryable: false, severity: "medium" },
+  };
+  const m = mapping[errorCode] ?? { category: "unknown" as FailureCategory, retryable: false, severity: "medium" as const };
+
+  return {
+    category: m.category,
+    severity: m.severity,
+    retryable: m.retryable,
+    userMessage: hint,
+    developerMessage: toolName ? `[${toolName}] ${raw}` : raw,
+    suggestedFix: hint,
+    rawError: raw,
+  };
+}

--- a/src/failures/classifier.ts
+++ b/src/failures/classifier.ts
@@ -10,13 +10,15 @@ interface Rule {
   suggestedFix?: string;
 }
 
+const hasCode = (h: string, code: string) => new RegExp(`\\b${code}\\b`).test(h);
+
 // Generic, non-proprietary pattern rules. Order matters: first match wins.
 const RULES: Rule[] = [
   {
     category: "rate_limited",
     severity: "low",
     retryable: true,
-    match: (h) => h.includes("429") || h.includes("rate limit") || h.includes("too many requests"),
+    match: (h) => hasCode(h, "429") || h.includes("rate limit") || h.includes("too many requests"),
     userMessage: "The data provider rate-limited the request. Retrying shortly should work.",
     suggestedFix: "Honor retry_after if present; otherwise back off and retry.",
   },
@@ -26,7 +28,7 @@ const RULES: Rule[] = [
     retryable: false,
     match: (h) =>
       h.includes("storage.objects.create denied") ||
-      (h.includes("403") && h.includes("storage")) ||
+      (hasCode(h, "403") && h.includes("storage")) ||
       h.includes("permission denied"),
     userMessage: "The action ran but a storage/permission check rejected it (403). Retrying won't help.",
     suggestedFix: "Grant the missing permission to the service account or use a writable target.",
@@ -35,7 +37,7 @@ const RULES: Rule[] = [
     category: "auth_error",
     severity: "high",
     retryable: false,
-    match: (h) => h.includes("401") || h.includes("unauthorized") || h.includes("invalid api key"),
+    match: (h) => hasCode(h, "401") || h.includes("unauthorized") || h.includes("invalid api key"),
     userMessage: "Authentication failed for this provider. Retrying won't help until credentials are fixed.",
     suggestedFix: "Check the provider API key / auth configuration.",
   },
@@ -105,7 +107,7 @@ export function classifyFailure(
     network_dns: { category: "provider_error", retryable: true, severity: "medium" },
     rate_limited: { category: "rate_limited", retryable: true, severity: "low" },
     python_version_incompatible: { category: "permission_config", retryable: false, severity: "high" },
-    circuit_open: { category: "provider_error", retryable: true, severity: "medium" },
+    circuit_open: { category: "provider_error", retryable: false, severity: "medium" },
     tool_execution_failed: { category: "unknown", retryable: false, severity: "medium" },
   };
   const m = mapping[errorCode] ?? { category: "unknown" as FailureCategory, retryable: false, severity: "medium" as const };

--- a/src/failures/types.ts
+++ b/src/failures/types.ts
@@ -1,0 +1,23 @@
+/** Structured failure categories for tool/workflow errors. */
+export type FailureCategory =
+  | "user_input"
+  | "data_not_ready"
+  | "provider_error"
+  | "rate_limited"
+  | "permission_config"
+  | "auth_error"
+  | "tool_contract"
+  | "agent_planning"
+  | "unknown";
+
+export interface ClassifiedFailure {
+  category: FailureCategory;
+  severity: "low" | "medium" | "high";
+  retryable: boolean;
+  /** Clean, human-facing explanation: what failed, why, whether retry helps, what to do next. */
+  userMessage: string;
+  /** Technical detail for logs/developers. */
+  developerMessage: string;
+  suggestedFix?: string;
+  rawError?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1381,6 +1381,71 @@ async function cmdHealth(args: string[]): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// CLI: `sportsclaw selftest` — schema smoke tests (Task 3's runner/report,
+// wired to the real Python-bridge tool dispatch used by the engine).
+// ---------------------------------------------------------------------------
+
+async function cmdSelftest(args: string[]): Promise<void> {
+  const json = args.includes("--json");
+  const live = args.includes("--live");
+  const quick = args.includes("--quick");
+  const sportIdx = args.indexOf("--sport");
+  const sports = sportIdx >= 0 && args[sportIdx + 1] ? [args[sportIdx + 1]] : undefined;
+
+  const { runSelftest } = await import("./selftest/runner.js");
+  const { renderMarkdown } = await import("./selftest/report.js");
+  const { classifyFailure } = await import("./failures/classifier.js");
+  const { ToolRegistry } = await import("./tools.js");
+
+  let { pythonPath } = resolveConfig();
+  const registry = new ToolRegistry();
+
+  // Only need the real Python bridge (venv + sport schemas) when actually
+  // executing tool calls; offline runs skip every case before this matters.
+  if (live) {
+    const venvResult = ensureVenv(pythonPath);
+    if (venvResult.ok) pythonPath = venvResult.pythonPath;
+    await ensureDefaultSchemas();
+    const { loadAllSchemas } = await import("./schema.js");
+    for (const schema of loadAllSchemas()) {
+      registry.injectSchema(schema);
+    }
+  }
+
+  const seen = new Set<string>();
+  const executor = async (c: { sport: string; toolName: string; args: Record<string, unknown> }) => {
+    if (quick) {
+      if (seen.has(c.sport)) return { ok: true, latencyMs: 0, note: "skipped (quick)" };
+      seen.add(c.sport);
+    }
+    const started = Date.now();
+    try {
+      const result = await registry.dispatchToolCall(c.toolName, c.args, { pythonPath });
+      const latencyMs = Date.now() - started;
+      if (result.isError) {
+        const classified = classifyFailure(result.content, c.toolName);
+        return { ok: false, latencyMs, note: classified.userMessage || result.content.slice(0, 200) };
+      }
+      return { ok: true, latencyMs };
+    } catch (err) {
+      const latencyMs = Date.now() - started;
+      const raw = err instanceof Error ? err.message : String(err);
+      const classified = classifyFailure(raw, c.toolName);
+      return { ok: false, latencyMs, note: classified.userMessage || raw.slice(0, 200) };
+    }
+  };
+
+  const report = await runSelftest({ sports, live, version: PKG_VERSION, execute: executor });
+
+  if (json) {
+    console.log(JSON.stringify(report.toJSON(), null, 2));
+  } else {
+    console.log(renderMarkdown(report));
+  }
+  process.exit(report.failed > 0 ? 1 : 0);
+}
+
+// ---------------------------------------------------------------------------
 // CLI: `sportsclaw init`
 // ---------------------------------------------------------------------------
 
@@ -2628,6 +2693,7 @@ function printHelp(): void {
   console.log("  sportsclaw setup [prompt]           AI-guided setup wizard");
   console.log("  sportsclaw doctor                  Check setup and diagnose issues");
   console.log("  sportsclaw health [--json]         Check system health and status");
+  console.log("  sportsclaw selftest [--quick] [--sport <s>] [--json] [--live]  Run schema smoke tests");
   console.log("  sportsclaw config                  Run interactive configuration wizard");
   console.log("  sportsclaw channels                Configure Discord & Telegram tokens");
   console.log("  sportsclaw login claude            Sign in via existing Claude Code session");
@@ -2850,6 +2916,8 @@ async function main(): Promise<void> {
       return cmdDoctor();
     case "health":
       return cmdHealth(subArgs);
+    case "selftest":
+      return cmdSelftest(subArgs);
     case "add":
       return cmdAdd(subArgs);
     case "remove":

--- a/src/index.ts
+++ b/src/index.ts
@@ -1415,7 +1415,7 @@ async function cmdSelftest(args: string[]): Promise<void> {
   const seen = new Set<string>();
   const executor = async (c: { sport: string; toolName: string; args: Record<string, unknown> }) => {
     if (quick) {
-      if (seen.has(c.sport)) return { ok: true, latencyMs: 0, note: "skipped (quick)" };
+      if (seen.has(c.sport)) return { ok: true, skip: true, latencyMs: 0, note: "skipped (quick)" };
       seen.add(c.sport);
     }
     const started = Date.now();
@@ -1423,8 +1423,17 @@ async function cmdSelftest(args: string[]): Promise<void> {
       const result = await registry.dispatchToolCall(c.toolName, c.args, { pythonPath });
       const latencyMs = Date.now() - started;
       if (result.isError) {
-        const classified = classifyFailure(result.content, c.toolName);
-        return { ok: false, latencyMs, note: classified.userMessage || result.content.slice(0, 200) };
+        // result.content is already-classified JSON (handleDynamicTool embeds a
+        // `hint` via classifyFailure) — parse it instead of re-classifying the
+        // rendered JSON string as if it were raw error text.
+        let note = result.content.slice(0, 200);
+        try {
+          const parsed = JSON.parse(result.content) as { hint?: string };
+          if (parsed.hint) note = parsed.hint;
+        } catch {
+          // not JSON — fall back to the raw (truncated) content above
+        }
+        return { ok: false, latencyMs, note };
       }
       return { ok: true, latencyMs };
     } catch (err) {

--- a/src/intelligence/entity-resolver.ts
+++ b/src/intelligence/entity-resolver.ts
@@ -35,6 +35,15 @@ export class EntityResolver {
   public async hydrate(store?: EntityStore): Promise<void> {
     this.store = store ?? new EntityStore();
     await this.store.load();
+    for (const entity of this.store.all()) {
+      if (entity.sport && (entity.entityType === "team" || entity.entityType === "player")) {
+        this.register(entity.sport, entity.entityType, {
+          canonicalId: entity.id,
+          aliases: [entity.canonicalName, ...entity.aliases],
+          providerIds: entity.providerIds,
+        });
+      }
+    }
   }
 
   public async remember(entity: CachedEntity): Promise<void> {

--- a/src/intelligence/entity-resolver.ts
+++ b/src/intelligence/entity-resolver.ts
@@ -5,6 +5,8 @@
  * (e.g. mapping ESPN IDs, bookmakers, and prediction markets to the same graph node).
  */
 
+import { EntityStore, type CachedEntity } from "../cache/entity-store.js";
+
 export interface EntityMapping {
   canonicalId: string;
   aliases: Set<string>;
@@ -26,6 +28,24 @@ export class EntityResolver {
       EntityResolver.instance = new EntityResolver();
     }
     return EntityResolver.instance;
+  }
+
+  private store: EntityStore | null = null;
+
+  public async hydrate(store?: EntityStore): Promise<void> {
+    this.store = store ?? new EntityStore();
+    await this.store.load();
+  }
+
+  public async remember(entity: CachedEntity): Promise<void> {
+    if (this.store) await this.store.upsert(entity);
+    if (entity.sport && (entity.entityType === "team" || entity.entityType === "player")) {
+      this.register(entity.sport, entity.entityType, {
+        canonicalId: entity.id,
+        aliases: [entity.canonicalName, ...entity.aliases],
+        providerIds: entity.providerIds,
+      });
+    }
   }
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types.js";
 import { buildProviderOptions, DEFAULT_TOKEN_BUDGETS } from "./types.js";
 import type { AgentDef } from "./agents.js";
+import { planSkillCaps } from "./routing/complexity.js";
 
 type ModelType = Parameters<typeof generateText>[0]["model"];
 
@@ -323,6 +324,13 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
 
   const promptNorm = normalizeText(input.prompt);
 
+  const capPlan = planSkillCaps(input.prompt, {
+    routingMaxSkills: input.config.routingMaxSkills,
+    routingAllowSpillover: input.config.routingAllowSpillover,
+  });
+  const effectiveMaxSkills = Math.max(input.config.routingMaxSkills, capPlan.maxSkills);
+  const seededSkills = capPlan.addSkills.filter((s) => input.installedSkills.includes(s));
+
   // --- MCP intent early exit ---
   // If the prompt targets pod/MCP entities and MCP tools are present in the
   // tool specs, return immediately with high confidence and zero sport skills.
@@ -395,10 +403,14 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
     .sort((a, b) => b[1] - a[1])
     .map(([skill]) => skill);
 
+  const deterministicCandidates = Array.from(
+    new Set([...rankedDeterministic.slice(0, 4), ...seededSkills])
+  ).slice(0, effectiveMaxSkills);
+
   const primaryAttempt = await runLlmRouter(
     input,
     input.model,
-    rankedDeterministic.slice(0, 4),
+    deterministicCandidates,
     rankedMemory.slice(0, 4)
   );
   const llmDecision = primaryAttempt.decision;
@@ -455,7 +467,7 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
       confidence = Math.max(confidence, 0.65);
       reason = `Deterministic fallback selected: ${fallback}`;
     } else {
-      for (const skill of rankedMemory.slice(0, input.config.routingMaxSkills)) {
+      for (const skill of rankedMemory.slice(0, effectiveMaxSkills)) {
         selected.add(skill);
       }
       if (selected.size > 0) {
@@ -479,7 +491,7 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
     const limit = Math.max(1, 1 + spillover);
     routedPrimary = primarySkills.slice(0, limit);
   } else {
-    const limit = Math.max(1, input.config.routingMaxSkills);
+    const limit = Math.max(1, effectiveMaxSkills);
     routedPrimary = primarySkills.slice(0, limit);
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -354,7 +354,7 @@ export async function routePromptToSkills(input: RouteInput): Promise<RouteOutco
     };
   }
 
-  const helperSkills = inferHelperSkills(promptNorm, installedSet);
+  const helperSkills = new Set([...inferHelperSkills(promptNorm, installedSet), ...seededSkills]);
   const fanProfile = extractFanProfileSection(input.memoryBlock);
   const toolTokens = buildToolTokensBySkill(input.installedSkills, input.toolSpecs);
 

--- a/src/routing/complexity.ts
+++ b/src/routing/complexity.ts
@@ -13,8 +13,15 @@ const NEWS_KW = ["injury", "injuries", "out", "questionable", "news", "report"];
 const MULTISPORT_KW = ["across sports", "what's happening", "whats happening", "everything", "all sports", "tonight across"];
 const RESEARCH_KW = ["audit", "deep dive", "analyze", "research", "compare", "breakdown"];
 
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function hasAny(h: string, kws: string[]): boolean {
-  return kws.some((k) => h.includes(k));
+  return kws.some((k) => {
+    if (k.includes(" ")) return h.includes(k);
+    return new RegExp(`\\b${escapeRegex(k)}\\b`).test(h);
+  });
 }
 
 export function classifyQueryComplexity(query: string): QueryComplexity {
@@ -32,7 +39,6 @@ export function planSkillCaps(
   base: { routingMaxSkills: number; routingAllowSpillover: number },
 ): SkillCapPlan {
   const complexity = classifyQueryComplexity(query);
-  const h = query.toLowerCase();
   const addSkills: string[] = [];
   let maxSkills = base.routingMaxSkills;
   let reason = "simple query — default caps";
@@ -49,7 +55,7 @@ export function planSkillCaps(
       break;
     case "compound":
       maxSkills = Math.max(maxSkills, 3);
-      if (hasAny(h, NEWS_KW)) addSkills.push("news");
+      addSkills.push("news");
       reason = "compound (injury/news) — added news";
       break;
     case "live_game":

--- a/src/routing/complexity.ts
+++ b/src/routing/complexity.ts
@@ -1,0 +1,64 @@
+export type QueryComplexity = "simple" | "compound" | "research" | "betting" | "live_game";
+
+export interface SkillCapPlan {
+  complexity: QueryComplexity;
+  maxSkills: number;
+  addSkills: string[];
+  reason: string;
+}
+
+const BETTING_KW = ["bet", "bets", "odds", "line", "spread", "total", "over", "under", "market", "price", "edge", "kelly"];
+const LIVE_KW = ["live", "right now", "winning", "quarter", "period", "inning"];
+const NEWS_KW = ["injury", "injuries", "out", "questionable", "news", "report"];
+const MULTISPORT_KW = ["across sports", "what's happening", "whats happening", "everything", "all sports", "tonight across"];
+const RESEARCH_KW = ["audit", "deep dive", "analyze", "research", "compare", "breakdown"];
+
+function hasAny(h: string, kws: string[]): boolean {
+  return kws.some((k) => h.includes(k));
+}
+
+export function classifyQueryComplexity(query: string): QueryComplexity {
+  const h = query.toLowerCase();
+  if (hasAny(h, MULTISPORT_KW)) return "research";
+  if (hasAny(h, RESEARCH_KW)) return "research";
+  if (hasAny(h, BETTING_KW)) return "betting";
+  if (hasAny(h, NEWS_KW)) return "compound";
+  if (hasAny(h, LIVE_KW)) return "live_game";
+  return "simple";
+}
+
+export function planSkillCaps(
+  query: string,
+  base: { routingMaxSkills: number; routingAllowSpillover: number },
+): SkillCapPlan {
+  const complexity = classifyQueryComplexity(query);
+  const h = query.toLowerCase();
+  const addSkills: string[] = [];
+  let maxSkills = base.routingMaxSkills;
+  let reason = "simple query — default caps";
+
+  switch (complexity) {
+    case "betting":
+      maxSkills = Math.max(maxSkills, 3);
+      addSkills.push("betting", "markets", "kalshi", "polymarket");
+      reason = "betting intent — added market skills";
+      break;
+    case "research":
+      maxSkills = Math.max(maxSkills, 4);
+      reason = "multi-sport/research — widened skill budget";
+      break;
+    case "compound":
+      maxSkills = Math.max(maxSkills, 3);
+      if (hasAny(h, NEWS_KW)) addSkills.push("news");
+      reason = "compound (injury/news) — added news";
+      break;
+    case "live_game":
+      maxSkills = Math.max(maxSkills, 3);
+      reason = "live-game intent";
+      break;
+    case "simple":
+    default:
+      break;
+  }
+  return { complexity, maxSkills, addSkills, reason };
+}

--- a/src/selftest/cases.ts
+++ b/src/selftest/cases.ts
@@ -1,0 +1,20 @@
+export interface SmokeTestCase {
+  sport: string;
+  name: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  live?: boolean;
+  required?: boolean;
+}
+
+// Tool names verified against sports-skills v0.28.0 (`<module>_<command>`).
+export const SMOKE_TESTS: SmokeTestCase[] = [
+  { sport: "nba", name: "scoreboard", toolName: "nba_get_scoreboard", args: {} },
+  { sport: "nba", name: "standings", toolName: "nba_get_standings", args: {} },
+  { sport: "nfl", name: "scoreboard", toolName: "nfl_get_scoreboard", args: {} },
+  { sport: "mlb", name: "scoreboard", toolName: "mlb_get_scoreboard", args: {} },
+  { sport: "football", name: "competitions", toolName: "football_get_competitions", args: {} },
+  { sport: "metadata", name: "team search", toolName: "metadata_search_teams", args: { query: "Lakers" } },
+  { sport: "kalshi", name: "exchange status", toolName: "kalshi_get_exchange_status", args: {} },
+  { sport: "polymarket", name: "sports config", toolName: "polymarket_get_sports_config", args: {} },
+];

--- a/src/selftest/report.ts
+++ b/src/selftest/report.ts
@@ -1,0 +1,29 @@
+export interface SmokeResult {
+  sport: string;
+  check: string;
+  status: "pass" | "fail" | "skip";
+  latencyMs: number;
+  notes: string;
+}
+
+export interface SelfTestReport {
+  version: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  results: SmokeResult[];
+  toJSON(): Record<string, unknown>;
+}
+
+export function renderMarkdown(report: SelfTestReport): string {
+  const lines = [
+    "| Sport | Check | Status | Latency | Notes |",
+    "| --- | --- | --- | --- | --- |",
+  ];
+  for (const r of report.results) {
+    lines.push(`| ${r.sport} | ${r.check} | ${r.status} | ${r.latencyMs}ms | ${r.notes} |`);
+  }
+  lines.push("");
+  lines.push(`**${report.passed} passed, ${report.failed} failed, ${report.skipped} skipped**`);
+  return lines.join("\n");
+}

--- a/src/selftest/runner.ts
+++ b/src/selftest/runner.ts
@@ -23,14 +23,25 @@ export async function runSelftest(opts: RunOptions): Promise<SelfTestReport> {
       results.push({ sport: c.sport, check: c.name, status: "skip", latencyMs: 0, notes: "no executor" });
       continue;
     }
-    const r = await opts.execute(c);
-    results.push({
-      sport: c.sport,
-      check: c.name,
-      status: r.ok ? "pass" : "fail",
-      latencyMs: r.latencyMs,
-      notes: r.note ?? "",
-    });
+    try {
+      const r = await opts.execute(c);
+      results.push({
+        sport: c.sport,
+        check: c.name,
+        status: r.ok ? "pass" : "fail",
+        latencyMs: r.latencyMs,
+        notes: r.note ?? "",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({
+        sport: c.sport,
+        check: c.name,
+        status: "fail",
+        latencyMs: 0,
+        notes: message.slice(0, 200),
+      });
+    }
   }
 
   const passed = results.filter((r) => r.status === "pass").length;

--- a/src/selftest/runner.ts
+++ b/src/selftest/runner.ts
@@ -5,7 +5,9 @@ interface RunOptions {
   sports?: string[];
   live?: boolean;
   version?: string;
-  execute?: (c: SmokeTestCase) => Promise<{ ok: boolean; note?: string; latencyMs: number }>;
+  execute?: (
+    c: SmokeTestCase
+  ) => Promise<{ ok: boolean; note?: string; latencyMs: number; skip?: boolean }>;
 }
 
 export async function runSelftest(opts: RunOptions): Promise<SelfTestReport> {
@@ -28,7 +30,7 @@ export async function runSelftest(opts: RunOptions): Promise<SelfTestReport> {
       results.push({
         sport: c.sport,
         check: c.name,
-        status: r.ok ? "pass" : "fail",
+        status: r.skip ? "skip" : r.ok ? "pass" : "fail",
         latencyMs: r.latencyMs,
         notes: r.note ?? "",
       });

--- a/src/selftest/runner.ts
+++ b/src/selftest/runner.ts
@@ -1,0 +1,46 @@
+import { SMOKE_TESTS, type SmokeTestCase } from "./cases.js";
+import type { SelfTestReport, SmokeResult } from "./report.js";
+
+interface RunOptions {
+  sports?: string[];
+  live?: boolean;
+  version?: string;
+  execute?: (c: SmokeTestCase) => Promise<{ ok: boolean; note?: string; latencyMs: number }>;
+}
+
+export async function runSelftest(opts: RunOptions): Promise<SelfTestReport> {
+  const version = opts.version ?? "0.0.0";
+  const live = opts.live ?? false;
+  const cases = SMOKE_TESTS.filter((c) => !opts.sports || opts.sports.includes(c.sport));
+
+  const results: SmokeResult[] = [];
+  for (const c of cases) {
+    if (c.live !== false && !live) {
+      results.push({ sport: c.sport, check: c.name, status: "skip", latencyMs: 0, notes: "offline (use --live)" });
+      continue;
+    }
+    if (!opts.execute) {
+      results.push({ sport: c.sport, check: c.name, status: "skip", latencyMs: 0, notes: "no executor" });
+      continue;
+    }
+    const r = await opts.execute(c);
+    results.push({
+      sport: c.sport,
+      check: c.name,
+      status: r.ok ? "pass" : "fail",
+      latencyMs: r.latencyMs,
+      notes: r.note ?? "",
+    });
+  }
+
+  const passed = results.filter((r) => r.status === "pass").length;
+  const failed = results.filter((r) => r.status === "fail").length;
+  const skipped = results.filter((r) => r.status === "skip").length;
+
+  return {
+    version, passed, failed, skipped, results,
+    toJSON() {
+      return { version, passed, failed, skipped, results };
+    },
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -296,6 +296,7 @@ export class ToolRegistry {
       toolName === "reflect" ||
       toolName === "evolve_strategy" ||
       toolName === "get_agent_config" ||
+      toolName === "run_selftest" ||
       toolName === "install_sport" ||
       toolName === "remove_sport" ||
       toolName === "upgrade_sports_skills" ||

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -18,6 +18,7 @@ import type { McpManager } from "./mcp.js";
 import { buildSportsSkillsRepairCommand } from "./python.js";
 import { isBlockedTool, logSecurityEvent } from "./security.js";
 import { BUILTIN_TOOLS, machinaLoopTool } from "./tools/index.js";
+import { classifyFailure } from "./failures/classifier.js";
 
 export {
   ToolCallInput,
@@ -550,7 +551,9 @@ export class ToolRegistry {
           ? `F1 support is unavailable. Repair with: ${repairCmd}`
           : `The sports-skills Python package may be missing. Install/repair with: ${repairCmd}`;
       } else {
-        hint = classified.hint;
+        const toolName = `${sport}_${command}`;
+        const failure = classifyFailure(result.error, toolName);
+        hint = failure.userMessage || result.error || classified.hint;
       }
       return {
         content: JSON.stringify({

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -19,6 +19,8 @@ import { buildSportsSkillsRepairCommand } from "./python.js";
 import { isBlockedTool, logSecurityEvent } from "./security.js";
 import { BUILTIN_TOOLS, machinaLoopTool } from "./tools/index.js";
 import { classifyFailure } from "./failures/classifier.js";
+import { logToolExecution } from "./analytics.js";
+import type { ToolExecutionResult } from "./tools/executor.js";
 
 export {
   ToolCallInput,
@@ -431,6 +433,30 @@ export class ToolRegistry {
   }
 
   /**
+   * Emit a redacted `tool_execution` analytics event for a dispatch result.
+   * Skips internal (non-sport) tools and MCP tools, which are not part of
+   * the sports-skills reliability surface this event tracks.
+   */
+  private logDispatchResult(
+    toolName: string,
+    input: ToolCallInput,
+    result: ToolCallResult,
+    started: number
+  ): void {
+    if (this.isInternalTool(toolName) || toolName.startsWith("mcp__")) return;
+    const execResult: ToolExecutionResult = {
+      ok: !result.isError,
+      toolName,
+      args: input as Record<string, unknown>,
+      warnings: [],
+      normalized: false,
+      failure: result.isError ? classifyFailure(result.content, toolName) : undefined,
+      latencyMs: Date.now() - started,
+    };
+    logToolExecution(execResult);
+  }
+
+  /**
    * Dispatch a tool call by name and return the structured result for the LLM.
    *
    * Handles both the built-in `sports_query` tool and any dynamically injected
@@ -441,6 +467,8 @@ export class ToolRegistry {
     input: ToolCallInput,
     config?: Partial<sportsclawConfig>
   ): Promise<ToolCallResult> {
+    const started = Date.now();
+
     // Sanitize input bare years
     sanitizeToolInput(toolName, input);
 
@@ -448,7 +476,7 @@ export class ToolRegistry {
     const blockReason = isBlockedTool(toolName, config?.allowTrading);
     if (blockReason) {
       logSecurityEvent("blocked_tool", { toolName, input });
-      return {
+      const blockedResult: ToolCallResult = {
         content: JSON.stringify({
           error: blockReason,
           error_code: "blocked_tool",
@@ -456,6 +484,8 @@ export class ToolRegistry {
         }),
         isError: true,
       };
+      this.logDispatchResult(toolName, input, blockedResult, started);
+      return blockedResult;
     }
 
 
@@ -473,6 +503,7 @@ export class ToolRegistry {
               `[sportsclaw] cache hit for ${toolName} (age: ${Math.round(age / 1000)}s)`
             );
           }
+          this.logDispatchResult(toolName, input, cached.result, started);
           return cached.result;
         }
         // Expired entry — remove it
@@ -512,6 +543,7 @@ export class ToolRegistry {
       });
     }
 
+    this.logDispatchResult(toolName, input, result, started);
     return result;
   }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -493,7 +493,7 @@ export class ToolRegistry {
       if (route) {
         const spec = this.dynamicSpecs.find((s) => s.name === toolName);
         const connectionName = spec?.connection || route.sport;
-        result = await this.handleDynamicTool(route.sport, route.command, input, config, connectionName);
+        result = await this.handleDynamicTool(route.sport, route.command, input, config, connectionName, toolName);
       } else {
         result = {
           content: JSON.stringify({ error: `Unknown tool: ${toolName}` }),
@@ -521,7 +521,8 @@ export class ToolRegistry {
     command: string,
     input: ToolCallInput,
     config?: Partial<sportsclawConfig>,
-    connectionName?: string
+    connectionName?: string,
+    dispatchedToolName?: string
 ): Promise<ToolCallResult> {
     const pythonPath = config?.pythonPath ?? "python3";
     const repairCmd = buildSportsSkillsRepairCommand(pythonPath);
@@ -551,8 +552,9 @@ export class ToolRegistry {
           ? `F1 support is unavailable. Repair with: ${repairCmd}`
           : `The sports-skills Python package may be missing. Install/repair with: ${repairCmd}`;
       } else {
-        const toolName = `${sport}_${command}`;
-        const failure = classifyFailure(result.error, toolName);
+        const toolName = dispatchedToolName ?? `${sport}_${command}`;
+        const combined = `${result.error ?? ""}\n${result.stderr ?? ""}`.trim();
+        const failure = classifyFailure(combined, toolName);
         hint = failure.userMessage || result.error || classified.hint;
       }
       return {

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -20,12 +20,15 @@ export async function executeToolSafely(
   nowFn: () => number = Date.now,
 ): Promise<ToolExecutionResult> {
   const started = nowFn();
-  const normalizedArgs = structuredClone(args);
-  const before = JSON.stringify(normalizedArgs);
-  sanitizeToolInput(toolName, normalizedArgs);
-  const normalized = JSON.stringify(normalizedArgs) !== before;
+  let normalizedArgs = args;
+  let normalized = false;
 
   try {
+    normalizedArgs = structuredClone(args);
+    const before = JSON.stringify(normalizedArgs);
+    sanitizeToolInput(toolName, normalizedArgs);
+    normalized = JSON.stringify(normalizedArgs) !== before;
+
     const result = await run(toolName, normalizedArgs);
     if (result.isError) {
       return {

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -20,7 +20,7 @@ export async function executeToolSafely(
   nowFn: () => number = Date.now,
 ): Promise<ToolExecutionResult> {
   const started = nowFn();
-  const normalizedArgs = { ...args };
+  const normalizedArgs = structuredClone(args);
   const before = JSON.stringify(normalizedArgs);
   sanitizeToolInput(toolName, normalizedArgs);
   const normalized = JSON.stringify(normalizedArgs) !== before;

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -1,0 +1,48 @@
+import { sanitizeToolInput } from "../tools.js";
+import { classifyFailure } from "../failures/classifier.js";
+import type { ClassifiedFailure } from "../failures/types.js";
+
+export interface ToolExecutionResult {
+  ok: boolean;
+  toolName: string;
+  args: Record<string, unknown>;
+  data?: unknown;
+  warnings: string[];
+  failure?: ClassifiedFailure;
+  latencyMs?: number;
+  normalized: boolean;
+}
+
+export async function executeToolSafely(
+  toolName: string,
+  args: Record<string, unknown>,
+  run: (name: string, a: Record<string, unknown>) => Promise<{ content: string; isError?: boolean }>,
+  nowFn: () => number = Date.now,
+): Promise<ToolExecutionResult> {
+  const started = nowFn();
+  const normalizedArgs = { ...args };
+  const before = JSON.stringify(normalizedArgs);
+  sanitizeToolInput(toolName, normalizedArgs);
+  const normalized = JSON.stringify(normalizedArgs) !== before;
+
+  try {
+    const result = await run(toolName, normalizedArgs);
+    if (result.isError) {
+      return {
+        ok: false, toolName, args: normalizedArgs, warnings: [], normalized,
+        failure: classifyFailure(result.content, toolName),
+        latencyMs: nowFn() - started,
+      };
+    }
+    return {
+      ok: true, toolName, args: normalizedArgs, data: result.content, warnings: [], normalized,
+      latencyMs: nowFn() - started,
+    };
+  } catch (err) {
+    return {
+      ok: false, toolName, args: normalizedArgs, warnings: [], normalized,
+      failure: classifyFailure(err instanceof Error ? err.message : String(err), toolName),
+      latencyMs: nowFn() - started,
+    };
+  }
+}

--- a/src/tools/sports_query.ts
+++ b/src/tools/sports_query.ts
@@ -1,11 +1,12 @@
 import type { sportsclawConfig } from "../types.js";
-import { 
-  executePythonBridge, 
-  validateIdentifier, 
+import {
+  executePythonBridge,
+  validateIdentifier,
   classifyBridgeError,
-  type ToolCallInput, 
-  type ToolCallResult 
+  type ToolCallInput,
+  type ToolCallResult
 } from "../bridge.js";
+import { classifyFailure } from "../failures/classifier.js";
 import { buildSportsSkillsRepairCommand } from "../python.js";
 import type { BuiltinTool } from "./builtin-tool.js";
 
@@ -21,7 +22,9 @@ function buildBridgeErrorResult(
       ? `F1 support is unavailable. Repair with: ${repairCmd}`
       : `The sports-skills Python package may be missing. Install/repair with: ${repairCmd}`;
   } else {
-    hint = classified.hint;
+    const combined = `${result.error ?? ""}\n${result.stderr ?? ""}`.trim();
+    const failure = classifyFailure(combined, "sports_query");
+    hint = failure.userMessage || result.error || classified.hint;
   }
   return {
     content: JSON.stringify({

--- a/test/entity-resolver-persistence.test.mjs
+++ b/test/entity-resolver-persistence.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EntityResolver } from "../dist/intelligence/entity-resolver.js";
+import { EntityStore } from "../dist/cache/entity-store.js";
+
+describe("EntityResolver persistence", () => {
+  it("remembers an entity to the store and maps its provider id", async () => {
+    const path = join(tmpdir(), `er-${process.pid}.json`);
+    const store = new EntityStore(path);
+    const r = EntityResolver.getInstance();
+    await r.hydrate(store);
+    await r.remember({
+      id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Los Angeles Lakers", aliases: ["Lakers"],
+      providerIds: { espn: "13" }, metadata: {}, confidence: 1,
+      firstSeenAt: new Date().toISOString(), lastVerifiedAt: new Date().toISOString(), mentionCount: 1,
+    });
+    // Fresh store instance sees the persisted row.
+    const store2 = new EntityStore(path);
+    await store2.load();
+    assert.equal(store2.get("Lakers", "team", "nba")?.providerIds.espn, "13");
+  });
+});

--- a/test/entity-resolver-persistence.test.mjs
+++ b/test/entity-resolver-persistence.test.mjs
@@ -23,4 +23,22 @@ describe("EntityResolver persistence", () => {
     await store2.load();
     assert.equal(store2.get("Lakers", "team", "nba")?.providerIds.espn, "13");
   });
+
+  it("hydrates persisted team entities into the in-memory registry", async () => {
+    const path = join(tmpdir(), `er-hydrate-${process.pid}.json`);
+    const seedStore = new EntityStore(path);
+    await seedStore.upsert({
+      id: "nba:team:celtics", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Boston Celtics", aliases: ["Celtics"],
+      providerIds: { espn: "2" }, metadata: {}, confidence: 1,
+      firstSeenAt: new Date().toISOString(), lastVerifiedAt: new Date().toISOString(), mentionCount: 1,
+    });
+
+    const store = new EntityStore(path);
+    const r = EntityResolver.getInstance();
+    await r.hydrate(store);
+
+    assert.equal(r.mapToProviderId("nba", "team", "nba:team:celtics", "espn"), "2");
+    assert.equal(r.resolveTeam("nba", "Celtics"), "nba:team:celtics");
+  });
 });

--- a/test/entity-store.test.mjs
+++ b/test/entity-store.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { writeFile } from "node:fs/promises";
 
 import { EntityStore, entityIsStale } from "../dist/cache/entity-store.js";
 
@@ -51,6 +52,23 @@ describe("EntityStore", () => {
     assert.equal(found?.mentionCount, 2);
     assert.equal(found?.firstSeenAt, firstSeen);
     assert.equal(found?.providerIds.nba, "1610612738");
+  });
+
+  it("survives a malformed cache row and still loads/gets a valid entity", async () => {
+    const filePath = join(tmpdir(), `ec-${process.pid}-${Math.floor(process.hrtime()[1])}-c.json`);
+    const rows = [
+      {
+        id: "nba:team:x", entityType: "team", sport: "nba", league: "NBA",
+        canonicalName: "X", aliases: undefined, providerIds: {}, metadata: {},
+        confidence: 1.0, firstSeenAt: nowISO(), lastVerifiedAt: nowISO(), mentionCount: 1,
+      },
+      "totally bogus row",
+    ];
+    await writeFile(filePath, JSON.stringify(rows), "utf8");
+    const store = new EntityStore(filePath);
+    await store.load();
+    const found = store.get("X", "team", "nba");
+    assert.equal(found?.canonicalName, "X");
   });
 
   it("treats a 2-day-old team entity as fresh (180-day TTL)", () => {

--- a/test/entity-store.test.mjs
+++ b/test/entity-store.test.mjs
@@ -31,6 +31,28 @@ describe("EntityStore", () => {
     assert.equal(entityIsStale(market), true);
   });
 
+  it("preserves firstSeenAt and bumps mentionCount on repeated upsert", async () => {
+    const store = new EntityStore(join(tmpdir(), `ec-${process.pid}-${Math.floor(process.hrtime()[1])}-b.json`));
+    await store.load();
+    const firstSeen = daysAgoISO(5);
+    await store.upsert({
+      id: "nba:team:celtics", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Boston Celtics", aliases: ["Celtics"],
+      providerIds: { espn: "2" }, metadata: {}, confidence: 1.0,
+      firstSeenAt: firstSeen, lastVerifiedAt: firstSeen, mentionCount: 1,
+    });
+    await store.upsert({
+      id: "nba:team:celtics", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Boston Celtics", aliases: ["Celtics"],
+      providerIds: { espn: "2", nba: "1610612738" }, metadata: {}, confidence: 1.0,
+      firstSeenAt: nowISO(), lastVerifiedAt: nowISO(), mentionCount: 1,
+    });
+    const found = store.get("Celtics", "team", "nba");
+    assert.equal(found?.mentionCount, 2);
+    assert.equal(found?.firstSeenAt, firstSeen);
+    assert.equal(found?.providerIds.nba, "1610612738");
+  });
+
   it("treats a 2-day-old team entity as fresh (180-day TTL)", () => {
     const team = {
       id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",

--- a/test/entity-store.test.mjs
+++ b/test/entity-store.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EntityStore, entityIsStale } from "../dist/cache/entity-store.js";
+
+function nowISO() { return new Date().toISOString(); }
+function daysAgoISO(d) { return new Date(Date.now() - d * 86400000).toISOString(); }
+
+describe("EntityStore", () => {
+  it("upserts and gets an entity by alias", async () => {
+    const store = new EntityStore(join(tmpdir(), `ec-${process.pid}-${Math.floor(process.hrtime()[1])}.json`));
+    await store.load();
+    await store.upsert({
+      id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Los Angeles Lakers", aliases: ["Lakers", "LA Lakers"],
+      providerIds: { espn: "13" }, metadata: {}, confidence: 1.0,
+      firstSeenAt: nowISO(), lastVerifiedAt: nowISO(), mentionCount: 1,
+    });
+    const found = store.get("Lakers", "team", "nba");
+    assert.equal(found?.providerIds.espn, "13");
+  });
+
+  it("treats a 2-day-old market entity as stale (1-day TTL)", () => {
+    const market = {
+      id: "kalshi:KX", entityType: "market", sport: null, league: null,
+      canonicalName: "KX", aliases: [], providerIds: {}, metadata: {},
+      confidence: 1.0, firstSeenAt: daysAgoISO(2), lastVerifiedAt: daysAgoISO(2), mentionCount: 1,
+    };
+    assert.equal(entityIsStale(market), true);
+  });
+
+  it("treats a 2-day-old team entity as fresh (180-day TTL)", () => {
+    const team = {
+      id: "nba:team:lakers", entityType: "team", sport: "nba", league: "NBA",
+      canonicalName: "Los Angeles Lakers", aliases: [], providerIds: {}, metadata: {},
+      confidence: 1.0, firstSeenAt: daysAgoISO(2), lastVerifiedAt: daysAgoISO(2), mentionCount: 1,
+    };
+    assert.equal(entityIsStale(team), false);
+  });
+});

--- a/test/failure-classifier.test.mjs
+++ b/test/failure-classifier.test.mjs
@@ -38,6 +38,13 @@ describe("classifyFailure", () => {
   it("accepts an object with a message field", () => {
     const f = classifyFailure({ message: "circuit breaker open" });
     assert.equal(f.category, "provider_error");
-    assert.equal(f.retryable, true);
+    assert.equal(f.retryable, false);
+  });
+
+  it("does not misclassify HTTP-code digits embedded in larger tokens/numbers", () => {
+    const a = classifyFailure("athlete 40123 not found");
+    assert.equal(a.category, "unknown");
+    const b = classifyFailure("market KX401ABC unavailable");
+    assert.equal(b.category, "unknown");
   });
 });

--- a/test/failure-classifier.test.mjs
+++ b/test/failure-classifier.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyFailure } from "../dist/failures/classifier.js";
+
+describe("classifyFailure", () => {
+  it("classifies a rate-limit error as retryable rate_limited", () => {
+    const f = classifyFailure("HTTP 429 Too Many Requests");
+    assert.equal(f.category, "rate_limited");
+    assert.equal(f.retryable, true);
+  });
+
+  it("classifies a storage permission error as non-retryable permission_config", () => {
+    const f = classifyFailure("403 storage.objects.create denied");
+    assert.equal(f.category, "permission_config");
+    assert.equal(f.retryable, false);
+  });
+
+  it("classifies a not-ready fixture error as retryable data_not_ready", () => {
+    const f = classifyFailure("Not enough knockout matches to build a bracket (0).");
+    assert.equal(f.category, "data_not_ready");
+    assert.equal(f.retryable, true);
+  });
+
+  it("classifies a 401 as non-retryable auth_error", () => {
+    const f = classifyFailure("401 Unauthorized");
+    assert.equal(f.category, "auth_error");
+    assert.equal(f.retryable, false);
+  });
+
+  it("always produces a non-empty userMessage and developerMessage", () => {
+    const f = classifyFailure("some totally unknown failure");
+    assert.equal(f.category, "unknown");
+    assert.ok(f.userMessage.length > 0);
+    assert.ok(f.developerMessage.length > 0);
+  });
+
+  it("accepts an object with a message field", () => {
+    const f = classifyFailure({ message: "circuit breaker open" });
+    assert.equal(f.category, "provider_error");
+    assert.equal(f.retryable, true);
+  });
+});

--- a/test/fixtures/maxbuffer-overflow-bridge.sh
+++ b/test/fixtures/maxbuffer-overflow-bridge.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Stand-in for `python3 -m sports_skills ...` that reproduces a real
+# divergence between exec's error.message and the raw stderr stream:
+# it writes a classifiable signal to stderr, then floods stdout past
+# execFile's maxBuffer so Node kills the process and replaces
+# error.message with the generic "stdout maxBuffer length exceeded" —
+# losing the classifying text that only exists in stderr.
+echo "${FLAKY_ERROR:-429 too many requests}" >&2
+yes A | head -c 40000000
+exit 1

--- a/test/router-complexity-integration.test.mjs
+++ b/test/router-complexity-integration.test.mjs
@@ -96,4 +96,50 @@ describe("router complexity integration contract", () => {
       `expected more than the base cap of 2 skills, got: ${result.decision.selectedSkills.join(", ")}`
     );
   });
+
+  it("routePromptToSkills actually attaches seeded market skills to the routed/selected skills for a betting prompt", async () => {
+    const mockModel = makeMockModel();
+    // "bets" (plural) triggers planSkillCaps' betting classification (BETTING_KW
+    // includes "bets"), but inferHelperSkills' regex only matches the exact word
+    // "bet" — not "bets" — so the pre-existing helper inference misses it. The
+    // only path a market skill can reach `selectedSkills` through is the
+    // capPlan.addSkills seeding at router.ts:332 actually being unioned into
+    // helperSkills before the final skill set is built.
+    const result = await routePromptToSkills({
+      prompt: "best lakers bets tonight",
+      installedSkills: ["nba", "betting", "markets", "kalshi", "polymarket"],
+      toolSpecs: [],
+      memoryBlock: "### Fan Profile (FAN_PROFILE.md)\nBig fan of nba.",
+      model: mockModel,
+      modelId: "mock-model",
+      provider: "anthropic",
+      config: baseConfig,
+    });
+
+    const marketSkills = ["betting", "markets", "kalshi", "polymarket"];
+    assert.ok(
+      result.decision.selectedSkills.some((s) => marketSkills.includes(s)),
+      `expected a seeded market skill in selectedSkills, got: ${result.decision.selectedSkills.join(", ")}`
+    );
+  });
+
+  it("a simple query with no betting/news intent does not gain market skills", async () => {
+    const mockModel = makeMockModel();
+    const result = await routePromptToSkills({
+      prompt: "lakers score",
+      installedSkills: ["nba", "betting", "markets", "kalshi", "polymarket"],
+      toolSpecs: [],
+      memoryBlock: "### Fan Profile (FAN_PROFILE.md)\nBig fan of nba.",
+      model: mockModel,
+      modelId: "mock-model",
+      provider: "anthropic",
+      config: baseConfig,
+    });
+
+    const marketSkills = ["betting", "markets", "kalshi", "polymarket"];
+    assert.ok(
+      result.decision.selectedSkills.every((s) => !marketSkills.includes(s)),
+      `expected no market skills for a simple query, got: ${result.decision.selectedSkills.join(", ")}`
+    );
+  });
 });

--- a/test/router-complexity-integration.test.mjs
+++ b/test/router-complexity-integration.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// The planner is the unit under test at the routing boundary; this guards the
+// contract router.ts relies on so a future refactor can't silently narrow it.
+import { planSkillCaps } from "../dist/routing/complexity.js";
+
+describe("router complexity integration contract", () => {
+  it("a betting prompt raises the effective max above the base of 2", () => {
+    const plan = planSkillCaps("best bets for lakers tonight", { routingMaxSkills: 2, routingAllowSpillover: 1 });
+    const effective = Math.max(2, plan.maxSkills);
+    assert.ok(effective >= 3);
+  });
+});

--- a/test/router-complexity-integration.test.mjs
+++ b/test/router-complexity-integration.test.mjs
@@ -4,11 +4,96 @@ import { describe, it } from "node:test";
 // The planner is the unit under test at the routing boundary; this guards the
 // contract router.ts relies on so a future refactor can't silently narrow it.
 import { planSkillCaps } from "../dist/routing/complexity.js";
+import { routePromptToSkills } from "../dist/router.js";
+import { DEFAULT_TOKEN_BUDGETS } from "../dist/types.js";
+
+// MockLanguageModelV3 (shipped by the "ai" SDK for exactly this purpose) lets
+// us drive routePromptToSkills end-to-end with no network call: doGenerate
+// returns non-JSON text, so the LLM attempt fails to parse and the function
+// falls through to its deterministic/memory-fallback code paths.
+import { MockLanguageModelV3 } from "ai/test";
+
+function makeMockModel() {
+  return new MockLanguageModelV3({
+    doGenerate: async () => ({
+      content: [{ type: "text", text: "NOT_JSON" }],
+      finishReason: { unified: "stop", raw: undefined },
+      usage: {
+        inputTokens: { total: 10 },
+        outputTokens: { total: 5 },
+        totalTokens: { total: 15 },
+        reasoningTokens: { total: undefined },
+      },
+      warnings: [],
+    }),
+  });
+}
+
+const baseConfig = {
+  routingMode: "soft_lock",
+  routingMaxSkills: 2,
+  routingAllowSpillover: 1,
+  thinkingBudget: 0,
+  tokenBudgets: DEFAULT_TOKEN_BUDGETS,
+};
 
 describe("router complexity integration contract", () => {
   it("a betting prompt raises the effective max above the base of 2", () => {
     const plan = planSkillCaps("best bets for lakers tonight", { routingMaxSkills: 2, routingAllowSpillover: 1 });
     const effective = Math.max(2, plan.maxSkills);
     assert.ok(effective >= 3);
+  });
+
+  it("routePromptToSkills seeds market skills into the deterministic candidate hint for a betting prompt", async () => {
+    const mockModel = makeMockModel();
+    // Only "nba" is a real sport skill here, so without the capPlan.addSkills
+    // union (router.ts:406-408) the deterministic candidate list would be
+    // just ["nba"] — it can only contain "betting"/"markets" if the seeded
+    // market skills from planSkillCaps are actually merged in.
+    await routePromptToSkills({
+      prompt: "who has the best bet tonight",
+      installedSkills: ["nba", "betting", "markets", "kalshi", "polymarket"],
+      toolSpecs: [],
+      memoryBlock: "### Fan Profile (FAN_PROFILE.md)\nBig fan of nba.",
+      model: mockModel,
+      modelId: "mock-model",
+      provider: "anthropic",
+      config: baseConfig,
+    });
+
+    const call = mockModel.doGenerateCalls[0];
+    const userMessage = call.prompt.find((m) => m.role === "user");
+    const promptText = userMessage.content.map((part) => part.text).join("\n");
+    const candidateLine = promptText.split("\n").find((line) => line.startsWith("Deterministic candidates"));
+
+    assert.ok(candidateLine, "expected a 'Deterministic candidates' line in the router prompt");
+    assert.match(candidateLine, /\b(betting|markets)\b/);
+  });
+
+  it("routePromptToSkills applies the raised effective cap to the skills it actually selects", async () => {
+    const mockModel = makeMockModel();
+    // Four installed sport skills, none named in the prompt, so selection
+    // falls through to the fan-profile memory ranking (router.ts:470) and
+    // then the ambiguous-mode limit (router.ts:494) — both gated on
+    // effectiveMaxSkills. A multi-sport prompt raises planSkillCaps'
+    // maxSkills to 4, well above the base routingMaxSkills of 2.
+    const result = await routePromptToSkills({
+      prompt: "what's happening across sports tonight",
+      installedSkills: ["nba", "nfl", "mlb", "nhl"],
+      toolSpecs: [],
+      memoryBlock: "### Fan Profile (FAN_PROFILE.md)\nI love nba, nfl, mlb, and nhl.",
+      model: mockModel,
+      modelId: "mock-model",
+      provider: "anthropic",
+      config: baseConfig,
+    });
+
+    // With the base cap of 2 this would top out at 2 skills; the wiring
+    // under test raises it to 4 for a multi-sport prompt. A revert of either
+    // effectiveMaxSkills call site back to routingMaxSkills caps this at 2.
+    assert.ok(
+      result.decision.selectedSkills.length > 2,
+      `expected more than the base cap of 2 skills, got: ${result.decision.selectedSkills.join(", ")}`
+    );
   });
 });

--- a/test/routing-complexity.test.mjs
+++ b/test/routing-complexity.test.mjs
@@ -25,4 +25,17 @@ describe("query complexity planning", () => {
   it("classifies an injury/news query as compound", () => {
     assert.equal(classifyQueryComplexity("any injury news for the lakers?"), "compound");
   });
+
+  it("does not misclassify 'about' as the 'out' news keyword", () => {
+    assert.equal(classifyQueryComplexity("let's talk about the lakers"), "simple");
+  });
+
+  it("does not misclassify 'understand' as the 'under' betting keyword", () => {
+    const plan = planSkillCaps("help me understand the nba season", base);
+    assert.ok(!plan.addSkills.some((s) => ["betting", "markets", "kalshi", "polymarket"].includes(s)));
+  });
+
+  it("still classifies a real standalone 'out' as compound", () => {
+    assert.equal(classifyQueryComplexity("who is out injured"), "compound");
+  });
 });

--- a/test/routing-complexity.test.mjs
+++ b/test/routing-complexity.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyQueryComplexity, planSkillCaps } from "../dist/routing/complexity.js";
+
+const base = { routingMaxSkills: 2, routingAllowSpillover: 1 };
+
+describe("query complexity planning", () => {
+  it("keeps a simple score query at <= 2 skills", () => {
+    const plan = planSkillCaps("lakers score", base);
+    assert.ok(plan.maxSkills <= 2);
+  });
+
+  it("expands a betting query to >= 3 skills with a market skill", () => {
+    const plan = planSkillCaps("best Lakers bets tonight", base);
+    assert.ok(plan.maxSkills >= 3);
+    assert.ok(plan.addSkills.some((s) => ["betting", "markets", "kalshi", "polymarket"].includes(s)));
+  });
+
+  it("expands a multi-sport query to >= 4 skills", () => {
+    const plan = planSkillCaps("what's happening tonight across sports", base);
+    assert.ok(plan.maxSkills >= 4);
+  });
+
+  it("classifies an injury/news query as compound", () => {
+    assert.equal(classifyQueryComplexity("any injury news for the lakers?"), "compound");
+  });
+});

--- a/test/safe-executor.test.mjs
+++ b/test/safe-executor.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { executeToolSafely } from "../dist/tools/executor.js";
+
+describe("executeToolSafely", () => {
+  it("returns ok with data on success and reports normalized args", async () => {
+    const res = await executeToolSafely(
+      "nba_get_standings",
+      { season: "2026" }, // bare year → sanitizeToolInput normalizes to espn.nba.2026
+      async (_n, a) => ({ content: JSON.stringify({ season: a.season }) }),
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.normalized, true);
+    assert.ok(String(res.data).includes("espn.nba.2026"));
+  });
+
+  it("classifies a failing run into a structured failure", async () => {
+    const res = await executeToolSafely(
+      "kalshi_get_exchange_status",
+      {},
+      async () => ({ content: "429 too many requests", isError: true }),
+    );
+    assert.equal(res.ok, false);
+    assert.equal(res.failure?.category, "rate_limited");
+    assert.equal(res.failure?.retryable, true);
+  });
+});

--- a/test/safe-executor.test.mjs
+++ b/test/safe-executor.test.mjs
@@ -50,4 +50,14 @@ describe("executeToolSafely", () => {
     assert.ok(res.failure);
     assert.equal(typeof res.failure.category, "string");
   });
+
+  it("does not throw on non-cloneable args and returns a classified failure", async () => {
+    const res = await executeToolSafely(
+      "weird_tool",
+      { fn: () => {} },
+      async (_n, a) => ({ content: JSON.stringify(a) }),
+    );
+    assert.equal(res.ok, false);
+    assert.ok(res.failure);
+  });
 });

--- a/test/safe-executor.test.mjs
+++ b/test/safe-executor.test.mjs
@@ -25,4 +25,29 @@ describe("executeToolSafely", () => {
     assert.equal(res.failure?.category, "rate_limited");
     assert.equal(res.failure?.retryable, true);
   });
+
+  it("does not mutate caller's original args (deep copy isolation)", async () => {
+    const original = { sport: "nba", args: { season: "2026" } };
+    const res = await executeToolSafely(
+      "sports_query",
+      original,
+      async (_n, a) => ({ content: JSON.stringify(a) }),
+    );
+    // Verify the caller's original is NOT mutated
+    assert.equal(original.args.season, "2026");
+    // Verify the copy WAS normalized
+    assert.equal(res.normalized, true);
+    assert.ok(String(res.data).includes("espn.nba.2026"));
+  });
+
+  it("catches thrown exceptions and classifies them", async () => {
+    const res = await executeToolSafely(
+      "weather_get_forecast",
+      { location: "NYC" },
+      async () => { throw new Error("boom network fail"); },
+    );
+    assert.equal(res.ok, false);
+    assert.ok(res.failure);
+    assert.equal(typeof res.failure.category, "string");
+  });
 });

--- a/test/selftest-runner.test.mjs
+++ b/test/selftest-runner.test.mjs
@@ -46,6 +46,17 @@ describe("runSelftest", () => {
     assert.equal(report.results.every((r) => r.status === "fail"), true);
   });
 
+  it("marks an executor-signaled skip as skip, not pass", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: true,
+      execute: async () => ({ ok: true, skip: true, latencyMs: 0, note: "skipped (quick)" }),
+    });
+    assert.equal(report.passed, 0);
+    assert.equal(report.skipped >= 1, true);
+    assert.equal(report.results.every((r) => r.status === "skip"), true);
+  });
+
   it("renders a markdown table with a header row", () => {
     const md = renderMarkdown({
       version: "0.29.1", passed: 1, failed: 0, skipped: 0,

--- a/test/selftest-runner.test.mjs
+++ b/test/selftest-runner.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { runSelftest } from "../dist/selftest/runner.js";
+import { renderMarkdown } from "../dist/selftest/report.js";
+
+describe("runSelftest", () => {
+  it("returns one result per case for the requested sport (offline)", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: false,
+      execute: async () => ({ ok: true, latencyMs: 1, note: "stub" }),
+    });
+    assert.ok(report.results.length >= 1);
+    assert.equal(report.results[0].sport, "metadata");
+    assert.equal(report.failed, 0);
+  });
+
+  it("produces a JSON-serializable report", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: false,
+      execute: async () => ({ ok: true, latencyMs: 1 }),
+    });
+    const json = JSON.stringify(report.toJSON());
+    assert.ok(json.includes("passed"));
+  });
+
+  it("marks a failing case as fail with a note", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: true,
+      execute: async () => ({ ok: false, latencyMs: 2, note: "401 auth" }),
+    });
+    assert.equal(report.failed >= 1, true);
+    assert.equal(report.results.some((r) => r.status === "fail"), true);
+  });
+
+  it("renders a markdown table with a header row", () => {
+    const md = renderMarkdown({
+      version: "0.29.1", passed: 1, failed: 0, skipped: 0,
+      results: [{ sport: "nba", check: "scoreboard", status: "pass", latencyMs: 431, notes: "6 games" }],
+      toJSON() { return {}; },
+    });
+    assert.ok(md.includes("Sport"));
+    assert.ok(md.includes("nba"));
+  });
+});

--- a/test/selftest-runner.test.mjs
+++ b/test/selftest-runner.test.mjs
@@ -36,6 +36,16 @@ describe("runSelftest", () => {
     assert.equal(report.results.some((r) => r.status === "fail"), true);
   });
 
+  it("marks a throwing execute case as fail and continues without rejecting", async () => {
+    const report = await runSelftest({
+      sports: ["metadata"],
+      live: true,
+      execute: async () => { throw new Error("boom"); },
+    });
+    assert.equal(report.results.length >= 1, true);
+    assert.equal(report.results.every((r) => r.status === "fail"), true);
+  });
+
   it("renders a markdown table with a header row", () => {
     const md = renderMarkdown({
       version: "0.29.1", passed: 1, failed: 0, skipped: 0,

--- a/test/tool-execution-log.test.mjs
+++ b/test/tool-execution-log.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { redactArgs, buildToolExecutionEvent } from "../dist/analytics.js";
+import { redactArgs, buildToolExecutionEvent, logToolExecution } from "../dist/analytics.js";
 
 describe("tool_execution logging", () => {
   it("redacts credential-like keys and never leaks their values", () => {
@@ -40,5 +43,32 @@ describe("tool_execution logging", () => {
     assert.equal(event.event, "tool_execution");
     assert.equal(event.failure_category, "user_input");
     assert.ok(String(event.args_hash).startsWith("sha256:"));
+  });
+
+  it("logToolExecution appends a single redacted JSON line to disk", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sportsclaw-tool-exec-"));
+    const logPath = join(dir, "tool_executions.jsonl");
+    try {
+      logToolExecution({
+        ok: true,
+        toolName: "nfl_scores",
+        args: { api_key: "secret", team: "Lakers" },
+        warnings: [],
+        normalized: false,
+        latencyMs: 42,
+      }, logPath);
+
+      const raw = readFileSync(logPath, "utf-8");
+      const lines = raw.trim().split("\n");
+      assert.equal(lines.length, 1);
+
+      const parsed = JSON.parse(lines[0]);
+      assert.equal(parsed.event, "tool_execution");
+      assert.equal(parsed.tool_name, "nfl_scores");
+      assert.ok(String(parsed.args_hash).startsWith("sha256:"));
+      assert.ok(!raw.includes("secret"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/tool-execution-log.test.mjs
+++ b/test/tool-execution-log.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { redactArgs, buildToolExecutionEvent } from "../dist/analytics.js";
+
+describe("tool_execution logging", () => {
+  it("redacts credential-like keys and never leaks their values", () => {
+    const out = redactArgs({ api_key: "secret", token: "abc", team: "Lakers" });
+    const json = JSON.stringify(out);
+    assert.ok(!json.includes("secret"));
+    assert.ok(!json.includes("abc"));
+    assert.ok(json.includes("Lakers"));
+    assert.ok(!("api_key" in out));
+  });
+
+  it("builds an event with a hashed args field and no raw secrets", () => {
+    const event = buildToolExecutionEvent({
+      ok: false, toolName: "worldcup-get-market-state",
+      args: { api_key: "secret", market_id: "kalshi:KX" },
+      warnings: [], normalized: false, latencyMs: 122,
+      failure: { category: "user_input", severity: "medium", retryable: false, userMessage: "x", developerMessage: "y" },
+    }, "2026-07-07T00:00:00Z");
+    const json = JSON.stringify(event);
+    assert.ok(!json.includes("secret"));
+    assert.equal(event.event, "tool_execution");
+    assert.equal(event.failure_category, "user_input");
+    assert.ok(String(event.args_hash).startsWith("sha256:"));
+  });
+});

--- a/test/tool-execution-log.test.mjs
+++ b/test/tool-execution-log.test.mjs
@@ -13,6 +13,21 @@ describe("tool_execution logging", () => {
     assert.ok(!("api_key" in out));
   });
 
+  it("recursively redacts credential-like keys nested in objects", () => {
+    const out = redactArgs({ config: { api_key: "secret", region: "us" }, team: "Lakers" });
+    assert.ok(!("api_key" in out.config));
+    assert.equal(out.config.region, "us");
+    assert.equal(out.team, "Lakers");
+    assert.ok(!JSON.stringify(out).includes("secret"));
+  });
+
+  it("recursively redacts credential-like keys nested in arrays", () => {
+    const out = redactArgs({ items: [{ token: "t1", name: "a" }] });
+    assert.ok(!("token" in out.items[0]));
+    assert.equal(out.items[0].name, "a");
+    assert.ok(!JSON.stringify(out).includes("t1"));
+  });
+
   it("builds an event with a hashed args field and no raw secrets", () => {
     const event = buildToolExecutionEvent({
       ok: false, toolName: "worldcup-get-market-state",

--- a/test/tool-failure-classification.test.mjs
+++ b/test/tool-failure-classification.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyFailure } from "../dist/failures/classifier.js";
+
+// Behavioral contract used by ToolRegistry.execute's failure branch:
+// a raw provider error is turned into a clean, actionable user message.
+describe("tool failure classification contract", () => {
+  it("produces an actionable message for a rate limit", () => {
+    const f = classifyFailure("429 too many requests", "nba_get_scoreboard");
+    assert.equal(f.category, "rate_limited");
+    assert.ok(/retry/i.test(f.userMessage));
+    assert.ok(f.developerMessage.includes("nba_get_scoreboard"));
+  });
+});

--- a/test/tool-failure-wiring.test.mjs
+++ b/test/tool-failure-wiring.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * ToolRegistry.dispatchToolCall — real wired-branch coverage for the
+ * classifyFailure integration in handleDynamicTool's general failure path.
+ *
+ * Uses test/fixtures/maxbuffer-overflow-bridge.sh as a stand-in for the
+ * Python interpreter. The fixture writes a classifiable signal to stderr,
+ * then floods stdout past execFile's hardcoded 25MB maxBuffer so Node
+ * replaces `error.message` with the generic "stdout maxBuffer length
+ * exceeded" — a real-world case where the classifying text only survives
+ * in `stderr`, not in `error`. This reproduces the exact divergence the
+ * error_code/hint mismatch fix addresses.
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ToolRegistry, bridgeBreaker } from "../dist/tools.js";
+
+const FIXTURE = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "maxbuffer-overflow-bridge.sh");
+
+describe("dispatchToolCall — wired classifyFailure branch", () => {
+  beforeEach(() => {
+    chmodSync(FIXTURE, 0o755);
+    bridgeBreaker.reset();
+  });
+
+  afterEach(() => {
+    bridgeBreaker.reset();
+  });
+
+  it("classifies the failure using both error and stderr, not error alone", async () => {
+    const registry = new ToolRegistry();
+    registry.injectSchema({
+      sport: "nfl",
+      version: "1",
+      tools: [{ name: "nfl_scores", command: "scores", description: "test tool", parameters: {} }],
+    });
+
+    const result = await registry.dispatchToolCall("nfl_scores", {}, {
+      pythonPath: FIXTURE,
+      timeout: 15_000,
+      env: { FLAKY_ERROR: "permission denied while reaching upstream" },
+    });
+
+    assert.equal(result.isError, true);
+    const parsed = JSON.parse(result.content);
+
+    // The classifying text ("permission denied") only exists in stderr —
+    // execFile's error.message is the generic maxBuffer message. A hint
+    // derived from `error` alone would fall back to the generic
+    // "command executed but returned a failure exit code" message.
+    assert.equal(parsed.error, "stdout maxBuffer length exceeded");
+    assert.match(parsed.stderr, /permission denied/);
+    assert.match(
+      parsed.hint,
+      /permission|storage/i,
+      `hint should reflect the stderr-only signal, got: ${parsed.hint}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Tool calls now fail *legibly* instead of surfacing raw provider text. Every tool/workflow error is classified into a structured category (rate-limit, auth, permission, data-not-ready, user-input, …) that carries a clean user message — *what failed, why, whether retrying helps, what to do next* — the engine can self-diagnose across all installed sport schemas (`sportsclaw selftest`, plus a `run_selftest` agent tool), complexity-aware routing attaches the right skills to compound/betting/multi-sport queries, and every real tool call now emits a credential-redacted `tool_execution` telemetry event.

This is deliberately the **generic, non-proprietary half** of the reliability upgrade. The kalshi/polymarket market-ID normalization that triggered this work is intentionally absent from the client (it's MIT and ships to npm) — that fix belongs server-side in the hosted `worldcup-get-market-state` MCP workflow and is tracked separately.

## What's live vs. staged

| Capability | Module | Status |
|---|---|---|
| Failure classification + clean user messages | `src/failures/*` → wired in `tools.ts` + `sports_query` | **Live** |
| `sportsclaw selftest` CLI + `run_selftest` agent tool | `src/selftest/*` → `cmdSelftest` + `engine.buildTools()` | **Live** |
| Complexity-aware routing (caps + attached skills) | `src/routing/complexity.ts` → `router.ts` | **Live** |
| `tool_execution` log + recursive credential redaction | `src/analytics.ts` → `tools.ts` dispatch | **Live** |
| Entity cache read-path (`hydrate` + JSON store + TTL) | `src/cache/entity-store.ts` + resolver `hydrate` | **Partial** — read-path correct; not yet hydrated at startup, no `remember` write-path |
| `executeToolSafely` wrapper | `src/tools/executor.ts` | **Staged** — the seam future call sites migrate onto |

## Design decisions

- **Compose, don't fork.** The classifier layers on the existing `classifyBridgeError`; routing extends `router.ts`'s existing config; the entity store sits *behind* the existing in-memory `EntityResolver`.
- **Market-ID normalization stays out of the MIT client.** Reviewer-verified: no kalshi/polymarket-specific logic in `src/`.
- **Word-boundary matching** in the router and the classifier — bare substrings mis-fired ("ab**out**" → news, "**401**" inside an ID → auth); now `\b`-anchored.
- **Complexity-seeded skills attach via the helper tier**, so betting/multi-sport queries reliably surface the intended skills on every branch (not just the LLM hint).
- **Deep-copy + recursive redaction.** `executeToolSafely` deep-clones before sanitize (never mutates the caller); redaction strips credential keys at any depth; the telemetry event carries only a `sha256:` hash of already-redacted args and no raw error text.

## Review + follow-through

An independent multi-agent review (9 personas) ran against this branch. Verified fixes were applied here, and the actionable follow-ups it surfaced have since been implemented:
- **Applied fixes:** classifier HTTP-code word boundaries + non-retryable `circuit_open`; `executeToolSafely` clone inside try/catch; `EntityStore` row validation so one bad row can't poison lookups; `selftest` per-case error isolation; **router seeding now attaches complexity-seeded skills to the routed set**.
- **Follow-ups completed on this branch:** `run_selftest` agent tool (with per-prompt whitelist wiring); `cmdSelftest` skip-count + double-classify cleanups; `sports_query` rolled onto `classifyFailure`; recursive `redactArgs`; `hydrate()` now populates the in-memory registry; `tool_execution` logging wired live.

## Remaining follow-ups (out of scope here)

- **Entity loop wiring:** hydrate the resolver at engine startup and add a `remember` write-path that persists externally-resolved IDs — deferred until the real `*_search_player`/`*_search_team` result shapes are sampled (per the machina-data-shapes rule) rather than guessed.
- **`executeToolSafely` seam migration:** route the shared `dispatchToolCall` path through the wrapper to unify classification — deferred as the highest-risk change to a core path.
- **Gated:** server-side `worldcup-get-market-state` normalization (the actual World Cup market-state fix) — separate repo, needs explicit go-ahead.

## Test plan

All new + affected suites green (76/76 across the reliability suites + regressions), build clean. Router integration verified end-to-end with `MockLanguageModelV3`; a real subprocess fixture reproduces the `stderr`-only failure divergence for the classifier wiring; `tool_execution` redaction verified against a real on-disk write.

Spec and plan committed under `docs/superpowers/`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
