### PR TITLE
fix(relay): harden evidence output normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sportsclaw-engine-core",
-      "version": "0.28.2",
+      "version": "0.28.3",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/sdk": "^2.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, and Google.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -482,30 +482,52 @@ export function stripInternalEvidenceArtifacts(text: string): string {
  * incorrectly dropped the final venue from oversized worldcup-get-schedule
  * payloads (pretty JSON >4000 chars, compact <2500).
  */
-export function summarizeToolOutputForEvidence(output: unknown): string {
-  const MAX_CHARS = 4_000;
-  let raw = "";
+/**
+ * extractEvidenceString — pull a string out of an arbitrary tool output without
+ * ever throwing. Direct strings and legacy {content:string} envelopes are
+ * returned verbatim; anything else is JSON-stringified. When JSON.stringify
+ * returns undefined (top-level undefined/function/symbol) or throws
+ * (BigInt/cyclic), it falls back to a deterministic String() coercion.
+ */
+function extractEvidenceString(output: unknown): string {
+  if (typeof output === "string") return output;
 
-  if (typeof output === "string") {
-    raw = output;
-    try {
-      raw = JSON.stringify(JSON.parse(output));
-    } catch {
-      // Not JSON — keep the raw string.
-    }
-  } else if (
+  if (
     output &&
     typeof output === "object" &&
     "content" in output &&
     typeof (output as { content?: unknown }).content === "string"
   ) {
-    raw = (output as { content: string }).content;
-  } else {
-    try {
-      raw = JSON.stringify(output);
-    } catch {
-      raw = String(output ?? "");
-    }
+    return (output as { content: string }).content;
+  }
+
+  try {
+    const json = JSON.stringify(output);
+    if (typeof json === "string") return json;
+  } catch {
+    // BigInt / cyclic structures — fall through to deterministic coercion.
+  }
+
+  return String(output ?? "");
+}
+
+export function summarizeToolOutputForEvidence(output: unknown): string {
+  const MAX_CHARS = 4_000;
+
+  // Centralized safe extraction: always yields a string, never throws — even
+  // for top-level undefined/function/symbol (JSON.stringify returns undefined)
+  // or BigInt/cyclic values (JSON.stringify throws).
+  let raw = extractEvidenceString(output);
+
+  // Shared compaction: any extracted string that is valid JSON is compacted so
+  // the whole payload can survive within budget. This applies uniformly to bare
+  // strings and to strings pulled from legacy {content:string} envelopes; a
+  // head-only slice of pretty JSON incorrectly dropped the final venue from
+  // oversized worldcup-get-schedule payloads (pretty >4000 chars, compact <2500).
+  try {
+    raw = JSON.stringify(JSON.parse(raw));
+  } catch {
+    // Not JSON — keep the raw string.
   }
 
   const trimmed = raw.trim();

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -501,19 +501,40 @@ const UNSERIALIZABLE_TOOL_OUTPUT = "[unserializable tool output]";
 function extractEvidenceString(output: unknown): string {
   if (typeof output === "string") return output;
 
-  // Legacy {content:string} envelope. Both the `in` check and the property
-  // read can trip hostile Proxy traps, so guard the whole inspection.
-  try {
-    if (output && typeof output === "object" && "content" in output) {
-      const content: unknown = (output as { content?: unknown }).content;
-      if (typeof content === "string") return content;
+  // Legacy contract: {content:string}. Once presence is established, read the
+  // property exactly once. Primitive values retain the historical safe
+  // conversion, while objects/functions fail closed without any introspection;
+  // they could alias this envelope and route serialization back into its traps.
+  if (output && typeof output === "object") {
+    let hasContent: boolean;
+    try {
+      hasContent = "content" in output;
+    } catch {
+      return UNSERIALIZABLE_TOOL_OUTPUT;
     }
-  } catch {
-    // Hostile has/get trap — fall through to serialization/coercion.
+
+    if (hasContent) {
+      let content: unknown;
+      try {
+        content = (output as { content?: unknown }).content;
+      } catch {
+        return UNSERIALIZABLE_TOOL_OUTPUT;
+      }
+      if ((typeof content === "object" && content !== null) || typeof content === "function") {
+        return UNSERIALIZABLE_TOOL_OUTPUT;
+      }
+      return safelySerializeOrCoerce(content);
+    }
   }
 
+  return safelySerializeOrCoerce(output);
+}
+
+function safelySerializeOrCoerce(value: unknown): string {
+  if (typeof value === "string") return value;
+
   try {
-    const json = JSON.stringify(output);
+    const json = JSON.stringify(value);
     if (typeof json === "string") return json;
   } catch {
     // BigInt / cyclic structures / hostile toJSON — fall through to coercion.
@@ -522,10 +543,49 @@ function extractEvidenceString(output: unknown): string {
   // Final fail-closed coercion. String()/`??` can themselves throw via hostile
   // Symbol.toPrimitive/toString/valueOf, so guard and fall back to a sentinel.
   try {
-    return String(output ?? "");
+    return String(value ?? "");
   } catch {
     return UNSERIALIZABLE_TOOL_OUTPUT;
   }
+}
+
+/** Trim only the four whitespace code points permitted by the JSON grammar. */
+function trimJsonWhitespace(raw: string): string {
+  return raw.replace(/^[\u0020\u0009\u000d\u000a]+|[\u0020\u0009\u000d\u000a]+$/g, "");
+}
+
+/** Losslessly remove JSON whitespace outside strings from objects/arrays only. */
+function compactStructuredJson(raw: string): string {
+  const trimmed = trimJsonWhitespace(raw);
+  const first = trimmed[0];
+  const last = trimmed[trimmed.length - 1];
+  if (!((first === "{" && last === "}") || (first === "[" && last === "]"))) {
+    return raw;
+  }
+
+  try {
+    JSON.parse(trimmed);
+  } catch {
+    return raw;
+  }
+
+  let compact = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of trimmed) {
+    if (inString) {
+      compact += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+    } else if (char === '"') {
+      compact += char;
+      inString = true;
+    } else if (char !== " " && char !== "\t" && char !== "\r" && char !== "\n") {
+      compact += char;
+    }
+  }
+  return compact;
 }
 
 export function summarizeToolOutputForEvidence(output: unknown): string {
@@ -536,18 +596,12 @@ export function summarizeToolOutputForEvidence(output: unknown): string {
   // or BigInt/cyclic values (JSON.stringify throws).
   let raw = extractEvidenceString(output);
 
-  // Shared compaction: any extracted string that is valid JSON is compacted so
-  // the whole payload can survive within budget. This applies uniformly to bare
-  // strings and to strings pulled from legacy {content:string} envelopes; a
-  // head-only slice of pretty JSON incorrectly dropped the final venue from
-  // oversized worldcup-get-schedule payloads (pretty >4000 chars, compact <2500).
-  try {
-    raw = JSON.stringify(JSON.parse(raw));
-  } catch {
-    // Not JSON — keep the raw string.
-  }
+  // Compact only object/array JSON, directly from its original lexical form.
+  // JSON.parse validates the document but its value is never stringified, so
+  // unsafe integer tokens and whitespace inside quoted strings remain exact.
+  raw = compactStructuredJson(raw);
 
-  const trimmed = raw.trim();
+  const trimmed = trimJsonWhitespace(raw);
   if (!trimmed) return "";
   if (trimmed.length <= MAX_CHARS) return trimmed;
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -483,32 +483,53 @@ export function stripInternalEvidenceArtifacts(text: string): string {
  * payloads (pretty JSON >4000 chars, compact <2500).
  */
 /**
+ * Stable, non-secret sentinel returned only when every extraction strategy
+ * fails closed — i.e. envelope introspection, JSON serialization, and String()
+ * coercion all throw (hostile Proxy traps, hostile toJSON/toString/
+ * Symbol.toPrimitive). It must never leak internal state.
+ */
+const UNSERIALIZABLE_TOOL_OUTPUT = "[unserializable tool output]";
+
+/**
  * extractEvidenceString — pull a string out of an arbitrary tool output without
  * ever throwing. Direct strings and legacy {content:string} envelopes are
- * returned verbatim; anything else is JSON-stringified. When JSON.stringify
- * returns undefined (top-level undefined/function/symbol) or throws
- * (BigInt/cyclic), it falls back to a deterministic String() coercion.
+ * returned verbatim; anything else is JSON-stringified. Every introspection
+ * and coercion step is guarded so that hostile inputs — Proxies whose has/get
+ * traps throw, objects whose toJSON/toString/Symbol.toPrimitive throw — fail
+ * closed to a deterministic sentinel instead of propagating.
  */
 function extractEvidenceString(output: unknown): string {
   if (typeof output === "string") return output;
 
-  if (
-    output &&
-    typeof output === "object" &&
-    "content" in output &&
-    typeof (output as { content?: unknown }).content === "string"
-  ) {
-    return (output as { content: string }).content;
+  // Legacy {content:string} envelope. Both the `in` check and the property
+  // read can trip hostile Proxy traps, so guard the whole inspection.
+  try {
+    if (
+      output &&
+      typeof output === "object" &&
+      "content" in output &&
+      typeof (output as { content?: unknown }).content === "string"
+    ) {
+      return (output as { content: string }).content;
+    }
+  } catch {
+    // Hostile has/get trap — fall through to serialization/coercion.
   }
 
   try {
     const json = JSON.stringify(output);
     if (typeof json === "string") return json;
   } catch {
-    // BigInt / cyclic structures — fall through to deterministic coercion.
+    // BigInt / cyclic structures / hostile toJSON — fall through to coercion.
   }
 
-  return String(output ?? "");
+  // Final fail-closed coercion. String()/`??` can themselves throw via hostile
+  // Symbol.toPrimitive/toString/valueOf, so guard and fall back to a sentinel.
+  try {
+    return String(output ?? "");
+  } catch {
+    return UNSERIALIZABLE_TOOL_OUTPUT;
+  }
 }
 
 export function summarizeToolOutputForEvidence(output: unknown): string {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -504,13 +504,9 @@ function extractEvidenceString(output: unknown): string {
   // Legacy {content:string} envelope. Both the `in` check and the property
   // read can trip hostile Proxy traps, so guard the whole inspection.
   try {
-    if (
-      output &&
-      typeof output === "object" &&
-      "content" in output &&
-      typeof (output as { content?: unknown }).content === "string"
-    ) {
-      return (output as { content: string }).content;
+    if (output && typeof output === "object" && "content" in output) {
+      const content: unknown = (output as { content?: unknown }).content;
+      if (typeof content === "string") return content;
     }
   } catch {
     // Hostile has/get trap — fall through to serialization/coercion.

--- a/test/evidence-artifact-cleanup.test.mjs
+++ b/test/evidence-artifact-cleanup.test.mjs
@@ -207,6 +207,29 @@ describe("summarizeToolOutputForEvidence", () => {
     assert.equal(typeof out, "string", "must return a string fallback");
   });
 
+  it("reads legacy envelope content exactly once", () => {
+    let contentReads = 0;
+    const stateful = new Proxy(
+      {},
+      {
+        has(_target, property) {
+          return property === "content";
+        },
+        get(_target, property) {
+          if (property !== "content") return undefined;
+          contentReads += 1;
+          return contentReads === 1 ? "legacy evidence" : Symbol("changed");
+        },
+      }
+    );
+    let out;
+    assert.doesNotThrow(() => {
+      out = summarizeToolOutputForEvidence(stateful);
+    }, "stateful content getter must not throw");
+    assert.equal(typeof out, "string", "must return a string");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+  });
+
   it("never throws when toJSON and toString both throw", () => {
     // JSON.stringify trips toJSON; the String() coercion fallback then trips
     // Symbol.toPrimitive/toString. Both paths must be caught, yielding the

--- a/test/evidence-artifact-cleanup.test.mjs
+++ b/test/evidence-artifact-cleanup.test.mjs
@@ -61,6 +61,80 @@ describe("stripInternalEvidenceArtifacts", () => {
 });
 
 describe("summarizeToolOutputForEvidence", () => {
+  it("rejects non-JSON whitespace around otherwise valid structured JSON", () => {
+    const prettyValues = [
+      `{
+  "team": "Norway",
+  "score": 3
+}`,
+      `[
+  "Norway",
+  "England"
+]`,
+    ];
+    const invalidBoundaryWhitespace = [
+      ["NBSP U+00A0", "\u00a0"],
+      ["form-feed U+000C", "\u000c"],
+      ["vertical-tab U+000B", "\u000b"],
+      ["BOM U+FEFF", "\ufeff"],
+      ["Ogham space mark U+1680", "\u1680"],
+      ["en quad U+2000", "\u2000"],
+      ["line separator U+2028", "\u2028"],
+      ["paragraph separator U+2029", "\u2029"],
+      ["ideographic space U+3000", "\u3000"],
+    ];
+
+    for (const pretty of prettyValues) {
+      const compact = pretty.replace(/[ \t\r\n]/g, "");
+      for (const [label, boundary] of invalidBoundaryWhitespace) {
+        const input = `${boundary}${pretty}${boundary}`;
+        const out = summarizeToolOutputForEvidence(input);
+        assert.equal(out, input, `${label} and the pretty JSON must be preserved byte-for-byte`);
+        assert.notEqual(out, compact, `${label} must preserve interior pretty whitespace`);
+      }
+    }
+  });
+
+  it("accepts only JSON whitespace around structured JSON and losslessly minifies it", () => {
+    const unsafeInteger = "9007199254740993";
+    const prettyObject = `{\n  "id": ${unsafeInteger},\n  "label": "kept   spacing"\n}`;
+    const prettyArray = `[\n  { "id": ${unsafeInteger} }\n]`;
+    const outerJsonWhitespace = " \t\r\n";
+
+    assert.equal(
+      summarizeToolOutputForEvidence(`${outerJsonWhitespace}${prettyObject}${outerJsonWhitespace}`),
+      `{"id":${unsafeInteger},"label":"kept   spacing"}`
+    );
+    assert.equal(
+      summarizeToolOutputForEvidence({
+        content: `${outerJsonWhitespace}${prettyArray}${outerJsonWhitespace}`,
+      }),
+      `[{"id":${unsafeInteger}}]`
+    );
+  });
+
+  it("preserves unsafe integer digits and only losslessly compacts object/array JSON strings", () => {
+    const unsafeInteger = "9007199254740993";
+    const prettyObject = `{\n  "id": ${unsafeInteger},\n  "label": "kept   spacing\\tand \\\"escapes\\\""\n}`;
+    const prettyArray = `[\n  { "id": ${unsafeInteger} }\n]`;
+
+    assert.equal(summarizeToolOutputForEvidence(9007199254740993n), unsafeInteger);
+    assert.equal(summarizeToolOutputForEvidence({ content: unsafeInteger }), unsafeInteger);
+    assert.equal(
+      summarizeToolOutputForEvidence(prettyObject),
+      `{"id":${unsafeInteger},"label":"kept   spacing\\tand \\\"escapes\\\""}`
+    );
+    assert.equal(
+      summarizeToolOutputForEvidence({ content: prettyArray }),
+      `[{"id":${unsafeInteger}}]`
+    );
+    assert.equal(
+      summarizeToolOutputForEvidence("  9007199254740993  "),
+      unsafeInteger,
+      "arbitrary JSON scalar strings must never be parsed/stringified"
+    );
+  });
+
   it("compacts an oversized pretty-JSON string, keeping beginning and end facts under the limit", () => {
     // Mirrors the production worldcup-get-schedule payload: pretty JSON is
     // >4000 chars while its compact form is well under, so a head-only slice
@@ -228,6 +302,110 @@ describe("summarizeToolOutputForEvidence", () => {
     }, "stateful content getter must not throw");
     assert.equal(typeof out, "string", "must return a string");
     assert.equal(contentReads, 1, "content must be read exactly once");
+  });
+
+  it("fails closed without re-entering a self-referential legacy envelope", () => {
+    let contentReads = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    let toJSONReads = 0;
+    let envelope;
+    envelope = new Proxy({}, {
+      has(_target, property) {
+        return property === "content";
+      },
+      get(_target, property) {
+        if (property === "content") {
+          contentReads += 1;
+          return envelope;
+        }
+        if (property === "toJSON") toJSONReads += 1;
+        return undefined;
+      },
+      ownKeys() {
+        ownKeysCalls += 1;
+        return [];
+      },
+      getOwnPropertyDescriptor() {
+        descriptorCalls += 1;
+        return undefined;
+      },
+    });
+
+    assert.equal(summarizeToolOutputForEvidence(envelope), "[unserializable tool output]");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+    assert.equal(ownKeysCalls, 0, "original envelope ownKeys must not be invoked");
+    assert.equal(descriptorCalls, 0, "original envelope descriptors must not be inspected");
+    assert.equal(toJSONReads, 0, "original envelope toJSON must not be inspected");
+  });
+
+  it("fails closed without inspecting object content that aliases the legacy envelope", () => {
+    let contentReads = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    let toJSONReads = 0;
+    let envelope;
+    envelope = new Proxy({}, {
+      has(_target, property) {
+        return property === "content";
+      },
+      get(_target, property) {
+        if (property === "content") {
+          contentReads += 1;
+          return { nested: envelope };
+        }
+        if (property === "toJSON") toJSONReads += 1;
+        return undefined;
+      },
+      ownKeys() {
+        ownKeysCalls += 1;
+        return [];
+      },
+      getOwnPropertyDescriptor() {
+        descriptorCalls += 1;
+        return undefined;
+      },
+    });
+
+    assert.equal(summarizeToolOutputForEvidence(envelope), "[unserializable tool output]");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+    assert.equal(ownKeysCalls, 0, "original envelope ownKeys must not be invoked");
+    assert.equal(descriptorCalls, 0, "original envelope descriptors must not be inspected");
+    assert.equal(toJSONReads, 0, "original envelope toJSON must not be inspected");
+  });
+
+  it("serializes a cached non-string legacy content value without rereading its getter", () => {
+    let contentReads = 0;
+    const stateful = {
+      get content() {
+        contentReads += 1;
+        return contentReads === 1 ? 9007199254740993n : "changed on second read";
+      },
+    };
+
+    const out = summarizeToolOutputForEvidence(stateful);
+
+    assert.equal(out, "9007199254740993");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+  });
+
+  it("attempts a throwing content getter once and returns the stable sentinel", () => {
+    let contentReads = 0;
+    const hostile = {
+      get content() {
+        contentReads += 1;
+        throw new Error("content getter failed");
+      },
+      toJSON() {
+        throw new Error("original envelope must not be re-serialized");
+      },
+    };
+
+    assert.equal(
+      summarizeToolOutputForEvidence(hostile),
+      "[unserializable tool output]"
+    );
+    assert.equal(contentReads, 1, "throwing content getter must be attempted once");
   });
 
   it("never throws when toJSON and toString both throw", () => {

--- a/test/evidence-artifact-cleanup.test.mjs
+++ b/test/evidence-artifact-cleanup.test.mjs
@@ -186,6 +186,54 @@ describe("summarizeToolOutputForEvidence", () => {
     assert.equal(typeof summarizeToolOutputForEvidence(cyclic), "string");
   });
 
+  it("never throws for a hostile proxy whose has/get traps throw", () => {
+    // Envelope inspection (`"content" in output` and reading `.content`) trips
+    // the proxy traps. Extraction must fail closed rather than propagate.
+    const hostile = new Proxy(
+      {},
+      {
+        has() {
+          throw new Error("hostile has trap");
+        },
+        get() {
+          throw new Error("hostile get trap");
+        },
+      }
+    );
+    let out;
+    assert.doesNotThrow(() => {
+      out = summarizeToolOutputForEvidence(hostile);
+    }, "hostile proxy must not throw");
+    assert.equal(typeof out, "string", "must return a string fallback");
+  });
+
+  it("never throws when toJSON and toString both throw", () => {
+    // JSON.stringify trips toJSON; the String() coercion fallback then trips
+    // Symbol.toPrimitive/toString. Both paths must be caught, yielding the
+    // stable non-secret sentinel.
+    const hostile = {
+      toJSON() {
+        throw new Error("hostile toJSON");
+      },
+      toString() {
+        throw new Error("hostile toString");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("hostile Symbol.toPrimitive");
+      },
+    };
+    let out;
+    assert.doesNotThrow(() => {
+      out = summarizeToolOutputForEvidence(hostile);
+    }, "hostile toJSON/toString object must not throw");
+    assert.equal(typeof out, "string", "must return a string fallback");
+    assert.equal(
+      out,
+      "[unserializable tool output]",
+      "must return the deterministic sentinel"
+    );
+  });
+
   it("returns an exactly-4000-char string unchanged", () => {
     const input = "x".repeat(4000);
     assert.equal(input.length, 4000);

--- a/test/evidence-artifact-cleanup.test.mjs
+++ b/test/evidence-artifact-cleanup.test.mjs
@@ -109,6 +109,99 @@ describe("summarizeToolOutputForEvidence", () => {
     assert.ok(out.includes(prefix), "head prefix preserved");
     assert.ok(out.includes(suffix), "tail suffix preserved");
   });
+
+  it("compacts pretty JSON carried inside a legacy {content:string} envelope", () => {
+    // Legacy supported envelope: the payload is a pretty-printed JSON string
+    // nested under `content`. It must go through the same compaction as a bare
+    // string so the whole payload survives instead of a head+tail slice that
+    // drops the middle.
+    const matches = Array.from({ length: 26 }, (_, i) => ({
+      matchId: 1000 + i,
+      stage: "group",
+      home: `Team Home ${i}`,
+      away: `Team Away ${i}`,
+      kickoff: "2026-06-15T18:00:00Z",
+      venue: `Stadium ${i}`,
+    }));
+    const payload = {
+      tournament: "World Cup",
+      firstVenue: "Hard Rock Stadium",
+      matches,
+      finalVenue: "New York New Jersey Stadium",
+    };
+    const pretty = JSON.stringify(payload, null, 2);
+    const compact = JSON.stringify(payload);
+    assert.ok(pretty.length > 4000, `pretty JSON must exceed 4000 (was ${pretty.length})`);
+    assert.ok(compact.length <= 4000, `compact JSON must be within 4000 (was ${compact.length})`);
+
+    const out = summarizeToolOutputForEvidence({ content: pretty });
+
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.includes("Hard Rock Stadium"), "beginning fact preserved");
+    assert.ok(out.includes("Stadium 13"), "middle fact preserved (compaction kept the whole payload)");
+    assert.ok(
+      out.includes("New York New Jersey Stadium"),
+      "late fact preserved (the final venue must survive)"
+    );
+  });
+
+  it("balanced-truncates a {content:string} JSON payload that stays oversized after compaction", () => {
+    const matches = Array.from({ length: 60 }, (_, i) => ({
+      matchId: 1000 + i,
+      stage: "group",
+      home: `TeamHome${i}`,
+      away: `TeamAway${i}`,
+      kickoff: "2026-06-15T18:00:00Z",
+      venue: `Stadium${i}`,
+    }));
+    const payload = {
+      headMarker: "HARDROCKSTADIUM",
+      matches,
+      tailMarker: "NEWYORKNEWJERSEYSTADIUM",
+    };
+    const pretty = JSON.stringify(payload, null, 2);
+    const compact = JSON.stringify(payload);
+    assert.ok(compact.length > 4000, `compact JSON must exceed 4000 (was ${compact.length})`);
+
+    const out = summarizeToolOutputForEvidence({ content: pretty });
+
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.includes("HARDROCKSTADIUM"), "head marker preserved");
+    assert.ok(out.includes("NEWYORKNEWJERSEYSTADIUM"), "tail marker preserved");
+    // Compaction must have run: pretty-print indentation must not survive.
+    assert.ok(!out.includes("  "), "no pretty-print indentation should remain (payload was compacted)");
+  });
+
+  it("never throws for unexpected top-level values", () => {
+    const cyclic = {};
+    cyclic.self = cyclic;
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(undefined), "undefined must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(() => 42), "function must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(Symbol("x")), "symbol must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(10n), "BigInt must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(cyclic), "cyclic object must not throw");
+    // Each must yield a string (the safe deterministic fallback).
+    assert.equal(typeof summarizeToolOutputForEvidence(undefined), "string");
+    assert.equal(typeof summarizeToolOutputForEvidence(10n), "string");
+    assert.equal(typeof summarizeToolOutputForEvidence(cyclic), "string");
+  });
+
+  it("returns an exactly-4000-char string unchanged", () => {
+    const input = "x".repeat(4000);
+    assert.equal(input.length, 4000);
+    const out = summarizeToolOutputForEvidence(input);
+    assert.equal(out, input);
+    assert.equal(out.length, 4000);
+  });
+
+  it("bounds a 4001-char string to <=4000 while preserving both ends", () => {
+    const input = `HEAD${"x".repeat(3993)}TAIL`;
+    assert.equal(input.length, 4001);
+    const out = summarizeToolOutputForEvidence(input);
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.startsWith("HEAD"), "head preserved");
+    assert.ok(out.endsWith("TAIL"), "tail preserved");
+  });
 });
 
 function isJson(value) {


### PR DESCRIPTION
## Summary
- centralize tool-output extraction so unexpected values never crash evidence synthesis
- apply valid-JSON compaction to direct strings and legacy `{content:string}` envelopes before the 4,000-character cap
- retain balanced head/tail truncation for oversized compact JSON and non-JSON
- bump relay to v0.28.3

## Why
A late independent review of v0.28.2 found two fail-closed gaps: top-level `undefined`/function/symbol and stringify-throw values could crash normalization, while `{content:string}` skipped compaction and could still drop middle facts.

## Verification
- strict TDD: 3 expected RED failures against v0.28.2 behavior
- focused evidence tests: 12/12 passed
- TypeScript build: passed
- isolated HOME CI smoke: passed
- exact 4,000/4,001 boundaries covered
- synchronous independent review: passed, no security or logic errors
- async fail-closed review pending before tag/deploy