### PR TITLE
test(openshell): sync the vault policy assertions with the shipped policy (unblocks CI)

### DIFF
--- a/test/openshell-policies.test.mjs
+++ b/test/openshell-policies.test.mjs
@@ -38,7 +38,11 @@ test("connected TV policy remains the existing external profile", () => {
 
 test("Vault REST and tail permissions are local and path-scoped", () => {
   const policy = loadPolicy("policy.vault.yaml");
+  // Exhaustive on purpose: a new egress policy must be a deliberate edit here.
+  // `espn` is the read-only site.api.espn.com egress the live cfb skills need;
+  // the local-and-path-scoped assertions below cover only the vault_* entries.
   assert.deepEqual(Object.keys(policy.network_policies).sort(), [
+    "espn",
     "vault_pod_mcp",
     "vault_runtime_rest",
     "vault_tail_bus",
@@ -47,7 +51,14 @@ test("Vault REST and tail permissions are local and path-scoped", () => {
   const expectedHosts = ["172.17.0.1", "host.docker.internal"];
   const cases = [
     ["vault_tail_bus", 8193, ["GET /events", "POST /ingest"]],
-    ["vault_runtime_rest", 5103, ["POST /document", "POST /document/retrieve"]],
+    [
+      "vault_runtime_rest",
+      5103,
+      // Listed exhaustively so widening the runtime's write surface stays a
+      // deliberate edit. search + wildcard update were added alongside the
+      // document-search/update policy change.
+      ["POST /document", "POST /document/retrieve", "POST /document/search", "PUT /document/*"],
+    ],
   ];
 
   for (const [name, port, rules] of cases) {
@@ -62,10 +73,31 @@ test("Vault REST and tail permissions are local and path-scoped", () => {
     }
   }
 
-  const allHosts = Object.values(policy.network_policies)
-    .flatMap((entry) => entry.endpoints)
+  // The vault_* surfaces stay loopback-only. `espn` is the one deliberate
+  // exception — read-only egress to site.api.espn.com for the live cfb skills,
+  // asserted by the sibling sandbox-egress test — so scope this to vault_*
+  // rather than dropping the invariant.
+  const vaultHosts = Object.entries(policy.network_policies)
+    .filter(([name]) => name.startsWith("vault_"))
+    .flatMap(([, entry]) => entry.endpoints)
     .map((endpoint) => endpoint.host);
-  assert.ok(allHosts.every((host) => expectedHosts.includes(host)));
+  assert.ok(vaultHosts.length > 0, "expected vault_* network policies to exist");
+  assert.ok(vaultHosts.every((host) => expectedHosts.includes(host)));
+
+  // And the only non-vault egress is the read-only ESPN host set — listed
+  // exhaustively so adding a host, or making one writable, is a deliberate edit.
+  const nonVault = Object.entries(policy.network_policies)
+    .filter(([name]) => !name.startsWith("vault_"))
+    .flatMap(([, entry]) => entry.endpoints);
+  assert.deepEqual(
+    [...new Set(nonVault.map((endpoint) => endpoint.host))].sort(),
+    ["site.api.espn.com", "site.web.api.espn.com", "sports.core.api.espn.com", "www.espn.com"],
+  );
+  for (const endpoint of nonVault) {
+    assert.equal(endpoint.access, "read-only");
+    assert.equal(endpoint.enforcement, "enforce");
+    assert.equal(endpoint.port, 443);
+  }
 });
 
 test("Vault MCP permits only the FastMCP SSE transport routes", () => {


### PR DESCRIPTION
CI has been red on `main` — and therefore on **every open PR** — since the vault policy grew. `test/openshell-policies.test.mjs` had three stale assertions, from two separate policy commits. None is a product bug: the policy changes were deliberate, the test just was not updated with them.

This test exists to make permission changes deliberate and visible, so each assertion is re-stated explicitly rather than loosened.

## What was stale

**1. `network_policies` key list** omitted `espn` — added by `feat(policy): ESPN read-only egress for the vault sandbox (cfb live skills)`.

**2. `vault_runtime_rest` route list** omitted `POST /document/search` and `PUT /document/*` — added by `feat(policy): vault runtime REST allows document search + update`.

**3. "every host is loopback" no longer held.** The ESPN egress is intentionally external, so this invariant genuinely changed. Rather than delete it, it is now scoped to where it still applies:

- `vault_*` policies must be loopback-only (`172.17.0.1`, `host.docker.internal`) — unchanged guarantee, now stated precisely
- the non-vault surface is asserted separately as **exactly** the four read-only ESPN hosts (`site.api.espn.com`, `site.web.api.espn.com`, `sports.core.api.espn.com`, `www.espn.com`), each pinned to `access: read-only`, `enforcement: enforce`, `port: 443`

Net effect: same guarantees, stated where they apply. Adding an egress host, making one writable, or widening the vault runtime routes still fails the test.

## Reviewer note

This ratifies a permission set that already shipped — notably `PUT /document/*` (wildcard write on the vault runtime) and four external ESPN hosts. The code is unchanged; only the assertions move. Worth a glance to confirm that surface is what you intend, since after this the test will no longer flag it.

## Verification

- `test/openshell-policies.test.mjs` → 3/3
- full `node --test test/*.test.mjs` → **949/949**, twice
- `npm run build` clean

`DurableStateStore Substrate` is separately flaky under the parallel full run (passes 3/3 in isolation, and the full suite passed twice after). Unrelated to this change and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)