### PR TITLE
fix(operator): serialize ticks, await hooks and drain safely (PR1)

### DIFF
--- a/src/operate.ts
+++ b/src/operate.ts
@@ -707,13 +707,12 @@ async function runOnce(jobId: string): Promise<void> {
     });
     const event = await daemon.tickOnce();
     console.log(JSON.stringify(event, null, 2));
-    // Drain: onTickEvent / onToolCall handlers may have fire-and-forget POSTs
-    // (e.g. broadcast sink's tail-server). Give them a short window to flush
-    // before process.exit kills any pending fetches.
-    if (sink.onTickEvent || sink.onToolCall) {
-      await new Promise<void>((resolve) => setTimeout(resolve, 1500));
-    }
-    process.exit(exitCodeFor(event));
+    // onTickEvent is awaited inside the tick now, so the sink has finished
+    // delivering by the time tickOnce() resolves — no fixed 1.5s flush needed.
+    // Drain any queued work, set the exit code, and let the finally disconnect
+    // MCP so the process exits cleanly when the loop empties (no abrupt exit).
+    await daemon.drain();
+    process.exitCode = exitCodeFor(event);
   } finally {
     await tools.mcpManager.disconnectAll().catch(() => {});
   }
@@ -793,13 +792,14 @@ async function runForeground(jobId: string): Promise<void> {
   const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
-    console.error(`[operate] received ${signal}, shutting down`);
-    daemon.stop();
-    // Best-effort final brief so the next start sees an explicit handoff.
+    console.error(`[operate] received ${signal}, draining`);
+    // Graceful drain: stop admitting ticks and wait for the active one to finish
+    // (incl. awaited sink delivery). No handoff tickOnce() — that would start a
+    // NEW inference at shutdown and could overlap the in-flight tick.
     try {
-      await daemon.tickOnce();
+      await daemon.drain();
     } catch {
-      // Don't block exit on a final-brief failure.
+      // Don't block exit on a drain failure.
     }
     await tools.mcpManager.disconnectAll().catch(() => {});
     process.exit(0);

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -300,8 +300,14 @@ export interface OperatorDaemon {
   readonly cronJob: CronJob | null;
   /** Start scheduling. Idempotent. */
   start(): void;
-  /** Stop scheduling and clear timers. */
+  /** Stop scheduling and clear timers (synchronous; does not await in-flight work). */
   stop(): void;
+  /**
+   * Graceful async shutdown: stop admitting new ticks, then await the active +
+   * queued tick(s) to finish (including awaited sink delivery). Starts no new
+   * inference. Prefer this over stop() on SIGINT/SIGTERM and after --once.
+   */
+  drain(): Promise<void>;
   /**
    * Run a single tick body synchronously, bypassing heartbeat scheduling.
    * Intended for tests and `sportsclaw operate --once` style commands.
@@ -393,18 +399,45 @@ export function createOperatorDaemon(
 
   let cronJob: CronJob | null = null;
   let started = false;
+  let draining = false;
+  let pending = 0; // ticks queued or executing (in-process single-flight counter)
+  let runChain: Promise<unknown> = Promise.resolve();
+
+  // Bounded, awaited hook invocation — a sink hook must never crash the tick nor
+  // leak an unhandled rejection. Awaiting it means the tick isn't "done" until
+  // the sink has handled the event (e.g. delivered the answer), so single-flight
+  // covers delivery, not just inference.
+  async function awaitHook<T>(name: string, fn: ((e: T) => unknown) | undefined, event: T): Promise<void> {
+    if (!fn) return;
+    try {
+      await fn(event);
+    } catch (err) {
+      console.error(`[operator-daemon] ${name} hook failed for ${jobId}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  // Full-tick single-flight: cron + manual ticks serialize through one chain, so
+  // only ONE tick (inference + tools + awaited hooks + ledger + delivery) runs at
+  // a time. Manual ticks (tickOnce) always enqueue FIFO; cron fires SKIP when a
+  // tick is already pending (no timer debt) — see onEvent.
+  function enqueueTick(tickId: string): Promise<TickEvent> {
+    pending++;
+    const p = runChain.then(() => runTick(tickId));
+    runChain = p.then(() => {}, () => {}).finally(() => { pending--; });
+    return p;
+  }
 
   // ---- core tick body ---------------------------------------------------
 
   async function runTick(tickId: string): Promise<TickEvent> {
     const timestamp = new Date().toISOString();
-    cfg.onTickEvent?.({
+    await awaitHook("onTickEvent", cfg.onTickEvent, {
       type: "tick_started",
       jobId,
       tickId,
       timestamp,
       inferenceRoute: cfg.inferenceRoute,
-    });
+    } as TickEvent);
 
     // 1. Frozen memory snapshot for this tick.
     await memory.load();
@@ -441,7 +474,10 @@ export function createOperatorDaemon(
     const guard = new ToolGuardController(cfg.guardOptions);
     const counts = { calls: 0, warnings: 0, blocks: 0 };
     const toolCallSink = (event: ToolCallEvent): void => {
-      try { cfg.onToolCall?.(event); } catch { /* swallow */ }
+      // Bounded + caught so a slow/throwing sink can't crash tool execution or
+      // leak an unhandled rejection. Not awaited here (would serialize tool
+      // execution behind telemetry); the tick's onTickEvent is the awaited seam.
+      void awaitHook("onToolCall", cfg.onToolCall, event);
     };
     // Daemon-owned tools: memory writeback (add/replace/remove_lesson)
     // tied to THIS tick's live EditorialMemory instance. Writes hit disk
@@ -883,7 +919,7 @@ export function createOperatorDaemon(
         // safetyValidation carries the original output and validator error.
         ...(safetyValidation !== undefined ? { safetyValidation } : {}),
       };
-      cfg.onTickEvent?.(event);
+      await awaitHook("onTickEvent", cfg.onTickEvent, event);
       const ledgerSync = await recordLedger(failureReason).catch(() => undefined);
       if (ledgerSync) event.ledgerSync = ledgerSync;
       return event;
@@ -922,7 +958,7 @@ export function createOperatorDaemon(
       inferenceRoute: cfg.inferenceRoute,
       ...(safetyValidation !== undefined ? { safetyValidation } : {}),
     };
-    cfg.onTickEvent?.(event);
+    await awaitHook("onTickEvent", cfg.onTickEvent, event);
     const ledgerSync = await recordLedger(undefined, silent).catch(() => undefined);
     if (ledgerSync) event.ledgerSync = ledgerSync;
     return event;
@@ -931,30 +967,42 @@ export function createOperatorDaemon(
   // ---- heartbeat event routing -----------------------------------------
 
   const onEvent = (event: HeartbeatEvent): void => {
-    cfg.onHeartbeatEvent?.(event);
+    // Heartbeat dispatch is synchronous; bound the hook so it can't leak an
+    // unhandled rejection, but don't block the heartbeat on it.
+    void awaitHook("onHeartbeatEvent", cfg.onHeartbeatEvent, event);
     if (event.cronJobId !== jobId) return;
 
     if (event.type === "cron_skipped") {
       const tickId = newTickId();
-      const skip: TickEvent = {
+      void awaitHook("onTickEvent", cfg.onTickEvent, {
         type: "tick_skipped",
         jobId,
         tickId,
         reason: event.result ?? "wake gate denied",
         timestamp: event.timestamp,
         inferenceRoute: cfg.inferenceRoute,
-      };
-      cfg.onTickEvent?.(skip);
+      } as TickEvent);
       return;
     }
 
     if (event.type === "cron_fired") {
-      const tickId = newTickId();
-      runTick(tickId).catch((err) => {
+      if (draining) return; // stop admission during shutdown
+      if (pending > 0) {
+        // A tick is still running — SKIP this fire (no timer debt / no overlap).
+        const tickId = newTickId();
+        void awaitHook("onTickEvent", cfg.onTickEvent, {
+          type: "tick_skipped",
+          jobId,
+          tickId,
+          reason: "previous tick still running",
+          timestamp: event.timestamp,
+          inferenceRoute: cfg.inferenceRoute,
+        } as TickEvent);
+        return;
+      }
+      enqueueTick(newTickId()).catch((err) => {
         console.error(
-          `[operator-daemon] tick crashed for ${jobId}: ${
-            err instanceof Error ? err.message : err
-          }`,
+          `[operator-daemon] tick crashed for ${jobId}: ${err instanceof Error ? err.message : err}`,
         );
       });
     }
@@ -1006,7 +1054,18 @@ export function createOperatorDaemon(
       if (heartbeat.hasPersistence) {
         await heartbeat.markJobStart(jobId, { intervalMs }).catch(() => {});
       }
-      return runTick(newTickId());
+      // Serialize through the same single-flight chain as cron ticks, so
+      // concurrent manual ticks run FIFO and never overlap a cron tick.
+      return enqueueTick(newTickId());
+    },
+    async drain(): Promise<void> {
+      // Graceful shutdown: stop admitting new work, then wait for the active +
+      // queued ticks (incl. awaited sink delivery) to finish. Starts no new
+      // inference. MCP disconnect is the caller's responsibility (operate.ts).
+      draining = true;
+      heartbeat.stop();
+      started = false;
+      await runChain.catch(() => {});
     },
   };
 }

--- a/test/operator-single-flight.test.mjs
+++ b/test/operator-single-flight.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * Operator daemon — tick single-flight, awaited hooks, and drain (PR1).
+ *
+ * Injects a mock generateText that tracks concurrency + an onTickEvent hook, so
+ * we can assert: only one inference runs at a time under manual/timer pressure,
+ * tickOnce() awaits the sink hook, and drain() waits for the active tick and
+ * starts no new inference.
+ */
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { createOperatorDaemon } from "../dist/operator-daemon.js";
+import { HeartbeatService } from "../dist/heartbeat.js";
+
+let tmpDir;
+beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "single-flight-")); });
+afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** generateText stub that tracks max concurrency + call/done counts. */
+function makeConcurrencyGen(sleepMs) {
+  let active = 0;
+  const stats = { max: 0, calls: 0, done: 0 };
+  const impl = async () => {
+    active++; stats.calls++; stats.max = Math.max(stats.max, active);
+    await wait(sleepMs);
+    active--; stats.done++;
+    return { text: "ok" };
+  };
+  impl.stats = stats;
+  return impl;
+}
+
+function baseConfig(overrides = {}) {
+  return {
+    jobId: "single-flight-test",
+    intervalMs: 60_000,
+    rootDir: tmpDir,
+    role: "You are a test operator.",
+    model: { name: "mock-model" },
+    heartbeat: new HeartbeatService(),
+    persistence: false, // in-memory; no lock/fs timing in these tests
+    generateTextImpl: makeConcurrencyGen(60),
+    ...overrides,
+  };
+}
+
+describe("tick single-flight + drain (PR1)", () => {
+  it("serializes concurrent manual ticks — inference concurrency stays 1", async () => {
+    const gen = makeConcurrencyGen(50);
+    const d = createOperatorDaemon(baseConfig({ generateTextImpl: gen }));
+    const events = await Promise.all([d.tickOnce(), d.tickOnce(), d.tickOnce(), d.tickOnce()]);
+    assert.equal(gen.stats.max, 1, "no two inferences overlapped");
+    assert.equal(gen.stats.calls, 4, "all four ticks ran (FIFO)");
+    assert.ok(events.every((e) => e.type === "tick_published" || e.type === "tick_silent"));
+  });
+
+  it("tickOnce() awaits the onTickEvent hook (>= 200ms hook keeps it pending)", async () => {
+    let hits = 0;
+    const onTickEvent = async () => { hits++; await wait(120); };
+    const d = createOperatorDaemon(baseConfig({ onTickEvent }));
+    const t0 = Date.now();
+    await d.tickOnce();
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed >= 200, `tickOnce should await hooks (elapsed=${elapsed}ms)`);
+    assert.ok(hits >= 2, "hook fired for tick_started and the terminal event");
+  });
+
+  it("recurring cron fire during an active tick is skipped (no overlap)", async () => {
+    const gen = makeConcurrencyGen(120);
+    const d = createOperatorDaemon(baseConfig({ intervalMs: 50, generateTextImpl: gen }));
+    d.start();
+    await wait(320);
+    await d.drain();
+    assert.equal(gen.stats.max, 1, "cron fires never overlapped the running tick");
+  });
+
+  it("drain() waits for the active tick and starts no new inference", async () => {
+    const gen = makeConcurrencyGen(120);
+    const d = createOperatorDaemon(baseConfig({ generateTextImpl: gen }));
+    const p = d.tickOnce();
+    await wait(20); // let the tick begin
+    await d.drain(); // must not resolve until the active tick finished
+    assert.equal(gen.stats.done, 1, "drain awaited the in-flight tick");
+    await p;
+    const before = gen.stats.calls;
+    await wait(60);
+    assert.equal(gen.stats.calls, before, "drain started no new inference");
+  });
+});


### PR DESCRIPTION
Athlete Vault July-31 hardening, **SportsClaw PR1** (lifecycle correctness). Foundational for the Vault correlated loop; also hardens the TV operator.

## What
- **Full-tick single-flight** — cron + manual ticks serialize through one chain; only one tick (inference + tools + awaited hooks + ledger + delivery) runs at a time. Manual ticks FIFO; a cron fire during an active tick is **skipped** (no timer debt, no overlap).
- **Awaited hooks** — `onTickEvent` is awaited (a tick isn't "done" until the sink delivered); `onToolCall`/`onHeartbeatEvent` are bounded + caught (no unhandled rejections).
- **drain()** — async graceful shutdown: stop admission, await active/queued work, start no new inference. SIGINT/SIGTERM now **drain** instead of firing a handoff `tickOnce()`; `--once` drains + sets `process.exitCode` (removed the fixed 1.5s sleep).

## Tests
New `operator-single-flight` suite: inference concurrency stays 1 under manual + timer pressure; a 200ms hook keeps `tickOnce()` pending ≥200ms; `drain()` waits for the active tick and starts nothing new. Full operator/heartbeat/**tv-contracts** sweep green (TV compatibility preserved).

## Notes
Cross-replica lock-held-through-tick (multi-replica overlap) is unchanged — in-process single-flight covers the single-replica demo path; lock staleness (5m) already exceeds the tick timeout (4m). Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)