### PR TITLE
fix(config): load persisted env before CLI routing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2889,6 +2889,11 @@ function cmdAnalytics(args: string[], _opts?: { fromChat?: boolean }): void {
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
+  // Load ~/.sportsclaw/.env and persisted config into process.env before any
+  // routing, so every command sees the same precedence (shell env > .env >
+  // config.json). Commands like `doctor` and `health` read process.env directly.
+  applyConfigToEnv();
+
   if (args.includes("--help") || args.includes("-h")) {
     printHelp();
     process.exit(0);

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -30,6 +30,74 @@ function runResolveConfigWithHome(home, extraEnv = {}) {
   return JSON.parse(stdout);
 }
 
+function runCliWithHome(cliArgs, home, extraEnv = {}) {
+  const env = {
+    ...process.env,
+    HOME: home,
+    ...extraEnv,
+  };
+  // Strip shell-level provider/Foundry values so only HOME-persisted config counts.
+  for (const key of [
+    "AZURE_FOUNDRY_BASE_URL",
+    "AZURE_FOUNDRY_API_MODE",
+    "AZURE_FOUNDRY_AUTH_MODE",
+    "AZURE_FOUNDRY_API_KEY",
+    "SPORTSCLAW_PROVIDER",
+    "SPORTSCLAW_MODEL",
+  ]) {
+    delete env[key];
+  }
+
+  try {
+    return execFileSync(process.execPath, ["dist/index.js", ...cliArgs], {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // `health --json` exits 1 when status is "down" — the payload is still on stdout.
+    if (typeof err.stdout === "string" && err.stdout.length > 0) return err.stdout;
+    throw err;
+  }
+}
+
+describe("CLI config preflight", () => {
+  it("loads ~/.sportsclaw/.env before running `health --json`", () => {
+    const home = mkdtempSync(join(tmpdir(), "sportsclaw-preflight-"));
+    try {
+      const dir = join(home, ".sportsclaw");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "config.json"),
+        JSON.stringify({ provider: "azure-foundry", model: "gpt-5.2" }, null, 2),
+      );
+      writeFileSync(
+        join(dir, ".env"),
+        [
+          "AZURE_FOUNDRY_BASE_URL=https://fake-foundry.invalid/openai/v1",
+          "AZURE_FOUNDRY_API_MODE=responses",
+          "AZURE_FOUNDRY_AUTH_MODE=entra_id",
+          "",
+        ].join("\n"),
+      );
+
+      const stdout = runCliWithHome(["health", "--json"], home);
+      const payload = JSON.parse(stdout);
+
+      assert.strictEqual(payload.config.provider, "azure-foundry");
+      assert.strictEqual(payload.config.azureFoundryBaseUrlConfigured, true);
+      assert.strictEqual(payload.config.azureFoundryAuthMode, "entra_id");
+      assert.deepStrictEqual(
+        payload.errors.filter((e) => e.includes("AZURE_FOUNDRY_BASE_URL")),
+        [],
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("resolveConfig", () => {
   it("does not reuse a persisted API key when SPORTSCLAW_PROVIDER overrides the persisted provider", () => {
     const home = mkdtempSync(join(tmpdir(), "sportsclaw-config-"));


### PR DESCRIPTION
## Summary
- load the managed SportsClaw dotenv before every CLI route
- make doctor and health honor Foundry settings written by the existing config wizard
- add an isolated temporary-HOME regression test

## Verification
- RED: health reported azureFoundryBaseUrlConfigured=false from a populated managed .env
- GREEN: targeted config/health tests 4/4
- full suite 968/968
- independent spec and quality reviews passed for 678ce5fafa5d125e21b0f10068d6a1839c53f1b0

No real keys or network calls are used by the test.