### PR TITLE
fix(inference): governed statuses, SinkContext model-role, strip <think> (PR4)

### DIFF
--- a/src/inference/inference-task.ts
+++ b/src/inference/inference-task.ts
@@ -54,7 +54,9 @@ export interface InferenceTrace {
   endedAt: string;
   latencyMs: number;
   route: InferenceRoute;
-  status: "completed" | "failed";
+  /** Governed statuses: only `completed` may be parsed as a usable result;
+   * `timed_out` / `cancelled` / `failed` must fail closed (never a verdict). */
+  status: "completed" | "failed" | "timed_out" | "cancelled";
   error?: string;
 }
 
@@ -141,8 +143,8 @@ export function validateInferenceTrace(trace: unknown): ValidationResult {
     return { ok: false, error: "Trace route must be openshell, nim, or mock." };
   }
 
-  if (t.status !== "completed" && t.status !== "failed") {
-    return { ok: false, error: "Trace status must be completed or failed." };
+  if (!["completed", "failed", "timed_out", "cancelled"].includes(t.status as string)) {
+    return { ok: false, error: "Trace status must be completed, failed, timed_out, or cancelled." };
   }
 
   return { ok: true };

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -59,10 +59,40 @@ import {
   TOOL_DISCIPLINE_FRAGMENT,
 } from "./prompts.js";
 import type { InferenceRoute, LLMProvider, OpenShellConfig } from "./types.js";
+import { invokeModelRole } from "./inference/model-role-router.js";
 
 // Cheap-wake probe budget: a sink's pollWake must be fast I/O. If it hangs or
 // throws we fail closed (skip the tick — never fall through to inference).
 const WAKE_POLL_TIMEOUT_MS = 5_000;
+// Governed second-inference budget (e.g. the Vault skeptic evaluator).
+const MODEL_ROLE_TIMEOUT_MS = 25_000;
+
+/** Governed wrapper around invokeModelRole exposed via SinkContext, so sinks run
+ *  a second inference WITHOUT importing /app/dist internals. Bounded + fail-closed:
+ *  only `completed` carries an output; timeout → timed_out, throw → failed. */
+function makeRunModelRole(): NonNullable<SinkContext["runModelRole"]> {
+  const invoke = invokeModelRole as (a: {
+    role: string;
+    input: unknown;
+    source: string;
+    config?: unknown;
+  }) => Promise<{ output?: unknown }>;
+  return async ({ role = "brain", input, source, config, timeoutMs }) => {
+    const started = Date.now();
+    try {
+      const res = await Promise.race([
+        invoke({ role, input, source: source ?? "sink", config }),
+        new Promise<never>((_r, rej) =>
+          setTimeout(() => rej(new Error("model role timeout")), timeoutMs ?? MODEL_ROLE_TIMEOUT_MS),
+        ),
+      ]);
+      return { status: "completed", output: res.output, latencyMs: Date.now() - started };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { status: /timeout/i.test(msg) ? "timed_out" : "failed", error: msg, latencyMs: Date.now() - started };
+    }
+  };
+}
 
 /** Adapt a sink's optional pollWake into the daemon's wake gate, with a bounded
  *  timeout + fail-closed behaviour. Returns undefined when the sink has none. */
@@ -693,6 +723,7 @@ async function runOnce(jobId: string): Promise<void> {
       intervalMs: cfg.intervalMs,
       mcpManager: tools.mcpManager,
       cfg,
+      runModelRole: makeRunModelRole(),
     };
     const outputSchema = sink.getOutputSchema?.({ cfg });
     const daemon = createOperatorDaemon({
@@ -777,6 +808,7 @@ async function runForeground(jobId: string): Promise<void> {
     intervalMs: cfg.intervalMs,
     mcpManager: tools.mcpManager,
     cfg,
+    runModelRole: makeRunModelRole(),
   };
   const outputSchema = sink.getOutputSchema?.({ cfg });
   const daemon = createOperatorDaemon({

--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -361,6 +361,15 @@ const DEFAULT_MAX_STEPS = 10;
 const DEFAULT_INFERENCE_TIMEOUT_MS = 240_000;
 const DEFAULT_RECENT_BRIEF_LIMIT = 1;
 
+/** Strip model reasoning (`<think>…</think>`, closed or dangling) so it never
+ *  leaks into published text, traces, receipts, or logs. */
+function stripThink(s: string): string {
+  return s
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    .replace(/<think>[\s\S]*$/i, "")
+    .trim();
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -632,13 +641,13 @@ export function createOperatorDaemon(
               : typeof (structuredOutput as { narrative?: unknown })?.narrative === "string"
                 ? (structuredOutput as { narrative: string }).narrative
                 : undefined;
-            text = (extracted ?? "").trim();
+            text = stripThink(extracted ?? "");
           } catch (e) {
             failureReason = failureReason ?? `output extractor threw: ${e instanceof Error ? e.message : e}`;
           }
         }
       } else {
-        text = (result.text ?? "").trim();
+        text = stripThink(result.text ?? "");
       }
     } catch (err) {
       // AI_APICallError shapes its message as "Unknown" when the upstream

--- a/src/operator-sink.ts
+++ b/src/operator-sink.ts
@@ -63,6 +63,26 @@ export interface SinkContext {
   mcpManager?: McpManager;
   /** Full operator job config, for sinks reading domain-specific fields. */
   cfg: OperatorJobConfig;
+  /**
+   * Governed model-role inference (PR4). A bounded wrapper around the engine's
+   * `invokeModelRole`, provided so sinks (e.g. the Vault skeptic evaluator) run
+   * a second governed inference WITHOUT importing `/app/dist/...` internals.
+   * Only `status:"completed"` may be parsed as a result; `timed_out` / `failed`
+   * / `cancelled` MUST fail closed (never approve). The caller supplies the same
+   * role/config it would pass to invokeModelRole.
+   */
+  runModelRole?: (args: {
+    role?: string;
+    input: unknown;
+    source?: string;
+    config?: unknown;
+    timeoutMs?: number;
+  }) => Promise<{
+    status: "completed" | "timed_out" | "failed" | "cancelled";
+    output?: unknown;
+    error?: string;
+    latencyMs?: number;
+  }>;
 }
 
 /**

--- a/test/operator-domain-neutral.test.mjs
+++ b/test/operator-domain-neutral.test.mjs
@@ -83,6 +83,18 @@ describe("domain-neutral output contract (PR2)", () => {
     assert.match(gen.calls[0].system, /submit_result/);
   });
 
+  it("strips <think> reasoning from the published text (never leaks)", async () => {
+    const gen = genToolCall("submit_broadcast", {
+      silent: false,
+      narrative: "<think>secret chain of thought</think>Cleared for full contact.",
+    });
+    const d = createOperatorDaemon(base({ generateTextImpl: gen, outputSchema: { schema: minimalSchema } }));
+    const ev = await d.tickOnce();
+    assert.equal(ev.type, "tick_published");
+    assert.doesNotMatch(ev.text, /<think>|secret chain of thought/i);
+    assert.match(ev.text, /Cleared for full contact\./);
+  });
+
   it("forwards a custom tickPrompt template", async () => {
     const gen = genToolCall("submit_broadcast", { silent: false, narrative: "x" });
     const d = createOperatorDaemon(base({


### PR DESCRIPTION
SportsClaw **PR4** (governed inference). Stacked on PR3 (#131).

## What (committed)
- **Governed status contract** — inference trace status widened to `completed | failed | timed_out | cancelled`. Only `completed` may be parsed as a verdict; the rest fail closed.
- **SinkContext.runModelRole** — a bounded (timeout) governed wrapper around `invokeModelRole`, so sinks (the Vault skeptic evaluator) run a second inference **without importing `/app/dist` internals**. Timeout → `timed_out`, throw → `failed`.
- **Strip `<think>`** reasoning from published text in the daemon extraction, so it never leaks into text / traces / receipts / logs.

## Deferred to box-verification (shared TV-inference risk)
Removing the `nimNemotronFetch` **model-name thinking heuristic** and adding **explicit per-stage temperature/top_p/reasoning** controls change live inference behaviour shared with the TV operator — they should be validated on the box (Phase 3) rather than merged blind. Flagged, not done here.

## Tests
`<think>` strip on published text; inference-contracts / model-role-router / operator-daemon / operate / tv-contracts all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)