### PR TITLE
fix(intelligence): close the fail-closed hole, add LLM timeouts, harden momentum edges (post-merge review fixes for #135)

### DIFF
--- a/src/intelligence/momentum-demo.ts
+++ b/src/intelligence/momentum-demo.ts
@@ -17,21 +17,11 @@
  *   SPORTSCLAW_PROVIDER / SPORTSCLAW_MODEL   LLM provider/model
  */
 
-import { fileURLToPath } from "node:url";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 import { MomentumExplainer } from "./momentum-explainer.js";
+import { REPO_ROOT, envInt } from "./momentum-runtime.js";
 import type { LLMProvider } from "../types.js";
-
-const HERE = dirname(fileURLToPath(import.meta.url)); // dist/intelligence
-const REPO_ROOT = resolve(HERE, "..", ".."); // <sportsclaw>
-
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
-}
 
 async function main(): Promise<void> {
   const mockFile =

--- a/src/intelligence/momentum-evaluator.ts
+++ b/src/intelligence/momentum-evaluator.ts
@@ -1,6 +1,11 @@
 /**
  * sportsclaw — Momentum Explainer, Phase 5: the generator/evaluator split.
  *
+ * NOTE — not to be confused with `src/evaluator.ts`. That one is a SOFT,
+ * non-blocking diagnostic (logs intent-alignment, never changes output). THIS
+ * one is a HARD, fail-CLOSED gate: a card it rejects is held, never shipped.
+ * Same word, opposite contract — keep them straight.
+ *
  * Phase 3 proved the loop can *generate* a Momentum Explainer card. But a
  * generator grading its own output is the "Nodding Loop" from the
  * loop-engineering write-up: the model that wrote the card is far too willing
@@ -32,6 +37,7 @@
 import { generateText } from "ai";
 import type { LLMProvider } from "../types.js";
 import {
+  LLM_CALL_TIMEOUT_MS,
   resolveExplainerModel,
   type CardVerdict,
   type MomentumCard,
@@ -239,6 +245,9 @@ async function judgeCard(
     system,
     prompt,
     maxOutputTokens: 1000,
+    // A hung checker must not wedge the loop; on timeout this throws and the
+    // caller treats it as a failed attempt (fail-closed — the card is held).
+    abortSignal: AbortSignal.timeout(LLM_CALL_TIMEOUT_MS),
   });
 
   const parsed = parseFirstJsonObject(result.text);

--- a/src/intelligence/momentum-explainer.ts
+++ b/src/intelligence/momentum-explainer.ts
@@ -705,11 +705,26 @@ export class MomentumExplainer {
     }
 
     for (const swing of swings) {
+      let resolved: ResolvedPlays;
       try {
-        const resolved = await resolvePlays(event, this.mode, {
+        resolved = await resolvePlays(event, this.mode, {
           pythonPath: this.pythonPath,
           env: this.env,
         });
+      } catch (err) {
+        // The play window could not be resolved (bridge error / status:false
+        // envelope). Fail CLOSED like any other bad card: hold the swing for a
+        // human with the failure as the reason, rather than logging it away.
+        // The generator is never asked to write about plays we don't have.
+        console.error(
+          "[momentum] play resolution failed — holding swing:",
+          err instanceof Error ? err.message : err,
+        );
+        this.rejectCount++;
+        this.onRejected(this.errorHeldCard(event, swing, null, err));
+        continue;
+      }
+      try {
         await this.produceCard(event, swing, resolved);
       } catch (err) {
         console.error(
@@ -788,40 +803,46 @@ export class MomentumExplainer {
   }
 
   /**
-   * A synthetic "held" card for when every attempt threw before producing one
-   * (e.g. the generator's provider was down or timed out). Routes the swing to
-   * the reject inbox with the error as the reason, so it is visibly held for
-   * review instead of vanishing into a log line.
+   * A synthetic "held" card for a swing that never produced a real one: either
+   * every generation attempt threw (`resolved` set — e.g. the provider was down
+   * or timed out), or the play window itself could not be resolved (`resolved`
+   * null — bridge/status-envelope failure, so no attempt was ever made). Routes
+   * the swing to the reject inbox with the error as the reason, so it is
+   * visibly held for review instead of vanishing into a log line.
    */
   private errorHeldCard(
     event: WatchEvent,
     swing: PriceSwing,
-    resolved: ResolvedPlays,
+    resolved: ResolvedPlays | null,
     error: unknown,
   ): MomentumCard {
     const data = snapshotData(event);
     const { home, away } = teamAbbrs(data);
     const reason = error instanceof Error ? error.message : String(error);
+    const stage = resolved ? "Card generation" : "Play resolution";
     return {
       text: "",
       swing,
-      causePlay: resolved.causePlay,
-      source: resolved.source,
+      // No plays resolved means no cause — never fabricate one.
+      causePlay: resolved?.causePlay ?? null,
+      source: resolved?.source ?? (this.mode === "live" ? "espn-live" : "mock-snapshot"),
       gameLabel: `${away} @ ${home}`,
       gameClock: String(data.game_clock ?? ""),
       timestamp: event.timestamp,
       verdict: {
         verdict: "reject",
-        reasons: [`Card generation failed, held closed: ${reason}`],
+        reasons: [`${stage} failed, held closed: ${reason}`],
         checks: {
           playInWindow: false,
-          hasCause: resolved.causePlay !== null,
+          hasCause: resolved?.causePlay != null,
           claimSupported: false,
           noHallucination: false,
           directionCoherent: false,
         },
         evaluatorModel: this.evaluator?.modelId ?? "n/a",
-        attempts: this.maxAttempts,
+        // Zero attempts spent when resolution failed — the retry loop is never
+        // entered, so reporting maxAttempts here would overstate the effort.
+        attempts: resolved ? this.maxAttempts : 0,
       },
     };
   }

--- a/src/intelligence/momentum-explainer.ts
+++ b/src/intelligence/momentum-explainer.ts
@@ -31,6 +31,7 @@
 
 import { WatchManager } from "../watch.js";
 import { executePythonBridge } from "../tools.js";
+import { unwrapBridge } from "./momentum-runtime.js";
 import { resolveModel, resolveAuthForModel } from "../llm-providers.js";
 import { resolveAnthropicAuth } from "../credentials.js";
 import {
@@ -224,6 +225,14 @@ export interface CardVerdict {
 const PRICE_PATH_SUFFIX = "home_price_cents";
 
 /**
+ * Wall-clock ceiling for a single generator/evaluator LLM call. A hung provider
+ * response would otherwise block the poll loop indefinitely (and stall
+ * WatchManager graceful shutdown); on timeout the call throws and is handled
+ * like any other generation failure — retried, then held for review.
+ */
+export const LLM_CALL_TIMEOUT_MS = 60_000;
+
+/**
  * Scan a WatchEvent's structural changes for home-price moves at/above the
  * threshold. `endsWith` (not `===`) so one detector serves both feeds: it
  * matches the mock's `polymarket_home_price_cents` AND the live Kalshi feed's
@@ -244,6 +253,11 @@ export function detectSwings(
     const before = Number(c.before);
     const after = Number(c.after);
     if (!Number.isFinite(before) || !Number.isFinite(after)) continue;
+    // An empty Kalshi book resolves to 0c (no bid / no last trade); a real live
+    // price is >0. Skip ticks where either side is 0 so a transient empty tick
+    // and its recovery can't manufacture a phantom swing attributed to an
+    // unrelated play.
+    if (before <= 0 || after <= 0) continue;
     const delta = after - before;
     if (Math.abs(delta) < thresholdCents) continue;
     // Upswings-only unless explicitly opted into down-swings.
@@ -354,10 +368,12 @@ async function resolvePlays(
     },
     { pythonPath: bridge.pythonPath, env: bridge.env },
   );
-  const inner = result.success && result.data && typeof result.data === "object"
-    ? ((result.data as Record<string, unknown>).data as Record<string, unknown> | undefined)
-    : undefined;
-  const rawLive = inner && Array.isArray(inner.plays) ? inner.plays : [];
+  // Enforce the skill's own status envelope — a status:false error would
+  // otherwise be silently read as an empty play window, producing an
+  // unverifiable card. unwrapBridge throws with the skill message on failure,
+  // which handleEvent catches and holds (never a phantom cause).
+  const inner = unwrapBridge(result, "get_plays_near_timestamp");
+  const rawLive = Array.isArray(inner.plays) ? inner.plays : [];
   const plays = rawLive.map((p) => normalizePlay(p as Record<string, unknown>));
   return { plays, causePlay: pickCause(plays), source: "espn-live" };
 }
@@ -477,6 +493,7 @@ async function generateCard(
     system,
     prompt,
     maxOutputTokens: 120,
+    abortSignal: AbortSignal.timeout(LLM_CALL_TIMEOUT_MS),
   });
 
   return {
@@ -652,6 +669,21 @@ export class MomentumExplainer {
   }
 
   private async handleEvent(event: WatchEvent): Promise<void> {
+    // A poll that returned a status:false envelope (feed/bridge error) is not a
+    // real price update — its "changes" are noise against the prior good tick.
+    // Skip it so a transient feed error can't drive a swing. (The Watcher polls
+    // structurally; this is the momentum-layer guard, leaving core watch.ts
+    // semantics untouched for other watchers.)
+    const snap = event.snapshot as Record<string, unknown> | undefined;
+    if (snap && typeof snap === "object" && snap.status === false) {
+      if (this.verbose) {
+        console.log(
+          `[momentum] tick skipped — feed error: ${String(snap.message ?? "unknown")}`,
+        );
+      }
+      return;
+    }
+
     const swings = detectSwings(event.changes, this.thresholdCents, this.direction);
 
     if (this.verbose && swings.length === 0) {
@@ -709,36 +741,88 @@ export class MomentumExplainer {
     }
 
     let lastCard: MomentumCard | null = null;
+    let lastError: unknown = null;
     for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
-      const card = await generateCard(this.model, event, swing, resolved);
-      const verdict = await evaluateCard(
-        this.evaluator,
-        card,
-        resolved.plays,
-        swing,
-        attempt,
-      );
-      card.verdict = verdict;
-      lastCard = card;
-
-      if (verdict.verdict === "pass") {
-        this.cardCount++;
-        this.onCard(card);
-        return;
-      }
-
-      if (this.verbose) {
-        console.log(
-          `[momentum] card rejected (attempt ${attempt}/${this.maxAttempts}): ` +
-            verdict.reasons.join("; "),
+      try {
+        const card = await generateCard(this.model, event, swing, resolved);
+        const verdict = await evaluateCard(
+          this.evaluator,
+          card,
+          resolved.plays,
+          swing,
+          attempt,
         );
+        card.verdict = verdict;
+        lastCard = card;
+
+        if (verdict.verdict === "pass") {
+          this.cardCount++;
+          this.onCard(card);
+          return;
+        }
+
+        if (this.verbose) {
+          console.log(
+            `[momentum] card rejected (attempt ${attempt}/${this.maxAttempts}): ` +
+              verdict.reasons.join("; "),
+          );
+        }
+      } catch (err) {
+        // A thrown generator/evaluator error (incl. an LLM timeout) must NOT
+        // abandon the swing — it fails CLOSED like a reject: continue to the
+        // next attempt, and if the budget exhausts, the swing is still held
+        // below rather than silently dropped.
+        lastError = err;
+        if (this.verbose) {
+          console.error(
+            `[momentum] attempt ${attempt}/${this.maxAttempts} errored: ` +
+              (err instanceof Error ? err.message : String(err)),
+          );
+        }
       }
     }
 
-    // Budget exhausted — hold the last draft for a human. Never ship it.
-    if (lastCard) {
-      this.rejectCount++;
-      this.onRejected(lastCard);
-    }
+    // Budget exhausted — hold for a human. Never silently drop the swing.
+    this.rejectCount++;
+    this.onRejected(lastCard ?? this.errorHeldCard(event, swing, resolved, lastError));
+  }
+
+  /**
+   * A synthetic "held" card for when every attempt threw before producing one
+   * (e.g. the generator's provider was down or timed out). Routes the swing to
+   * the reject inbox with the error as the reason, so it is visibly held for
+   * review instead of vanishing into a log line.
+   */
+  private errorHeldCard(
+    event: WatchEvent,
+    swing: PriceSwing,
+    resolved: ResolvedPlays,
+    error: unknown,
+  ): MomentumCard {
+    const data = snapshotData(event);
+    const { home, away } = teamAbbrs(data);
+    const reason = error instanceof Error ? error.message : String(error);
+    return {
+      text: "",
+      swing,
+      causePlay: resolved.causePlay,
+      source: resolved.source,
+      gameLabel: `${away} @ ${home}`,
+      gameClock: String(data.game_clock ?? ""),
+      timestamp: event.timestamp,
+      verdict: {
+        verdict: "reject",
+        reasons: [`Card generation failed, held closed: ${reason}`],
+        checks: {
+          playInWindow: false,
+          hasCause: resolved.causePlay !== null,
+          claimSupported: false,
+          noHallucination: false,
+          directionCoherent: false,
+        },
+        evaluatorModel: this.evaluator?.modelId ?? "n/a",
+        attempts: this.maxAttempts,
+      },
+    };
   }
 }

--- a/src/intelligence/momentum-live.ts
+++ b/src/intelligence/momentum-live.ts
@@ -22,38 +22,11 @@
  *   SPORTSCLAW_PROVIDER / SPORTSCLAW_MODEL   LLM provider/model
  */
 
-import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { MomentumExplainer } from "./momentum-explainer.js";
+import { REPO_ROOT, certifiPath, envInt } from "./momentum-runtime.js";
 import type { LLMProvider } from "../types.js";
-
-const HERE = dirname(fileURLToPath(import.meta.url)); // dist/intelligence
-const REPO_ROOT = resolve(HERE, "..", ".."); // <sportsclaw>
-
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
-}
-
-/**
- * The macOS cert fix: Python's urllib doesn't trust the system keychain, so a
- * live HTTPS fetch to ESPN/Kalshi fails with a cert error unless SSL_CERT_FILE
- * points at certifi's bundle. Compute it once and thread it into the subprocess
- * env, alongside PYTHONPATH.
- */
-function certifiPath(pythonPath: string): string | undefined {
-  try {
-    return execFileSync(pythonPath, ["-c", "import certifi; print(certifi.where())"], {
-      encoding: "utf8",
-    }).trim();
-  } catch {
-    return undefined;
-  }
-}
 
 async function main(): Promise<void> {
   const sport = (process.env.MOMENTUM_SPORT ?? process.argv[2] ?? "").toLowerCase();

--- a/src/intelligence/momentum-replay.ts
+++ b/src/intelligence/momentum-replay.ts
@@ -27,16 +27,12 @@
  *   SPORTSCLAW_PROVIDER / SPORTSCLAW_MODEL / SPORTSCLAW_EVALUATOR_MODEL
  */
 
-import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { executePythonBridge } from "../tools.js";
 import { MomentumExplainer } from "./momentum-explainer.js";
+import { REPO_ROOT, certifiPath, envInt, unwrapBridge } from "./momentum-runtime.js";
 import type { LLMProvider, WatchEvent } from "../types.js";
-
-const HERE = dirname(fileURLToPath(import.meta.url)); // dist/intelligence
-const REPO_ROOT = resolve(HERE, "..", ".."); // <sportsclaw>
 
 // ---------------------------------------------------------------------------
 // Pure pieces (exported for tests)
@@ -131,45 +127,6 @@ export function swingToWatchEvent(
 // Runner
 // ---------------------------------------------------------------------------
 
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
-}
-
-/** The macOS cert fix (same as momentum-live): certifi bundle for urllib. */
-function certifiPath(pythonPath: string): string | undefined {
-  try {
-    return execFileSync(pythonPath, ["-c", "import certifi; print(certifi.where())"], {
-      encoding: "utf8",
-    }).trim();
-  } catch {
-    return undefined;
-  }
-}
-
-/** Unwrap a bridge result's inner sports-skills payload, or throw. */
-function bridgeData(
-  result: { success: boolean; data?: unknown; error?: string },
-  what: string,
-): Record<string, unknown> {
-  const envelope =
-    result.success && result.data && typeof result.data === "object"
-      ? (result.data as Record<string, unknown>)
-      : null;
-  if (!envelope || envelope.status !== true) {
-    const msg =
-      (envelope && String(envelope.message ?? "")) || result.error || "unknown error";
-    throw new Error(`${what} failed: ${msg}`);
-  }
-  const data = envelope.data;
-  if (!data || typeof data !== "object") {
-    throw new Error(`${what} returned no data`);
-  }
-  return data as Record<string, unknown>;
-}
-
 async function main(): Promise<void> {
   const sport = (process.env.MOMENTUM_SPORT ?? process.argv[2] ?? "").toLowerCase();
   const eventId = process.env.MOMENTUM_EVENT_ID ?? process.argv[3] ?? "";
@@ -205,7 +162,7 @@ async function main(): Promise<void> {
   );
 
   // 1. ESPN event → Kalshi winner market (settled markets included).
-  const market = bridgeData(
+  const market = unwrapBridge(
     await executePythonBridge(
       "markets",
       "resolve_game_market",
@@ -227,7 +184,7 @@ async function main(): Promise<void> {
     Math.floor(Date.now() / 1000),
     startSec + 600 + 6 * 3600,
   );
-  const history = bridgeData(
+  const history = unwrapBridge(
     await executePythonBridge(
       "markets",
       "get_price_history",

--- a/src/intelligence/momentum-runtime.ts
+++ b/src/intelligence/momentum-runtime.ts
@@ -1,0 +1,65 @@
+/**
+ * sportsclaw — shared runtime helpers for the Momentum Explainer pipeline and
+ * its demo/live/replay runners. Extracted so the bridge-envelope contract and
+ * the runner boilerplate live in ONE place (they were copy-pasted across the
+ * three runners and re-implemented inline in the explainer).
+ */
+
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** The sportsclaw repo root, resolved from this module's built location. */
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", ".."); // dist/intelligence -> <sportsclaw>
+
+/** Positive-integer env var with a fallback (ignores blank/invalid/<=0). */
+export function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * The macOS cert fix: certifi bundle path for Python urllib, or undefined.
+ * execFileSync with an argv array (never a shell string) so a pythonPath
+ * carrying shell metacharacters can't be interpolated into a command.
+ */
+export function certifiPath(pythonPath: string): string | undefined {
+  try {
+    return execFileSync(pythonPath, ["-c", "import certifi; print(certifi.where())"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Unwrap a Python-bridge result, enforcing the sports-skills
+ * `{status, data, message}` envelope — NOT just the process-level `success`
+ * flag. The bridge exits 0 and reports `success: true` for any parseable
+ * stdout, so a skill that returned `status: false` (or an empty-but-valid
+ * envelope) would otherwise be read as a valid empty payload. Throws with the
+ * skill's own message on `status !== true` or missing data; `what` labels the
+ * call site.
+ */
+export function unwrapBridge(
+  result: { success: boolean; data?: unknown; error?: string },
+  what: string,
+): Record<string, unknown> {
+  const envelope =
+    result.success && result.data && typeof result.data === "object"
+      ? (result.data as Record<string, unknown>)
+      : null;
+  if (!envelope || envelope.status !== true) {
+    const msg =
+      (envelope && String(envelope.message ?? "")) || result.error || "unknown error";
+    throw new Error(`${what} failed: ${msg}`);
+  }
+  const data = envelope.data;
+  if (!data || typeof data !== "object") {
+    throw new Error(`${what} returned no data`);
+  }
+  return data as Record<string, unknown>;
+}

--- a/test/momentum-evaluator.test.mjs
+++ b/test/momentum-evaluator.test.mjs
@@ -136,11 +136,12 @@ function makeEvent({ before = 42, after = 68 } = {}) {
 }
 
 /** Build an explainer with injected models and capturing sinks. */
-function makeExplainer({ gen, checker, maxAttempts = 2 }) {
+function makeExplainer({ gen, checker, maxAttempts = 2, mode = "mock", pythonPath }) {
   const emitted = [];
   const rejected = [];
   const explainer = new MomentumExplainer({
-    mode: "mock",
+    mode,
+    pythonPath,
     direction: "up",
     thresholdCents: 10,
     evaluate: true,
@@ -305,6 +306,43 @@ describe("produceCard loop (thrown-error handling)", () => {
     assert.equal(emitted.length, 1);
     assert.equal(emitted[0].verdict.verdict, "pass");
     assert.equal(emitted[0].verdict.attempts, 2, "passed on the second attempt");
+  });
+
+  it("holds the swing when live play resolution fails — never drops it, never generates", async () => {
+    // A generator + checker that WOULD produce and approve a card, so a
+    // regression that swallowed the resolution failure (or read it as an empty
+    // play window) would emit a card here instead of holding the swing.
+    const gen = constModel("C.Lawrence's 45-yard TD to B.Thomas moved the home price up 26 points.");
+    const checker = constModel(verdictJson({ claim: true, noHall: true, dir: true }));
+    // mode "live" calls get_plays_near_timestamp over the Python bridge; an
+    // interpreter path that cannot exist makes that call fail locally and
+    // deterministically (ENOENT), with no network and no credentials.
+    const { explainer, emitted, rejected } = makeExplainer({
+      gen,
+      checker,
+      mode: "live",
+      pythonPath: "/nonexistent/sportsclaw-test-python3",
+    });
+
+    await explainer.injectEvent(makeEvent());
+
+    assert.equal(emitted.length, 0, "no card ships when the play window cannot be resolved");
+    assert.equal(rejected.length, 1, "the swing is HELD for review, not silently dropped");
+    assert.equal(explainer.cardsRejected, 1);
+    assert.equal(gen.state.calls, 0, "the generator is never asked to write about plays we don't have");
+    assert.equal(checker.state.calls, 0, "the checker is never reached either");
+
+    const held = rejected[0];
+    assert.equal(held.source, "espn-live", "provenance of the failed live lookup is preserved");
+    assert.equal(held.causePlay, null, "no cause play is fabricated");
+    assert.equal(held.verdict.verdict, "reject");
+    assert.equal(held.verdict.checks.hasCause, false);
+    assert.match(
+      held.verdict.reasons.join(" "),
+      /get_plays_near_timestamp failed/i,
+      "the bridge failure is surfaced as the hold reason",
+    );
+    assert.equal(held.verdict.attempts, 0, "the LLM retry loop was never entered");
   });
 
   it("skips a tick whose snapshot reports a feed error (status:false)", async () => {

--- a/test/momentum-evaluator.test.mjs
+++ b/test/momentum-evaluator.test.mjs
@@ -53,6 +53,37 @@ function textModel(nextText) {
 /** Constant-text model (the generator: its exact wording is not under test). */
 const constModel = (text) => textModel(() => text);
 
+/** A model whose first `throwUntilCall` invocations throw, then returns `text`. */
+function flakyModel(throwUntilCall, text) {
+  const state = { calls: 0 };
+  const model = new MockLanguageModelV3({
+    doGenerate: async () => {
+      const i = state.calls;
+      state.calls += 1;
+      if (i < throwUntilCall) throw new Error("transient provider timeout");
+      return {
+        content: [{ type: "text", text }],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+        warnings: [],
+      };
+    },
+  });
+  return { model, state };
+}
+
+/** A model that always throws (simulates a down/timed-out provider). */
+function throwingModel(message) {
+  const state = { calls: 0 };
+  const model = new MockLanguageModelV3({
+    doGenerate: async () => {
+      state.calls += 1;
+      throw new Error(message);
+    },
+  });
+  return { model, state };
+}
+
 /** A checker verdict as the JSON the skeptic is prompted to emit. */
 const verdictJson = ({ claim = true, noHall = true, dir = true, reasons = [] }) =>
   JSON.stringify({
@@ -231,5 +262,67 @@ describe("produceCard loop (injected generator + semantic checker)", () => {
       /no parseable verdict/i,
       "the fail-closed reason is recorded for diagnosis",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Thrown-error handling — a generator/evaluator exception (incl. an LLM
+// timeout) must fail CLOSED: held for review, never silently dropped, and
+// never allowed to abandon the retry budget. (Regression guard for the review
+// finding where a thrown error bypassed both the retry loop and the inbox.)
+// ---------------------------------------------------------------------------
+
+describe("produceCard loop (thrown-error handling)", () => {
+  it("holds the swing when the generator throws on every attempt — never drops it", async () => {
+    const gen = throwingModel("anthropic 529 overloaded");
+    const checker = constModel(verdictJson({})); // never reached — gen throws first
+    const { explainer, emitted, rejected } = makeExplainer({ gen, checker, maxAttempts: 2 });
+
+    await explainer.injectEvent(makeEvent());
+
+    assert.equal(emitted.length, 0, "no card ships when generation fails");
+    assert.equal(rejected.length, 1, "the swing is HELD for review, not silently dropped");
+    assert.equal(rejected[0].verdict.verdict, "reject");
+    assert.match(rejected[0].verdict.reasons.join(" "), /generation failed/i);
+    assert.match(rejected[0].verdict.reasons.join(" "), /529 overloaded/, "the error is surfaced");
+    assert.equal(explainer.cardsRejected, 1);
+    assert.equal(gen.state.calls, 2, "the full retry budget was spent before holding");
+    assert.equal(checker.state.calls, 0, "the checker is never reached when the generator throws");
+  });
+
+  it("recovers when an early attempt throws but a later one succeeds", async () => {
+    // Generator throws once, then returns a good card; checker approves it.
+    const gen = flakyModel(
+      1,
+      "C.Lawrence's 45-yard TD to B.Thomas moved the home price up 26 points.",
+    );
+    const checker = constModel(verdictJson({ claim: true, noHall: true, dir: true }));
+    const { explainer, emitted, rejected } = makeExplainer({ gen, checker, maxAttempts: 3 });
+
+    await explainer.injectEvent(makeEvent());
+
+    assert.equal(rejected.length, 0, "a transient error on attempt 1 doesn't abandon the swing");
+    assert.equal(emitted.length, 1);
+    assert.equal(emitted[0].verdict.verdict, "pass");
+    assert.equal(emitted[0].verdict.attempts, 2, "passed on the second attempt");
+  });
+
+  it("skips a tick whose snapshot reports a feed error (status:false)", async () => {
+    const gen = constModel("should never be generated");
+    const checker = constModel(verdictJson({}));
+    const { explainer, emitted, rejected } = makeExplainer({ gen, checker });
+
+    await explainer.injectEvent({
+      timestamp: "2026-07-01T18:08:00Z",
+      changesSummary: "feed error",
+      changes: [
+        { path: "data.polymarket_home_price_cents", type: "modified", before: 42, after: 68 },
+      ],
+      snapshot: { status: false, message: "ESPN 503" },
+    });
+
+    assert.equal(emitted.length, 0);
+    assert.equal(rejected.length, 0, "a feed-error tick is skipped, not turned into a card or a reject");
+    assert.equal(gen.state.calls, 0, "the generator is never consulted for an error tick");
   });
 });

--- a/test/momentum-evaluator.test.mjs
+++ b/test/momentum-evaluator.test.mjs
@@ -21,7 +21,10 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { MockLanguageModelV3 } from "ai/test";
 
-import { MomentumExplainer } from "../dist/intelligence/momentum-explainer.js";
+import {
+  LLM_CALL_TIMEOUT_MS,
+  MomentumExplainer,
+} from "../dist/intelligence/momentum-explainer.js";
 import { DEFAULT_MODELS } from "../dist/types.js";
 import { DEFAULT_EVALUATOR_MODELS } from "../dist/intelligence/momentum-evaluator.js";
 
@@ -31,14 +34,16 @@ import { DEFAULT_EVALUATOR_MODELS } from "../dist/intelligence/momentum-evaluato
 
 /**
  * A language model whose text output is produced by `nextText(callIndex)`.
- * `calls` counts invocations so a test can assert the retry budget was spent.
+ * `calls` counts invocations so a test can assert the retry budget was spent;
+ * `options` records what each call was invoked with (e.g. the abort signal).
  */
 function textModel(nextText) {
-  const state = { calls: 0 };
+  const state = { calls: 0, options: [] };
   const model = new MockLanguageModelV3({
-    doGenerate: async () => {
+    doGenerate: async (options) => {
       const text = nextText(state.calls);
       state.calls += 1;
+      state.options.push(options);
       return {
         content: [{ type: "text", text }],
         finishReason: "stop",
@@ -208,6 +213,27 @@ describe("produceCard loop (injected generator + semantic checker)", () => {
     assert.equal(explainer.cardsEmitted, 1);
     assert.equal(gen.state.calls, 1, "one generation on a first-try pass");
     assert.equal(checker.state.calls, 1, "the skeptic was actually consulted");
+  });
+
+  it("passes a live abort signal to BOTH the generator and the evaluator", async () => {
+    const gen = constModel(
+      "C.Lawrence's 45-yard TD to B.Thomas flipped the home price up 26 points.",
+    );
+    const checker = constModel(verdictJson({ claim: true, noHall: true, dir: true }));
+    const { explainer, emitted } = makeExplainer({ gen, checker });
+
+    await explainer.injectEvent(makeEvent());
+
+    assert.equal(emitted.length, 1, "the pass path ran, so both calls were made");
+    assert.ok(
+      Number.isInteger(LLM_CALL_TIMEOUT_MS) && LLM_CALL_TIMEOUT_MS > 0,
+      "the timeout ceiling is a positive finite integer",
+    );
+    for (const [label, state] of [["generator", gen.state], ["evaluator", checker.state]]) {
+      const signal = state.options[0]?.abortSignal;
+      assert.ok(signal instanceof AbortSignal, `${label} call receives an AbortSignal`);
+      assert.equal(signal.aborted, false, `${label} signal is still live well inside the ceiling`);
+    }
   });
 
   it("holds a card the skeptic rejects — never emits it — after exhausting attempts", async () => {

--- a/test/momentum-explainer.test.mjs
+++ b/test/momentum-explainer.test.mjs
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { detectSwings } from "../dist/intelligence/momentum-explainer.js";
+import { unwrapBridge } from "../dist/intelligence/momentum-runtime.js";
 import {
   runHardGates,
   evaluateCard,
@@ -81,6 +82,15 @@ describe("detectSwings", () => {
     assert.equal(detectSwings([priceChange("x", 68)], 10, "up").length, 0);
   });
 
+  it("ignores empty-book sentinel prices (0c) so a recovery can't fake a swing", () => {
+    // An empty Kalshi book resolves to 0c; the recovery tick (0 -> 60) must NOT
+    // register as a +60 phantom swing, and a drop into an empty book must not either.
+    assert.equal(detectSwings([priceChange(0, 60)], 10, "up").length, 0);
+    assert.equal(detectSwings([priceChange(60, 0)], 10, "both").length, 0);
+    // A genuine 1c -> 60c move is still a real swing (1 is a valid live price).
+    assert.equal(detectSwings([priceChange(1, 60)], 10, "up").length, 1);
+  });
+
   it("fires on any path ending in home_price_cents (mock + live feeds)", () => {
     // The source-neutral suffix matches both the mock's polymarket-prefixed
     // key and the live Kalshi feed's bare home_price_cents.
@@ -90,6 +100,39 @@ describe("detectSwings", () => {
       assert.equal(swings[0].delta, 26);
       assert.equal(swings[0].path, path);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unwrapBridge — enforce the sports-skills {status,data} envelope
+// ---------------------------------------------------------------------------
+
+describe("unwrapBridge", () => {
+  it("returns the inner data on a status:true envelope", () => {
+    const result = { success: true, data: { status: true, data: { plays: [1, 2] } } };
+    assert.deepEqual(unwrapBridge(result, "get_plays_near_timestamp"), { plays: [1, 2] });
+  });
+
+  it("throws (never silently empties) when the skill reported status:false", () => {
+    const result = { success: true, data: { status: false, message: "no game found" } };
+    assert.throws(
+      () => unwrapBridge(result, "get_plays_near_timestamp"),
+      /get_plays_near_timestamp failed: no game found/,
+    );
+  });
+
+  it("throws when the process failed outright", () => {
+    assert.throws(
+      () => unwrapBridge({ success: false, error: "python crashed" }, "resolve_game_market"),
+      /resolve_game_market failed: python crashed/,
+    );
+  });
+
+  it("throws when status:true carries no data object", () => {
+    assert.throws(
+      () => unwrapBridge({ success: true, data: { status: true } }, "get_live_tick"),
+      /get_live_tick returned no data/,
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up review fixes for the Momentum & Price Explainer pipeline merged in #135. Companion: machina-sports/sports-skills#96 (data layer).

These came out of a multi-agent code review of #135 that finished after the merge landed. The headline fix protects the part of #135 that matters most — the independent evaluator gate.

## Fixes

### 1. The fail-closed hole (the important one)
`produceCard` promised that a card rejected on every attempt is routed to `onRejected` and "never emitted as good". That held only for **returned reject verdicts** — not for **exceptions**.

The `try/catch` sat in `handleEvent`, *outside* the retry loop, while `onRejected` was only reached from inside `produceCard`. So a thrown generator/evaluator error (provider 5xx, network drop, timeout) exited `produceCard` entirely: the retry budget was abandoned **and** the swing never reached the inbox — it vanished into a `console.error`.

Now each attempt is individually wrapped: an error is logged, the loop continues to the next attempt, and on exhaustion the swing is **always** held. When every attempt threw before producing a draft, a synthetic held card carries the error as its reject reason, so the swing is visible in the inbox rather than silently dropped.

### 2. No timeout on either LLM call
Neither `generateText` call passed an `abortSignal`, so a hung provider response would block the poll loop indefinitely — and with it `WatchManager.stopAll()`, wedging graceful shutdown.

Both the generator and the evaluator now pass `AbortSignal.timeout(LLM_CALL_TIMEOUT_MS)` (60s). A timeout throws and is handled by fix 1 — retried, then held closed.

### 3. Phantom swings from an empty order book
An empty Kalshi book resolves to `0c`. `detectSwings` only rejected non-finite values, so a transient empty tick and its recovery (`0 -> 60`) registered as a real +60 up-swing — and because the cited play genuinely *is* in the window, the evaluator would pass the resulting card. A fabricated momentum story with a real play attached.

Ticks where either side is `0` are now skipped. A genuine `1c -> 60c` move is still a real swing.

### 4. Bridge error envelopes were swallowed
The Python bridge exits 0 and reports `success: true` for any parseable stdout, so a skill returning `{status: false, message: ...}` was read as a valid payload. `resolvePlays` degraded a real ESPN failure into an **empty play window** (an unverifiable card), and `handleEvent` treated an error snapshot as a legitimate price update.

Both now enforce the `{status, data}` envelope via a shared `unwrapBridge`, matching the pattern `momentum-replay.ts` already had in `bridgeData`. Error snapshots are skipped at the momentum layer, leaving core `watch.ts` semantics untouched for other watchers.

### 5. Cleanup
- New `src/intelligence/momentum-runtime.ts` holds `unwrapBridge` plus the `envInt` / `certifiPath` / `REPO_ROOT` boilerplate that was copy-pasted across all three runners (and re-implemented inline in the explainer).
- Doc-note distinguishing this hard, fail-closed `momentum-evaluator.ts` from the soft, non-blocking `src/evaluator.ts` — same word, opposite contract.

## Preserved from the #135 merge
This branch keeps all three hardening fixes applied during the merge review, verified explicitly:
- **`execFileSync` with an argv array** (never a shell string) — carried into the shared `certifiPath`, so the refactor does not reintroduce the `execSync` interpolation. Zero `execSync(` remain in `src/intelligence/`.
- **Maker/checker enforcement** — the constructor throw when evaluator model == generator model.
- **Distinct `DEFAULT_EVALUATOR_MODELS`** literals and the test pinning them apart from `DEFAULT_MODELS`.

## Tests
+8 deterministic tests (mocked models, no network):
- a thrown generator error on every attempt is **held**, spends the full retry budget, and surfaces the error
- a throw on attempt 1 followed by success still emits (transient errors do not abandon the swing)
- a `status: false` feed tick is skipped, never becoming a card or a reject
- empty-book `0c` guard, including that a real `1c` move still fires
- the `unwrapBridge` envelope contract (status false / process failure / missing data)

| Suite | Before | After |
|---|---|---|
| `npm run test:momentum` | 23 | **31** |
| Full `node --test test/*.test.mjs` | 949 | **957** |

`npm run build` clean.

Note: `Vault REST and tail permissions are local and path-scoped` fails on `main` today, before and after this branch — pre-existing and unrelated to momentum.

## Deferred
The two performance findings (the Kalshi market re-resolved via a fresh keyword search every poll, and the ESPN summary fetched twice per swing) are **not** addressed here. `Watcher.poll()` spawns a fresh Python subprocess per poll, so no in-process or module-level cache survives between ticks — the honest fix is a persistent price worker rather than a cache that dies with the process. Worth folding into the operator/scheduler direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)