### PR TITLE
fix(operator): foreground daemon stops ticking without an MCP connection

### DIFF
--- a/src/operate.ts
+++ b/src/operate.ts
@@ -685,6 +685,7 @@ async function runOnce(jobId: string): Promise<void> {
       maxSteps: cfg.maxSteps,
       guardOptions: cfg.guardOptions,
       enableMemoryTools: cfg.enableMemoryTools,
+      persistence: cfg.persistence,
       inferenceRoute: inputs.inferenceRoute,
       broadcastSafety: cfg.broadcastSafety,
       mcpManager: tools.mcpManager,
@@ -767,6 +768,7 @@ async function runForeground(jobId: string): Promise<void> {
     maxSteps: cfg.maxSteps,
     guardOptions: cfg.guardOptions,
     enableMemoryTools: cfg.enableMemoryTools,
+    persistence: cfg.persistence,
     inferenceRoute: inputs.inferenceRoute,
     broadcastSafety: cfg.broadcastSafety,
     mcpManager: tools.mcpManager,
@@ -813,8 +815,21 @@ async function runForeground(jobId: string): Promise<void> {
     `[operate] job=${cfg.jobId} interval=${cfg.intervalMs}ms provider=${inputs.provider} model=${inputs.modelId}${inferenceTag}`,
   );
   daemon.start();
-  // Keep the process alive without unref'd heartbeat timers exiting early.
-  await new Promise<void>(() => {});
+  // Keep the event loop alive with a REF'd handle so the (unref'd) heartbeat +
+  // cron timers keep firing. A bare pending promise does not hold libuv open;
+  // without any ref'd handle, a daemon that connects no MCP servers (e.g. a
+  // single-purpose operator like the Athlete Vault) goes idle after the first
+  // tick's inference settles and the unref'd recurring cron stops advancing —
+  // the daemon "fires once, then silently never ticks again". A daemon that
+  // happens to hold ref'd handles (MCP stdio/SSE sockets, like the broadcast
+  // operator) masks the bug. This ref'd keep-alive makes foreground `operate`
+  // tick reliably regardless of whether any MCP server is connected.
+  const keepAlive = setInterval(() => {}, 1 << 30); // ref'd; ~12.4 days, no-op
+  try {
+    await new Promise<void>(() => {});
+  } finally {
+    clearInterval(keepAlive);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/operator-config.ts
+++ b/src/operator-config.ts
@@ -122,6 +122,18 @@ export interface OperatorJobConfig {
    */
   enableMemoryTools?: boolean;
   /**
+   * Enable heartbeat state persistence + the cross-process per-job tick lock.
+   * The lock exists to coordinate MULTIPLE daemon replicas of the same job so
+   * they don't double-fire a tick. A single-replica operator (the common case,
+   * e.g. one daemon in a sandbox) does not need it, and the lockfile lives on
+   * whatever `stateDir` resolves to — on a restricted/overlay filesystem a
+   * lock that fails to release cleanly stalls every subsequent tick (fires
+   * once, then silently ELOCKED-skips). Set `false` to run the heartbeat fully
+   * in-memory (overlapping ticks are still guarded by an in-process flag).
+   * Default: true (unchanged behaviour for existing single/multi-replica jobs).
+   */
+  persistence?: boolean;
+  /**
    * Opt in to routing LLM calls through NVIDIA OpenShell's Privacy Router.
    * Absent block = default direct LLM calls; nothing changes. When present
    * and enabled, the launcher constructs the AI SDK provider with a
@@ -412,6 +424,11 @@ export function validateOperatorJobConfig(
     push("enableMemoryTools", "must be a boolean");
   }
 
+  // persistence
+  if (raw.persistence !== undefined && typeof raw.persistence !== "boolean") {
+    push("persistence", "must be a boolean");
+  }
+
   // openshell — optional opt-in routing block
   let parsedOpenShell: OpenShellConfig | undefined;
   if (raw.openshell !== undefined) {
@@ -547,6 +564,7 @@ export function validateOperatorJobConfig(
       guardOptions: raw.guardOptions as Record<string, unknown> | undefined,
       sinkRole: raw.sinkRole as string | undefined,
       enableMemoryTools: raw.enableMemoryTools as boolean | undefined,
+      persistence: raw.persistence as boolean | undefined,
       openshell: parsedOpenShell,
       inference: raw.inference as ModelRoleRouterConfig | undefined,
       broadcastSafety: raw.broadcastSafety as OperatorJobConfig["broadcastSafety"],

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -212,6 +212,14 @@ export interface OperatorDaemonConfig {
   briefDir?: string;
   /** State + lock dir for heartbeat persistence. Default `<rootDir>`. */
   stateDir?: string;
+  /**
+   * Enable heartbeat persistence + the cross-process per-job tick lock (for
+   * coordinating multiple replicas of the same job). Set `false` for a
+   * single-replica daemon to run the heartbeat in-memory and avoid the
+   * lockfile — which, on a restricted/overlay filesystem, can fail to release
+   * and stall every tick after the first. Default: true (unchanged).
+   */
+  persistence?: boolean;
 
   /** Optional wake gate. Forwarded to heartbeat unchanged. */
   wakeGate?: WakeGateFn;
@@ -366,8 +374,17 @@ export function createOperatorDaemon(
   const tickPromptTemplate = cfg.tickPrompt ?? DEFAULT_TICK_PROMPT;
   const generateImpl = cfg.generateTextImpl ?? generateText;
 
-  const heartbeat = cfg.heartbeat ?? new HeartbeatService();
-  if (!heartbeat.hasPersistence) {
+  const heartbeat =
+    cfg.heartbeat ??
+    new HeartbeatService({
+      verbose: process.env.SPORTSCLAW_HEARTBEAT_VERBOSE === "1",
+    });
+  // Persistence (+ the cross-process per-job tick lock) is opt-out. It exists
+  // to coordinate multiple replicas of one job; a single-replica daemon does
+  // not need it, and the lockfile on a restricted/overlay filesystem can fail
+  // to release and stall every tick after the first. `persistence: false`
+  // keeps the heartbeat in-memory (overlapping ticks still guarded in-process).
+  if (cfg.persistence !== false && !heartbeat.hasPersistence) {
     heartbeat.configurePersistence({ stateDir });
   }
 

--- a/test/operator-config.test.mjs
+++ b/test/operator-config.test.mjs
@@ -299,6 +299,22 @@ describe("validateOperatorJobConfig — optional fields", () => {
     }
   });
 
+  it("accepts persistence as boolean (true and false)", () => {
+    for (const v of [true, false]) {
+      const r = validateOperatorJobConfig({ ...base, persistence: v });
+      assert.strictEqual(r.valid, true, `persistence=${v}`);
+      assert.strictEqual(r.config.persistence, v);
+    }
+  });
+
+  it("rejects a non-boolean persistence", () => {
+    for (const bad of ["false", 1, 0, null, [], {}]) {
+      const r = validateOperatorJobConfig({ ...base, persistence: bad });
+      assert.strictEqual(r.valid, false, `persistence=${JSON.stringify(bad)}`);
+      assert.ok(r.issues.find((i) => i.field === "persistence"));
+    }
+  });
+
   it("accepts known sink values (noop, broadcast)", () => {
     for (const s of ["noop", "broadcast"]) {
       const r = validateOperatorJobConfig({ ...base, sink: s });

--- a/test/operator-daemon.test.mjs
+++ b/test/operator-daemon.test.mjs
@@ -77,6 +77,30 @@ function baseConfig(overrides = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// persistence opt-out (single-replica mode)
+// ---------------------------------------------------------------------------
+
+describe("persistence opt-out", () => {
+  it("default configures heartbeat persistence (+ per-job lock)", () => {
+    const daemon = createOperatorDaemon(baseConfig());
+    assert.strictEqual(daemon.heartbeat.hasPersistence, true);
+  });
+
+  it("persistence:false runs the heartbeat in-memory (no lock path)", () => {
+    const daemon = createOperatorDaemon(baseConfig({ persistence: false }));
+    assert.strictEqual(daemon.heartbeat.hasPersistence, false);
+  });
+
+  it("persistence:false still ticks (no lock to stall on)", async () => {
+    const daemon = createOperatorDaemon(baseConfig({ persistence: false }));
+    const first = await daemon.tickOnce();
+    const second = await daemon.tickOnce();
+    assert.strictEqual(first.type, "tick_published");
+    assert.strictEqual(second.type, "tick_published");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // tickOnce — published path
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

A foreground `operate` daemon **fires exactly one tick, then silently never ticks again** when it connects **no MCP servers**.

The recurring tick is scheduled with an **unref'd** `setInterval` (`heartbeat.ts` `startCronTimer`), and `runForeground` keeps the process up with a bare `await new Promise(() => {})`. A pending promise does **not** hold libuv open — so once the first tick's inference settles and its socket closes, a daemon with no other **ref'd** handle has nothing keeping the event loop active, and the unref'd cron timer stops advancing.

- The **broadcast/TV operator masks this** because its MCP stdio/SSE sockets are ref'd handles that keep the loop alive → it ticks 24/7.
- A **lean single-purpose operator** (e.g. the Athlete Vault decision-support daemon, which takes its inputs in the tick payload and connects no MCP pod) hits it every time.

The failure is **silent** — no error, no log — because the heartbeat's skip/lock diagnostics are `verbose`-gated and `verbose` was never wired to anything.

## Fix

1. **`operate` foreground: add a ref'd keep-alive** so the event loop stays active regardless of whether any MCP server is connected. This is the core fix.
2. **`SPORTSCLAW_HEARTBEAT_VERBOSE=1`** now enables `HeartbeatService` verbose logging (cron fired / skipped / lock contention) — turns a silent stall into a diagnosable event.
3. **`persistence` job-config option (default `true`)** — lets a single-replica daemon skip the cross-process per-job lockfile. That lock exists only to coordinate *multiple replicas* of one job (#37); a single replica doesn't need it, and the lockfile is an extra failure surface on a restricted/overlay sandbox filesystem.

## Verification

- Full suite: **850 tests passing** (`node --test test/*.test.mjs`), incl. +5 new (persistence opt-out + config validation).
- **Live on an 8×RTX-PRO-6000 box under OpenShell:** before, the vault operator polled once and stopped; after, it ticks continuously (**4 cron fires in 70s**, was stuck at 1) and drives a full decision-support turn end-to-end: `gate ✓ → nemotron analyst ✓ → skeptic evaluator ✓ → verified`, all on-box.

## Compatibility

Fully backward-compatible. `persistence` defaults to `true` (unchanged); the keep-alive and verbose env are additive. Existing operators (broadcast/TV) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)