### PR TITLE
chore(release): v0.29.2 reliability and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,14 @@ For deployments that want sandboxed execution and policy-enforced LLM routing, S
 
 ### Built-in Sports Data Skills
 
-sportsclaw ships with **20 skills** out of the box, powered by [`sports-skills`](https://sports-skills.sh):
+sportsclaw ships with **14 default sports and six default support modules** out of the box, powered by [`sports-skills`](https://sports-skills.sh):
 
-- **Sports data** — `football` `nfl` `nba` `nhl` `mlb` `wnba` `tennis` `cfb` `cbb` `golf` `f1` `cricket` `volleyball` `xctf`
+- **Sports data (14 default)** — `football` `nfl` `nba` `nhl` `mlb` `wnba` `tennis` `cfb` `cbb` `golf` `f1` `cricket` `volleyball` `xctf`
 - **Prediction markets & analysis** — `kalshi` `polymarket` `markets` (unified ESPN ↔ Kalshi ↔ Polymarket) `betting` (de-vig, edge, Kelly, arbitrage)
 - **Utility** — `news` `metadata` (team/player logos & badges)
+- **Optional add-ons** — `esports` and `polymarket-trading`, installed on request with `sportsclaw add <name>`
+
+Run `sportsclaw list` (or `sportsclaw list --json`) to see exactly what's installed locally and how many tools it exposes.
 
 Skills are auto-discovered from the installed `sports-skills` package, so the set stays in sync as it grows. When a free public API rate-limits a request, results carry an `upgrade` signal and sportsclaw surfaces the licensed / real-time option via [`sports-skills premium`](https://docs.machina.gg/).
 

--- a/demo/vault_data/README.md
+++ b/demo/vault_data/README.md
@@ -2,6 +2,11 @@
 
 Static mock data for the Momentum & Price Explainer loop demo.
 
+For what evidence actually backs each of the seven momentum sports — and why no sport
+is currently live-certified — see the certification artifact:
+[`docs/sports-data/momentum-certification.md`](../../docs/sports-data/momentum-certification.md)
+(machine-readable source: [`docs/sports-data/momentum-certification.json`](../../docs/sports-data/momentum-certification.json)).
+
 ## Cross-sport fixtures (2026-07-18)
 
 The momentum pipeline's `markets` connector is already sport-parametric

--- a/docs/sports-data/coverage.md
+++ b/docs/sports-data/coverage.md
@@ -1,7 +1,9 @@
 # Coverage
 
-sportsclaw comes with live data for 14 sports plus odds and prediction markets — all keyless
-for the data itself. You don't wire up feeds or manage API keys; you just ask.
+sportsclaw comes with live data for 14 default sports plus six default support modules for
+odds, prediction markets, news and metadata — all keyless for the data itself. You don't wire
+up feeds or manage API keys; you just ask. Esports and Polymarket trading are optional
+add-ons you install when you want them.
 
 <div class="tip custom-block"><p class="custom-block-title">Powered by sports-skills</p>
 
@@ -28,6 +30,8 @@ pods. Connect a Machina pod in one command with `sportsclaw machina connect`.
 Typical questions each can answer: live and recent scores, standings, schedules, rosters,
 player stats, play-by-play, and news — availability varies a little by sport.
 
+**Optional:** 🎮 Esports isn't installed by default — add it with `sportsclaw add esports`.
+
 ## Markets & analysis
 
 | Source | What it gives you |
@@ -36,6 +40,9 @@ player stats, play-by-play, and news — availability varies a little by sport.
 | **Kalshi** | Event-market prices |
 | **Polymarket** | Prediction-market odds |
 | **Betting tools** | Edge, de-vig, Kelly, arbitrage math |
+
+**Optional:** Polymarket trading (order placement) ships as a separate module — add it with
+`sportsclaw add polymarket-trading`.
 
 See **[Odds & Prediction Markets](./odds-and-markets)** for how to use these together.
 

--- a/docs/sports-data/momentum-certification.json
+++ b/docs/sports-data/momentum-certification.json
@@ -1,0 +1,162 @@
+{
+  "artifact": "momentum-seven-sport-certification",
+  "version": 1,
+  "generatedAt": "2026-08-08T14:29:13Z",
+  "statement": "Synthetic fixture evidence proves the momentum pipeline's mechanics only (swing detection, card generation, evaluator gate). The live-reported evidence for MLB and WNBA is historical, recorded in PR #135, and its complete run receipts (exact run timestamp, latency, and for MLB the output/evaluator counts) were not retained. Fresh revalidation on 2026-08-08 was blocked for both. Therefore no row is currently live-certified.",
+  "revalidationPolicy": "A row may move to live certification only when a single fresh run produces, together: an ESPN event id, a resolved Kalshi market, a non-empty price series, an output verdict, an evaluator verdict, and a measured latency — all captured in one receipt.",
+  "sports": [
+    {
+      "sport": "nfl",
+      "evidenceType": "synthetic",
+      "certificationStatus": "pending-live",
+      "evidenceRecordedAt": null,
+      "espnEventId": null,
+      "marketResolution": null,
+      "outputVerdict": "card-generated",
+      "evaluatorVerdict": "accepted",
+      "latencyMs": null,
+      "fixturePath": "demo/vault_data/mock_game.json",
+      "receiptSources": [
+        "demo/vault_data/mock_game.json",
+        "demo/vault_data/README.md",
+        "https://github.com/machina-sports/sportsclaw/pull/135"
+      ],
+      "pendingLive": true,
+      "notes": "JAX @ HOU synthetic 3-tick timeline (42 -> 43 -> 68 cents). Run end-to-end through momentum-demo.js; the card was accepted by the evaluator. Offline fixture, so this proves mechanics only. The original run timestamp and latency were not retained."
+    },
+    {
+      "sport": "mlb",
+      "evidenceType": "live-reported",
+      "certificationStatus": "pending-live-revalidation",
+      "evidenceRecordedAt": "2026-07-18T15:44:32Z",
+      "espnEventId": "401872178",
+      "marketResolution": {
+        "source": "kalshi",
+        "ticker": "KXMLBGAME-26JUL171335TBBOSG1-BOS",
+        "provenance": "referenced by test/momentum-replay.test.mjs, not read back from a retained run receipt"
+      },
+      "outputVerdict": "not-retained",
+      "evaluatorVerdict": "not-retained",
+      "latencyMs": null,
+      "fixturePath": null,
+      "receiptSources": [
+        "https://github.com/machina-sports/sportsclaw/pull/135",
+        "commit 21ec5b8854150e067146262df7f0dae1e878e9fe",
+        "test/momentum-replay.test.mjs"
+      ],
+      "pendingLive": true,
+      "notes": "PR #135 reports live runs for BOS/TB game 1 and LAD @ NYY. The ESPN event id and Kalshi ticker recorded here come from the replay test fixture frame, not from a retained run receipt. The original output counts, evaluator counts, exact run timestamp and latency were not retained, so this row is a historical report rather than a certified receipt.",
+      "revalidation": {
+        "recordedAt": "2026-08-08T14:29:13Z",
+        "command": "node dist/intelligence/momentum-replay.js mlb 401872178",
+        "status": "blocked",
+        "observedResult": "Run failed: no Kalshi winner market resolved for ESPN event 401872178. A follow-up MLB scoreboard discovery call also returned ESPN HTTP 403, so no alternate live event could be selected."
+      }
+    },
+    {
+      "sport": "nba",
+      "evidenceType": "synthetic",
+      "certificationStatus": "pending-live",
+      "evidenceRecordedAt": "2026-07-18T15:44:32Z",
+      "espnEventId": null,
+      "marketResolution": null,
+      "outputVerdict": "card-generated",
+      "evaluatorVerdict": "accepted",
+      "latencyMs": null,
+      "fixturePath": "demo/vault_data/mock_game_nba.json",
+      "receiptSources": [
+        "demo/vault_data/mock_game_nba.json",
+        "demo/vault_data/README.md",
+        "commit 21ec5b8854150e067146262df7f0dae1e878e9fe"
+      ],
+      "pendingLive": true,
+      "notes": "BOS @ MIA (fictional), steal + dunk swing. NBA was out of season on 2026-07-18, so there was no live game or open Kalshi market. Card generation was run end-to-end and accepted; this proves mechanics only."
+    },
+    {
+      "sport": "nhl",
+      "evidenceType": "synthetic",
+      "certificationStatus": "pending-live",
+      "evidenceRecordedAt": "2026-07-18T15:44:32Z",
+      "espnEventId": null,
+      "marketResolution": null,
+      "outputVerdict": "card-generated",
+      "evaluatorVerdict": "held",
+      "latencyMs": null,
+      "fixturePath": "demo/vault_data/mock_game_nhl.json",
+      "receiptSources": [
+        "demo/vault_data/mock_game_nhl.json",
+        "demo/vault_data/README.md",
+        "commit 21ec5b8854150e067146262df7f0dae1e878e9fe"
+      ],
+      "pendingLive": true,
+      "notes": "TOR @ BOS (fictional), shorthanded goal swing. The generator consistently adds unsupported momentum language on this play and the evaluator holds the card for review rather than passing it. This exercises the fail-closed evaluator rejection path — NHL has never produced an accepted card, synthetic or live."
+    },
+    {
+      "sport": "wnba",
+      "evidenceType": "live-reported",
+      "certificationStatus": "pending-live-revalidation",
+      "evidenceRecordedAt": "2026-07-18T15:44:32Z",
+      "espnEventId": "401857073",
+      "marketResolution": {
+        "source": "kalshi",
+        "ticker": "KXWNBAGAME-26JUL17SEAIND-IND",
+        "provenance": "ticker as originally reported in PR #135; not reproducible in the 2026-08-08 revalidation"
+      },
+      "outputVerdict": "3-cards-generated",
+      "evaluatorVerdict": "2-passed-1-held",
+      "latencyMs": null,
+      "fixturePath": null,
+      "receiptSources": [
+        "https://github.com/machina-sports/sportsclaw/pull/135",
+        "commit 21ec5b8854150e067146262df7f0dae1e878e9fe",
+        "demo/vault_data/README.md"
+      ],
+      "pendingLive": true,
+      "notes": "SEA @ IND, reported as a live run in PR #135: 3 cards generated, 2 passed the evaluator and 1 was held. Evidence was recorded by commit 21ec5b8854150e067146262df7f0dae1e878e9fe at 2026-07-18T15:44:32Z; the original exact run timestamp and latency were not retained, so this is a historical report rather than a certified receipt.",
+      "revalidation": {
+        "recordedAt": "2026-08-08T14:29:13Z",
+        "command": "node dist/intelligence/momentum-replay.js wnba 401857073",
+        "status": "blocked",
+        "observedResult": "Run resolved a different market, KXWNBAGAME-26JUL28INDSEA-IND, instead of the reported KXWNBAGAME-26JUL17SEAIND-IND, and returned 0 price points. A follow-up WNBA scoreboard discovery call returned ESPN HTTP 403."
+      }
+    },
+    {
+      "sport": "cfb",
+      "evidenceType": "synthetic",
+      "certificationStatus": "pending-live",
+      "evidenceRecordedAt": "2026-07-18T15:44:32Z",
+      "espnEventId": null,
+      "marketResolution": null,
+      "outputVerdict": "card-generated",
+      "evaluatorVerdict": "accepted",
+      "latencyMs": null,
+      "fixturePath": "demo/vault_data/mock_game_cfb.json",
+      "receiptSources": [
+        "demo/vault_data/mock_game_cfb.json",
+        "demo/vault_data/README.md",
+        "commit 21ec5b8854150e067146262df7f0dae1e878e9fe"
+      ],
+      "pendingLive": true,
+      "notes": "OSU @ MICH (fictional), punt-return TD swing. CFB was out of season on 2026-07-18, so there was no live game or open Kalshi market. Card generation was run end-to-end and accepted; this proves mechanics only."
+    },
+    {
+      "sport": "cbb",
+      "evidenceType": "synthetic",
+      "certificationStatus": "pending-live",
+      "evidenceRecordedAt": "2026-07-18T15:44:32Z",
+      "espnEventId": null,
+      "marketResolution": null,
+      "outputVerdict": "card-generated",
+      "evaluatorVerdict": "accepted",
+      "latencyMs": null,
+      "fixturePath": "demo/vault_data/mock_game_cbb.json",
+      "receiptSources": [
+        "demo/vault_data/mock_game_cbb.json",
+        "demo/vault_data/README.md",
+        "commit 21ec5b8854150e067146262df7f0dae1e878e9fe"
+      ],
+      "pendingLive": true,
+      "notes": "DUKE @ UNC (fictional), go-ahead 3-pointer swing. CBB was out of season on 2026-07-18, so there was no live game or open Kalshi market. Card generation was run end-to-end and accepted; this proves mechanics only."
+    }
+  ]
+}

--- a/docs/sports-data/momentum-certification.json
+++ b/docs/sports-data/momentum-certification.json
@@ -2,7 +2,7 @@
   "artifact": "momentum-seven-sport-certification",
   "version": 1,
   "generatedAt": "2026-08-08T14:29:13Z",
-  "statement": "Synthetic fixture evidence proves the momentum pipeline's mechanics only (swing detection, card generation, evaluator gate). The live-reported evidence for MLB and WNBA is historical, recorded in PR #135, and its complete run receipts (exact run timestamp, latency, and for MLB the output/evaluator counts) were not retained. Fresh revalidation on 2026-08-08 was blocked for both. Therefore no row is currently live-certified.",
+  "statement": "Synthetic fixture evidence proves the momentum pipeline's mechanics only (swing detection, card generation, evaluator gate). The live-reported evidence for MLB and WNBA is historical, recorded in PR #135, and its complete run receipts (exact run timestamp, latency, and for MLB the output/evaluator counts) were not retained. Fresh revalidation on 2026-08-08 found an unresolved MLB market and a WNBA resolver anomaly; separate scoreboard discovery attempts were blocked by ESPN HTTP 403. Therefore no row is currently live-certified.",
   "revalidationPolicy": "A row may move to live certification only when a single fresh run produces, together: an ESPN event id, a resolved Kalshi market, a non-empty price series, an output verdict, an evaluator verdict, and a measured latency — all captured in one receipt.",
   "sports": [
     {
@@ -50,7 +50,9 @@
         "recordedAt": "2026-08-08T14:29:13Z",
         "command": "node dist/intelligence/momentum-replay.js mlb 401872178",
         "status": "blocked",
-        "observedResult": "Run failed: no Kalshi winner market resolved for ESPN event 401872178. A follow-up MLB scoreboard discovery call also returned ESPN HTTP 403, so no alternate live event could be selected."
+        "observedResult": "Run failed: no Kalshi winner market resolved for ESPN event 401872178.",
+        "discoveryStatus": "blocked",
+        "discoveryObservedResult": "A follow-up MLB scoreboard discovery call returned ESPN HTTP 403, so no alternate live event could be selected."
       }
     },
     {
@@ -116,8 +118,10 @@
       "revalidation": {
         "recordedAt": "2026-08-08T14:29:13Z",
         "command": "node dist/intelligence/momentum-replay.js wnba 401857073",
-        "status": "blocked",
-        "observedResult": "Run resolved a different market, KXWNBAGAME-26JUL28INDSEA-IND, instead of the reported KXWNBAGAME-26JUL17SEAIND-IND, and returned 0 price points. A follow-up WNBA scoreboard discovery call returned ESPN HTTP 403."
+        "status": "resolver-anomaly",
+        "observedResult": "Run resolved a different market, KXWNBAGAME-26JUL28INDSEA-IND, instead of the reported KXWNBAGAME-26JUL17SEAIND-IND, and returned 0 price points.",
+        "discoveryStatus": "blocked",
+        "discoveryObservedResult": "A follow-up WNBA scoreboard discovery call returned ESPN HTTP 403."
       }
     },
     {

--- a/docs/sports-data/momentum-certification.md
+++ b/docs/sports-data/momentum-certification.md
@@ -6,7 +6,9 @@ Generated **2026-08-08T14:29:13Z**. Guarded by `test/momentum-certification.test
 > **No sport in this table is currently live-certified.** Synthetic evidence proves the
 > pipeline's mechanics only. The MLB and WNBA rows are *historical reports* from
 > [PR #135](https://github.com/machina-sports/sportsclaw/pull/135) whose complete run
-> receipts were not retained, and the fresh 2026-08-08 revalidation of both was **blocked**.
+> receipts were not retained. Fresh 2026-08-08 revalidation found a WNBA
+> **resolver anomaly** and an unresolved MLB market; separate scoreboard discovery for
+> both sports was **blocked** by ESPN HTTP 403.
 
 ## Evidence types
 
@@ -48,18 +50,18 @@ language, and the evaluator holds the card rather than passing it. That is the f
 gate working as designed — but it means NHL has **never** produced an accepted card, synthetic
 or live. Any future artifact that shows NHL as `accepted` without a new run is a regression.
 
-## Fresh revalidation (2026-08-08T14:29:13Z) — blocked
+## Fresh revalidation (2026-08-08T14:29:13Z) — unresolved
 
 Both live-reported rows were re-run to try to close the receipt gap. Neither succeeded, so
 neither row advanced.
 
-| sport | command | status | observed |
-| --- | --- | --- | --- |
-| wnba | `node dist/intelligence/momentum-replay.js wnba 401857073` | blocked | Resolved a different market, `KXWNBAGAME-26JUL28INDSEA-IND`, instead of the reported `KXWNBAGAME-26JUL17SEAIND-IND`, and returned 0 price points. Follow-up scoreboard discovery returned ESPN HTTP 403. |
-| mlb | `node dist/intelligence/momentum-replay.js mlb 401872178` | blocked | No Kalshi winner market resolved for ESPN event 401872178. Follow-up scoreboard discovery returned ESPN HTTP 403. |
+| sport | command | revalidation status | observed | discovery status | discovery observed |
+| --- | --- | --- | --- | --- | --- |
+| wnba | `node dist/intelligence/momentum-replay.js wnba 401857073` | resolver-anomaly | Resolved a different market, `KXWNBAGAME-26JUL28INDSEA-IND`, instead of the reported `KXWNBAGAME-26JUL17SEAIND-IND`, and returned 0 price points. | blocked | Follow-up scoreboard discovery returned ESPN HTTP 403. |
+| mlb | `node dist/intelligence/momentum-replay.js mlb 401872178` | blocked | No Kalshi winner market resolved for ESPN event 401872178. | blocked | Follow-up scoreboard discovery returned ESPN HTTP 403. |
 
-These are **blocked revalidation receipts, not passes.** Response bodies are deliberately not
-embedded here — only the status and the one-line outcome.
+These are unresolved revalidation and blocked discovery receipts, not passes. Response bodies
+are deliberately not embedded here — only each status and one-line outcome.
 
 ## What the offline test suite does and does not prove
 

--- a/docs/sports-data/momentum-certification.md
+++ b/docs/sports-data/momentum-certification.md
@@ -1,0 +1,73 @@
+# Momentum seven-sport certification
+
+Machine-checkable companion to [`momentum-certification.json`](./momentum-certification.json).
+Generated **2026-08-08T14:29:13Z**. Guarded by `test/momentum-certification.test.mjs`.
+
+> **No sport in this table is currently live-certified.** Synthetic evidence proves the
+> pipeline's mechanics only. The MLB and WNBA rows are *historical reports* from
+> [PR #135](https://github.com/machina-sports/sportsclaw/pull/135) whose complete run
+> receipts were not retained, and the fresh 2026-08-08 revalidation of both was **blocked**.
+
+## Evidence types
+
+| Type | Meaning |
+| --- | --- |
+| `live-reported` | A live run against real ESPN + Kalshi data was reported in PR #135, but the retained receipt is incomplete (missing exact run timestamp and latency; for MLB also the output/evaluator counts). |
+| `synthetic` | The sport was out of season, or no live market existed. A fixture was run end-to-end through swing detection → card generation → evaluator gate. Proves mechanics, not live behaviour. |
+
+There is deliberately **no `live-certified` type**. A row earns one only when a single fresh
+run yields, together: ESPN event id, resolved Kalshi market, non-empty price series, output
+verdict, evaluator verdict, and a measured latency.
+
+## The seven sports
+
+| sport | evidenceType | certificationStatus | ESPN event | market | output | evaluator | latencyMs | pendingLive |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| nfl | synthetic | pending-live | — | — | card-generated | accepted | not retained | yes |
+| mlb | live-reported | pending-live-revalidation | 401872178 | `KXMLBGAME-26JUL171335TBBOSG1-BOS` | not-retained | not-retained | not retained | yes |
+| nba | synthetic | pending-live | — | — | card-generated | accepted | not retained | yes |
+| nhl | synthetic | pending-live | — | — | card-generated | **held** | not retained | yes |
+| wnba | live-reported | pending-live-revalidation | 401857073 | `KXWNBAGAME-26JUL17SEAIND-IND` | 3-cards-generated | 2-passed-1-held | not retained | yes |
+| cfb | synthetic | pending-live | — | — | card-generated | accepted | not retained | yes |
+| cbb | synthetic | pending-live | — | — | card-generated | accepted | not retained | yes |
+
+### Fixtures behind the synthetic rows
+
+| sport | fixture |
+| --- | --- |
+| nfl | `demo/vault_data/mock_game.json` |
+| nba | `demo/vault_data/mock_game_nba.json` |
+| nhl | `demo/vault_data/mock_game_nhl.json` |
+| cfb | `demo/vault_data/mock_game_cfb.json` |
+| cbb | `demo/vault_data/mock_game_cbb.json` |
+
+### NHL is a held card, not an accepted one
+
+The NHL fixture's shorthanded-goal swing makes the generator add unsupported "momentum"
+language, and the evaluator holds the card rather than passing it. That is the fail-closed
+gate working as designed — but it means NHL has **never** produced an accepted card, synthetic
+or live. Any future artifact that shows NHL as `accepted` without a new run is a regression.
+
+## Fresh revalidation (2026-08-08T14:29:13Z) — blocked
+
+Both live-reported rows were re-run to try to close the receipt gap. Neither succeeded, so
+neither row advanced.
+
+| sport | command | status | observed |
+| --- | --- | --- | --- |
+| wnba | `node dist/intelligence/momentum-replay.js wnba 401857073` | blocked | Resolved a different market, `KXWNBAGAME-26JUL28INDSEA-IND`, instead of the reported `KXWNBAGAME-26JUL17SEAIND-IND`, and returned 0 price points. Follow-up scoreboard discovery returned ESPN HTTP 403. |
+| mlb | `node dist/intelligence/momentum-replay.js mlb 401872178` | blocked | No Kalshi winner market resolved for ESPN event 401872178. Follow-up scoreboard discovery returned ESPN HTTP 403. |
+
+These are **blocked revalidation receipts, not passes.** Response bodies are deliberately not
+embedded here — only the status and the one-line outcome.
+
+## What the offline test suite does and does not prove
+
+`npm run test:momentum` passes 33/33. Those tests are offline and cover candle→swing
+extraction, card generation surfaces, and the evaluator gate. They prove the mechanics are
+correct; they say nothing about live ESPN or Kalshi behaviour for any sport.
+
+## Related
+
+- [`demo/vault_data/README.md`](../../demo/vault_data/README.md) — fixture details and run commands
+- [`coverage.md`](./coverage.md) — sports-data coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sportsclaw-engine-core",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/sdk": "^2.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, Google, and Azure Foundry.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -52,6 +52,7 @@ import { routePromptToSkills, routeToAgents } from "./router.js";
 import {
   finalizeActiveTools,
   providerToolCeiling,
+  resolveParallelAgentRoutedTools,
 } from "./routing/tool-activation.js";
 import { loadAgents, type AgentDef } from "./agents.js";
 import { McpManager, summarizeMcpServers } from "./mcp.js";
@@ -645,29 +646,21 @@ export class sportsclawEngine {
   ): Promise<{ activeTools?: string[]; decision?: RouteDecision; routeMeta?: RouteMeta }> {
     const installedSkills = this.registry.getInstalledSkills();
     if (installedSkills.length === 0) {
-      // No Python sport schemas installed — but MCP tools may still be available
-      const mcpToolNames = toolNames.filter((n) => n.startsWith("mcp__"));
-      if (mcpToolNames.length > 0) {
-        // Include internal tools alongside MCP tools
-        const internalNames = toolNames.filter((n) =>
-          n === "generate_image" || n === "generate_video" ||
-          n.startsWith("update_") || n === "reflect" || n === "evolve_strategy" ||
-          n === "get_agent_config" || n === "install_sport" || n === "remove_sport" ||
-          n === "upgrade_sports_skills" || n === "spawn_subagent" || n === "list_subagents" ||
-          n === "schedule_task" || n === "list_scheduled_tasks" || n === "cancel_scheduled_task" ||
-          n === "consolidate_memory" || n === "machina_loop" || n === "run_selftest"
-        );
-        return {
-          activeTools: [...internalNames, ...mcpToolNames],
-          decision: {
-            selectedSkills: [],
-            mode: "focused" as const,
-            confidence: 0.8,
-            reason: "MCP-only mode — no sport schemas installed",
-          },
-        };
-      }
-      return {};
+      // With no sport schemas there is nothing to skill-filter. Every tool is
+      // engine-owned or MCP-provided, so keep the complete registry active.
+      return {
+        activeTools: toolNames,
+        ...(toolNames.some((name) => name.startsWith("mcp__"))
+          ? {
+              decision: {
+                selectedSkills: [],
+                mode: "focused" as const,
+                confidence: 0.8,
+                reason: "MCP-only mode — no sport schemas installed",
+              },
+            }
+          : {}),
+      };
     }
 
     // Build recent conversation context from user messages (excluding memory
@@ -699,28 +692,10 @@ export class sportsclawEngine {
     const decision = routed.decision;
 
     const selectedSkills = new Set(decision.selectedSkills);
-    const isInternalTool = (name: string) =>
-      name === "generate_image" ||
-      name === "generate_video" ||
-      name.startsWith("update_") ||
-      name === "reflect" ||
-      name === "evolve_strategy" ||
-      name === "get_agent_config" ||
-      name === "install_sport" ||
-      name === "remove_sport" ||
-      name === "upgrade_sports_skills" ||
-      name === "spawn_subagent" ||
-      name === "list_subagents" ||
-      name === "schedule_task" ||
-      name === "list_scheduled_tasks" ||
-      name === "cancel_scheduled_task" ||
-      name === "consolidate_memory" ||
-      name === "run_selftest";
     const active = toolNames.filter((name) => {
-      if (isInternalTool(name)) return true;
       if (name.startsWith("mcp__")) return true; // MCP tools always active
       const skill = this.registry.getSkillName(name);
-      return skill ? selectedSkills.has(skill) : false;
+      return skill !== undefined ? selectedSkills.has(skill) : true;
     });
 
     // Always return the filtered list — even when it is internal-only or empty.
@@ -772,19 +747,10 @@ export class sportsclawEngine {
   private filterToolsForAgent(agent: AgentDef, allToolNames: string[]): string[] | undefined {
     if (agent.skills.length === 0) return undefined;
     const agentSkillSet = new Set(agent.skills);
-    const isInternalTool = (name: string) =>
-      name === "generate_image" || name === "generate_video" ||
-      name.startsWith("update_") || name === "reflect" ||
-      name === "evolve_strategy" || name === "get_agent_config" ||
-      name === "install_sport" || name === "remove_sport" ||
-      name === "upgrade_sports_skills" || name === "spawn_subagent" ||
-      name === "list_subagents" || name === "schedule_task" ||
-      name === "list_scheduled_tasks" || name === "cancel_scheduled_task" ||
-      name === "consolidate_memory" || name === "machina_loop" || name === "run_selftest";
     return allToolNames.filter((name) => {
-      if (isInternalTool(name) || name.startsWith("mcp__")) return true;
+      if (name.startsWith("mcp__")) return true;
       const skill = this.registry.getSkillName(name);
-      return skill ? agentSkillSet.has(skill) : false;
+      return skill !== undefined ? agentSkillSet.has(skill) : true;
     });
   }
 
@@ -3690,13 +3656,15 @@ export class sportsclawEngine {
       const allToolNames = Object.keys(tools);
       const parallelMaxTurns = Math.max(5, Math.floor(this.config.maxTurns / 2));
       const providerOpts = buildProviderOptions(this.config.provider, this.config.thinkingBudget);
+      const ceiling = providerToolCeiling(this.config.provider);
 
       const lanePromises = activeAgents.map((agent) => {
-        // Generalist lanes have no skill filter. Reuse the already-safe main
-        // filter instead of omitting activeTools and exposing a capped
-        // provider to the full registry. Skilled lanes finalize independently.
-        const agentRoutedTools =
-          this.filterToolsForAgent(agent, allToolNames) ?? activeTools;
+        const agentRoutedTools = resolveParallelAgentRoutedTools({
+          agentRoutedTools: this.filterToolsForAgent(agent, allToolNames),
+          mainActiveTools: activeTools,
+          totalToolCount: allToolNames.length,
+          ceiling,
+        });
         const agentActiveTools = finalizeActiveTools({
           routedActiveTools: agentRoutedTools,
           isFollowUp,
@@ -3707,7 +3675,7 @@ export class sportsclawEngine {
           // current message list; pruned tool calls are intentionally absent.
           historyToolNames: Array.from(historyToolNames),
           totalToolCount: allToolNames.length,
-          ceiling: providerToolCeiling(this.config.provider),
+          ceiling,
         });
         const laneLabel = `${agent.name} (${this.mainModelId})`;
         emitProgress?.({ type: "phase", label: laneLabel });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -49,6 +49,7 @@ import {
 import { loadConfig, saveConfig, SPORTS_SKILLS_DISCLAIMER } from "./config.js";
 import { MemoryManager, PodMemoryStorage } from "./memory.js";
 import { routePromptToSkills, routeToAgents } from "./router.js";
+import { finalizeActiveTools } from "./routing/tool-activation.js";
 import { loadAgents, type AgentDef } from "./agents.js";
 import { McpManager, summarizeMcpServers } from "./mcp.js";
 import { loadSkillGuides } from "./skill-guides.js";
@@ -719,10 +720,11 @@ export class sportsclawEngine {
       return skill ? selectedSkills.has(skill) : false;
     });
 
-    const hasExternalTool = active.some((name) => !isInternalTool(name));
-    return hasExternalTool
-      ? { activeTools: active, decision, routeMeta: routed.meta }
-      : { decision, routeMeta: routed.meta };
+    // Always return the filtered list — even when it is internal-only or empty.
+    // Omitting `activeTools` makes the AI SDK send the ENTIRE registry (291 tools
+    // with all schemas installed), which providers with a tool ceiling reject
+    // outright ("Invalid tools: array too long. Expected maximum 128, got 291").
+    return { activeTools: active, decision, routeMeta: routed.meta };
   }
 
   /**
@@ -3545,20 +3547,13 @@ export class sportsclawEngine {
       Object.keys(tools),
       memoryBlock
     );
-    // On follow-up turns with low routing confidence, clear activeTools so the
-    // LLM can use any tool based on conversation context (e.g. "started already"
-    // after asking about the Celtics game should still access NBA tools).
-    let activeTools = (isFollowUp && routing.decision && routing.decision.confidence < this.config.clarifyThreshold)
-      ? undefined
-      : routing.activeTools;
-
     // When session history contains tool-call messages from prior turns, the
     // Vercel AI SDK only sends tool definitions in `activeTools` to the provider.
     // If the current routing selects different tools, the provider rejects the
     // request because historical tool_use blocks reference undefined tools.
-    // Fix: merge any tool names from the session history into activeTools.
-    if (activeTools && isFollowUp) {
-      const historyToolNames = new Set<string>();
+    // So any surviving filter is widened with the tool names used in history.
+    const historyToolNames = new Set<string>();
+    if (isFollowUp) {
       for (const msg of this.messages) {
         if (msg.role === "assistant" && Array.isArray(msg.content)) {
           for (const part of msg.content) {
@@ -3568,12 +3563,17 @@ export class sportsclawEngine {
           }
         }
       }
-      if (historyToolNames.size > 0) {
-        const merged = new Set(activeTools);
-        for (const name of historyToolNames) merged.add(name);
-        activeTools = Array.from(merged);
-      }
     }
+
+    const activeTools = finalizeActiveTools({
+      routedActiveTools: routing.activeTools,
+      isFollowUp,
+      lowConfidence: Boolean(
+        routing.decision && routing.decision.confidence < this.config.clarifyThreshold
+      ),
+      historyToolNames: Array.from(historyToolNames),
+      totalToolCount: Object.keys(tools).length,
+    });
 
     // --- Agent routing: pick the best agent(s) for this prompt ---
     const selectedSkills = routing.decision?.selectedSkills ?? [];

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -49,7 +49,10 @@ import {
 import { loadConfig, saveConfig, SPORTS_SKILLS_DISCLAIMER } from "./config.js";
 import { MemoryManager, PodMemoryStorage } from "./memory.js";
 import { routePromptToSkills, routeToAgents } from "./router.js";
-import { finalizeActiveTools } from "./routing/tool-activation.js";
+import {
+  finalizeActiveTools,
+  providerToolCeiling,
+} from "./routing/tool-activation.js";
 import { loadAgents, type AgentDef } from "./agents.js";
 import { McpManager, summarizeMcpServers } from "./mcp.js";
 import { loadSkillGuides } from "./skill-guides.js";
@@ -3573,6 +3576,7 @@ export class sportsclawEngine {
       ),
       historyToolNames: Array.from(historyToolNames),
       totalToolCount: Object.keys(tools).length,
+      ceiling: providerToolCeiling(this.config.provider),
     });
 
     // --- Agent routing: pick the best agent(s) for this prompt ---
@@ -3687,28 +3691,24 @@ export class sportsclawEngine {
       const parallelMaxTurns = Math.max(5, Math.floor(this.config.maxTurns / 2));
       const providerOpts = buildProviderOptions(this.config.provider, this.config.thinkingBudget);
 
-      // Collect tool names from session history to ensure parallel lanes
-      // include definitions for tools referenced in prior turns.
-      const historyToolNames: string[] = [];
-      if (isFollowUp) {
-        for (const msg of this.messages) {
-          if (msg.role === "assistant" && Array.isArray(msg.content)) {
-            for (const part of msg.content as Array<{ type?: string; toolName?: string }>) {
-              if (part.type === "tool-call" && part.toolName && part.toolName in tools) {
-                historyToolNames.push(part.toolName);
-              }
-            }
-          }
-        }
-      }
-
       const lanePromises = activeAgents.map((agent) => {
-        let agentActiveTools = this.filterToolsForAgent(agent, allToolNames);
-        if (agentActiveTools && historyToolNames.length > 0) {
-          const merged = new Set(agentActiveTools);
-          for (const name of historyToolNames) merged.add(name);
-          agentActiveTools = Array.from(merged);
-        }
+        // Generalist lanes have no skill filter. Reuse the already-safe main
+        // filter instead of omitting activeTools and exposing a capped
+        // provider to the full registry. Skilled lanes finalize independently.
+        const agentRoutedTools =
+          this.filterToolsForAgent(agent, allToolNames) ?? activeTools;
+        const agentActiveTools = finalizeActiveTools({
+          routedActiveTools: agentRoutedTools,
+          isFollowUp,
+          lowConfidence: Boolean(
+            routing.decision && routing.decision.confidence < this.config.clarifyThreshold
+          ),
+          // This set was collected after context pruning from the retained,
+          // current message list; pruned tool calls are intentionally absent.
+          historyToolNames: Array.from(historyToolNames),
+          totalToolCount: allToolNames.length,
+          ceiling: providerToolCeiling(this.config.provider),
+        });
         const laneLabel = `${agent.name} (${this.mainModelId})`;
         emitProgress?.({ type: "phase", label: laneLabel });
 
@@ -3726,7 +3726,7 @@ export class sportsclawEngine {
           }),
           messages: this.messages,
           tools,
-          ...(agentActiveTools ? { activeTools: agentActiveTools } : {}),
+          ...(agentActiveTools !== undefined ? { activeTools: agentActiveTools } : {}),
           abortSignal: options?.abortSignal,
           stopWhen: stepCountIs(parallelMaxTurns),
           maxOutputTokens: budgets.main,

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ import {
   saveSchema,
   removeSchema,
   listSchemas,
+  loadAllSchemas,
+  summarizeInstalledSchemas,
   getSchemaDir,
   bootstrapDefaultSchemas,
   ensureSportsSkills,
@@ -944,16 +946,62 @@ function cmdRemove(args: string[], _opts?: { fromChat?: boolean }): void {
 // CLI: `sportsclaw list`
 // ---------------------------------------------------------------------------
 
-function cmdList(_opts?: { fromChat?: boolean }): void {
-  const schemas = listSchemas();
-  if (schemas.length === 0) {
-    console.log("No sport schemas installed.");
+function cmdList(args: string[] = [], _opts?: { fromChat?: boolean }): void {
+  const schemas = [...loadAllSchemas()].sort((a, b) => a.sport.localeCompare(b.sport));
+  const summary = summarizeInstalledSchemas(schemas);
+
+  if (args.includes("--json")) {
+    console.log(
+      JSON.stringify(
+        {
+          schemaDir: getSchemaDir(),
+          defaultSports: summary.defaultSports,
+          optionalSports: summary.optionalSports,
+          defaultSupport: summary.defaultSupport,
+          optionalSupport: summary.optionalSupport,
+          unknown: summary.unknown,
+          totals: {
+            sports: summary.totalSports,
+            support: summary.totalSupport,
+            schemas: summary.totalSchemas,
+            tools: summary.totalTools,
+          },
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  if (summary.totalSchemas === 0) {
+    console.log("No sport schemas or support modules installed.");
     console.log('Add one with: sportsclaw add <sport>');
     return;
   }
-  console.log(`Installed sport schemas (${schemas.length}):`);
-  for (const name of schemas) {
-    console.log(`  - ${name}`);
+
+  const group = (label: string, names: string[]) => {
+    if (names.length === 0) return;
+    console.log(`  ${label} (${names.length})`);
+    console.log(`    ${names.join(", ")}`);
+  };
+
+  console.log(
+    `Installed schemas (${summary.totalSchemas}) — ${summary.totalTools} tools`
+  );
+  if (summary.totalSports > 0) {
+    console.log(`\nSports (${summary.totalSports})`);
+    group("Default", summary.defaultSports);
+    group("Optional", summary.optionalSports);
+  }
+  if (summary.totalSupport > 0) {
+    console.log(`\nSupport modules (${summary.totalSupport})`);
+    group("Default", summary.defaultSupport);
+    group("Optional", summary.optionalSupport);
+  }
+  if (summary.unknown.length > 0) {
+    console.log(`\nUnknown (${summary.unknown.length})`);
+    console.log(`    ${summary.unknown.join(", ")}`);
   }
   console.log(`\nSchema directory: ${getSchemaDir()}`);
 }
@@ -1046,9 +1094,8 @@ async function cmdDoctor(_opts?: { fromChat?: boolean }): Promise<void> {
       const sub = anthroAuth.tokens.subscriptionType ? ` ${anthroAuth.tokens.subscriptionType}` : "";
       console.log(pc.green("  ✓") + ` Anthropic auth: OAuth (Claude Code${sub}, expires in ${minLeft} min)`);
     } else if (anthroAuth?.kind === "api_key") {
-      const masked = anthroAuth.value.slice(0, 6) + "..." + anthroAuth.value.slice(-4);
       const src = anthroAuth.source === "env" ? "env" : "keychain";
-      console.log(pc.green("  ✓") + ` Anthropic API key (${masked}, ${src})`);
+      console.log(pc.green("  ✓") + ` Anthropic API key configured (source: ${src})`);
     } else {
       console.log(pc.red("  ✗") + ` No Anthropic credentials`);
       console.log(`    Set ANTHROPIC_API_KEY, run ${pc.cyan("sportsclaw config")}, or ${pc.cyan("sportsclaw login claude")}`);
@@ -1062,18 +1109,16 @@ async function cmdDoctor(_opts?: { fromChat?: boolean }): Promise<void> {
       console.log(`    Set it or run: ${pc.cyan("sportsclaw config")}`);
       allGood = false;
     } else if (authMode === "entra_id") {
-      console.log(pc.green("  ✓") + ` Azure Foundry auth: Entra ID (DefaultAzureCredential, ${baseUrl})`);
+      console.log(pc.green("  ✓") + " Azure Foundry auth: Entra ID (DefaultAzureCredential), base URL configured");
     } else if (apiKey) {
-      const masked = apiKey.slice(0, 6) + "..." + apiKey.slice(-4);
-      console.log(pc.green("  ✓") + ` Azure Foundry API key (${masked}, ${baseUrl})`);
+      console.log(pc.green("  ✓") + " Azure Foundry API key configured, base URL configured");
     } else {
       console.log(pc.red("  ✗") + " No Azure Foundry credentials (auth mode: api_key)");
       console.log(`    Set AZURE_FOUNDRY_API_KEY or run: ${pc.cyan("sportsclaw config")}`);
       allGood = false;
     }
   } else if (apiKey) {
-    const masked = apiKey.slice(0, 6) + "..." + apiKey.slice(-4);
-    console.log(pc.green("  ✓") + ` ${provider} API key (${masked})`);
+    console.log(pc.green("  ✓") + ` ${provider} API key configured`);
   } else {
     console.log(pc.red("  ✗") + ` No API key for ${provider}`);
     console.log(`    Set the env var or run: sportsclaw config`);
@@ -1231,8 +1276,10 @@ function detectConfigDrift(): string[] {
     );
     if (distinct.size <= 1) continue; // all matching values
 
-    const mask = (v: string | undefined) =>
-      v ? `${v.slice(0, 6)}...${v.slice(-4)}` : pc.dim("(unset)");
+    // Never render any part of a credential — only whether each source holds
+    // one. The drift itself is already established by the distinct-value check.
+    const state = (v: string | undefined) =>
+      v ? "configured" : pc.dim("(unset)");
 
     const winner = looksFromShell(key)
       ? "shell env"
@@ -1241,8 +1288,8 @@ function detectConfigDrift(): string[] {
         : "config.json";
 
     issues.push(
-      `${pc.bold(key)}: env=${mask(looksFromShell(key) ? inProc : undefined)} ` +
-      `.env=${mask(inDotenv)} config.json=${mask(saved)} → ${pc.yellow(winner)} wins`
+      `${pc.bold(key)}: env=${state(looksFromShell(key) ? inProc : undefined)} ` +
+      `.env=${state(inDotenv)} config.json=${state(saved)} → ${pc.yellow(winner)} wins`
     );
   }
 
@@ -1817,7 +1864,7 @@ async function handleSlashMenu(): Promise<true | string> {
   if (selection === "/clip") {
     await cmdClip([], { fromChat: true });
   } else if (selection === "/skills") {
-    cmdList({ fromChat: true });
+    cmdList([], { fromChat: true });
   } else if (selection === "/channels") {
     await cmdChannels({ fromChat: true });
   } else if (selection === "/stats") {
@@ -1955,7 +2002,7 @@ async function cmdChat(args: string[]): Promise<void> {
 
     // Direct slash command shortcuts (without dropdown)
     if (prompt === "/clip") { await cmdClip([], { fromChat: true }); continue; }
-    if (prompt === "/skills") { cmdList({ fromChat: true }); continue; }
+    if (prompt === "/skills") { cmdList([], { fromChat: true }); continue; }
     if (prompt === "/channels") { await cmdChannels({ fromChat: true }); continue; }
     if (prompt === "/stats") { cmdAnalytics(["summary"], { fromChat: true }); continue; }
     if (prompt === "/compact") {
@@ -2937,7 +2984,7 @@ async function main(): Promise<void> {
     case "remove":
       return cmdRemove(subArgs);
     case "list":
-      return cmdList();
+      return cmdList(subArgs);
     case "init":
       return cmdInit(subArgs);
     case "listen":

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * Subcommands:
  *   sportsclaw add <sport>       — Inject a sport schema from the Python package
  *   sportsclaw remove <sport>    — Remove a previously added sport schema
- *   sportsclaw list              — List all installed sport schemas
+ *   sportsclaw list [--json]     — List all installed schemas and support modules
  *   sportsclaw init              — Bootstrap all 14 default sport schemas
  *   sportsclaw chat              — Start an interactive conversation (REPL)
  *   sportsclaw doctor            — Check setup and diagnose issues
@@ -947,7 +947,7 @@ function cmdRemove(args: string[], _opts?: { fromChat?: boolean }): void {
 // ---------------------------------------------------------------------------
 
 function cmdList(args: string[] = [], _opts?: { fromChat?: boolean }): void {
-  const schemas = [...loadAllSchemas()].sort((a, b) => a.sport.localeCompare(b.sport));
+  const schemas = [...loadAllSchemas({ installed: true })].sort((a, b) => a.sport.localeCompare(b.sport));
   const summary = summarizeInstalledSchemas(schemas);
 
   if (args.includes("--json")) {
@@ -1131,17 +1131,21 @@ async function cmdDoctor(_opts?: { fromChat?: boolean }): Promise<void> {
   }
 
   // 7. Schemas installed
-  const schemas = listSchemas();
-  if (schemas.length > 0) {
-    console.log(pc.green("  ✓") + ` ${schemas.length} sport schemas installed`);
+  const schemaSummary = summarizeInstalledSchemas(loadAllSchemas({ installed: true }));
+  if (schemaSummary.totalSchemas > 0) {
+    console.log(
+      pc.green("  ✓") +
+        ` ${schemaSummary.totalSchemas} schemas (${schemaSummary.totalSports} sports, ` +
+        `${schemaSummary.totalSupport} support modules)`
+    );
   } else {
-    console.log(pc.yellow("  ⚠") + " No sport schemas installed");
+    console.log(pc.yellow("  ⚠") + " No schemas or support modules installed");
     console.log("    Fix: sportsclaw init --all");
     allGood = false;
   }
 
   // 8. Schema directory location
-  if (schemas.length > 0) {
+  if (schemaSummary.totalSchemas > 0) {
     console.log(pc.green("  ✓") + ` Schema dir: ${getSchemaDir()}`);
   }
 
@@ -1359,7 +1363,8 @@ async function cmdHealth(args: string[]): Promise<void> {
     status = "degraded";
   }
 
-  const schemasCount = listSchemas().length;
+  const schemaSummary = summarizeInstalledSchemas(loadAllSchemas({ installed: true }));
+  const schemasCount = schemaSummary.totalSchemas;
 
   if (jsonMode) {
     const payload = {
@@ -1380,6 +1385,15 @@ async function cmdHealth(args: string[]): Promise<void> {
       },
       mcp: mcpDetails,
       schemasInstalled: schemasCount,
+      sportsInstalled: schemaSummary.totalSports,
+      supportModulesInstalled: schemaSummary.totalSupport,
+      schemaCatalog: {
+        defaultSports: schemaSummary.defaultSports,
+        optionalSports: schemaSummary.optionalSports,
+        defaultSupport: schemaSummary.defaultSupport,
+        optionalSupport: schemaSummary.optionalSupport,
+        unknown: schemaSummary.unknown,
+      },
       errors,
       warnings,
     };
@@ -1392,7 +1406,10 @@ async function cmdHealth(args: string[]): Promise<void> {
   console.log(`  Overall Status:  ${status === "healthy" ? pc.green(status.toUpperCase()) : status === "degraded" ? pc.yellow(status.toUpperCase()) : pc.red(status.toUpperCase())}`);
   console.log(`  Engine Version:  v${PKG_VERSION}`);
   console.log(`  Provider/Model:  ${provider} (${model || "default"})`);
-  console.log(`  Schemas Active:  ${schemasCount} installed`);
+  console.log(
+    `  Schemas Installed: ${schemasCount} schemas ` +
+      `(${schemaSummary.totalSports} sports, ${schemaSummary.totalSupport} support modules)`
+  );
   console.log("");
 
   console.log(pc.bold("  MCP Connectivity:"));
@@ -2756,7 +2773,7 @@ function printHelp(): void {
   console.log("  sportsclaw logout claude           Stop using Claude Code OAuth (revert to API key)");
   console.log("  sportsclaw add <sport>             Add a sport schema (e.g. nfl-data, nba-data)");
   console.log("  sportsclaw remove <sport>          Remove a sport schema");
-  console.log("  sportsclaw list                    List installed sport schemas");
+  console.log("  sportsclaw list [--json]           List all installed schemas and support modules");
   console.log("  sportsclaw init                    Interactive sport selection & install");
   console.log("  sportsclaw init --all              Bootstrap all 14 default sport schemas");
   console.log("  sportsclaw listen <platform>       Start a chat listener (discord, telegram)");

--- a/src/operate.ts
+++ b/src/operate.ts
@@ -60,6 +60,7 @@ import {
 } from "./prompts.js";
 import type { InferenceRoute, LLMProvider, OpenShellConfig } from "./types.js";
 import { invokeModelRole } from "./inference/model-role-router.js";
+import { providerToolCeiling } from "./routing/tool-activation.js";
 
 // Cheap-wake probe budget: a sink's pollWake must be fast I/O. If it hangs or
 // throws we fail closed (skip the tick — never fall through to inference).
@@ -391,6 +392,39 @@ export function applyOperatorSkillFilter(skills: string[] | undefined): void {
     process.env.sportsclaw_SKILLS !== undefined;
   if (skills === undefined || callerConfigured) return;
   process.env.SPORTSCLAW_SKILLS = skills.join(",");
+}
+
+export interface ValidateOperatorToolCountInput {
+  provider: LLMProvider;
+  toolCount: number;
+  jobId: string;
+  skills: string[] | undefined;
+}
+
+/** Fail before daemon inference when an operator would exceed a provider cap. */
+export function validateOperatorToolCount(input: ValidateOperatorToolCountInput): void {
+  const ceiling = providerToolCeiling(input.provider);
+  if (ceiling === undefined || input.toolCount <= ceiling) return;
+  throw new Error(
+    `Operator job "${input.jobId}" constructed ${input.toolCount} tools, above the ` +
+      `${ceiling}-tool ${input.provider} ceiling. Configure the job's "skills" array ` +
+      `to a focused set and retry.`
+  );
+}
+
+function operatorRequestToolCount(
+  toolSet: ToolSet,
+  cfg: OperatorJobConfig,
+  outputToolName?: string,
+): number {
+  const names = new Set(Object.keys(toolSet));
+  if (cfg.enableMemoryTools !== false) {
+    names.add("add_lesson");
+    names.add("replace_lesson");
+    names.add("remove_lesson");
+  }
+  if (outputToolName) names.add(outputToolName);
+  return names.size;
 }
 
 /**
@@ -754,6 +788,18 @@ async function runDryRun(jobId: string): Promise<void> {
   const tools = await buildOperatorTools(cfg, false, sink);
   try {
     const inputs = await resolveJobInputs(cfg, tools.mcpManager);
+    const outputSchema = sink.getOutputSchema?.({ cfg });
+    const totalToolCount = operatorRequestToolCount(
+      tools.toolSet,
+      cfg,
+      outputSchema?.toolName ?? (outputSchema ? "submit_broadcast" : undefined),
+    );
+    validateOperatorToolCount({
+      provider: inputs.provider,
+      toolCount: totalToolCount,
+      jobId: cfg.jobId,
+      skills: cfg.skills,
+    });
     const system = buildSystemPrompt({
       role: inputs.personaText,
       isCron: true,
@@ -766,8 +812,6 @@ async function runDryRun(jobId: string): Promise<void> {
     console.log(system);
     console.log("");
     const memoryToolsOn = cfg.enableMemoryTools !== false;
-    const memoryToolCount = memoryToolsOn ? 3 : 0;
-    const totalToolCount = tools.toolNames.length + memoryToolCount;
     console.log(`=== Tools (${totalToolCount}) ===`);
     for (const name of tools.toolNames) console.log(`  - ${name}`);
     if (memoryToolsOn) {
@@ -801,6 +845,17 @@ async function runOnce(jobId: string): Promise<void> {
   const tools = await buildOperatorTools(cfg, false, sink);
   try {
     const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
+    const outputSchema = sink.getOutputSchema?.({ cfg });
+    validateOperatorToolCount({
+      provider: inputs.provider,
+      toolCount: operatorRequestToolCount(
+        tools.toolSet,
+        cfg,
+        outputSchema?.toolName ?? (outputSchema ? "submit_broadcast" : undefined),
+      ),
+      jobId: cfg.jobId,
+      skills: cfg.skills,
+    });
     if (inputs.openshell?.enabled) {
       await probeOpenShellHost(inputs.openshell.baseUrl);
     }
@@ -812,7 +867,6 @@ async function runOnce(jobId: string): Promise<void> {
       cfg,
       runModelRole: makeRunModelRole(),
     };
-    const outputSchema = sink.getOutputSchema?.({ cfg });
     const daemon = createOperatorDaemon({
       jobId: cfg.jobId,
       jobLabel: cfg.label,
@@ -897,6 +951,17 @@ async function runForeground(jobId: string): Promise<void> {
   }
   const tools = await buildOperatorTools(cfg, false, sink);
   const inputs = await resolveJobInputs(cfg, tools.mcpManager, { ensureRootDir: true });
+  const outputSchema = sink.getOutputSchema?.({ cfg });
+  validateOperatorToolCount({
+    provider: inputs.provider,
+    toolCount: operatorRequestToolCount(
+      tools.toolSet,
+      cfg,
+      outputSchema?.toolName ?? (outputSchema ? "submit_broadcast" : undefined),
+    ),
+    jobId: cfg.jobId,
+    skills: cfg.skills,
+  });
   if (inputs.openshell?.enabled) {
     await probeOpenShellHost(inputs.openshell.baseUrl);
   }
@@ -909,7 +974,6 @@ async function runForeground(jobId: string): Promise<void> {
     cfg,
     runModelRole: makeRunModelRole(),
   };
-  const outputSchema = sink.getOutputSchema?.({ cfg });
   const daemon = createOperatorDaemon({
     jobId: cfg.jobId,
     jobLabel: cfg.label,

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,6 +18,7 @@ interface RouteInput {
   toolSpecs: ToolSpec[];
   memoryBlock?: string;
   recentContext?: string; // Last few user messages for multi-turn context
+  abortSignal?: AbortSignal;
   model: ModelType;
   modelId: string;
   provider: LLMProvider;
@@ -280,6 +281,7 @@ async function runLlmRouter(
         `Return JSON schema: {"selected_skills":["skill"],"mode":"focused|ambiguous","confidence":0.0,"reason":"short reason","intent":"live_scores|standings|schedule|odds|best_bets|player_stats|team_stats|news|roster|analysis|prediction|ambiguous","needs_clarification":false}`,
       ].join("\n"),
       maxOutputTokens: input.config.tokenBudgets?.router ?? DEFAULT_TOKEN_BUDGETS.router,
+      abortSignal: input.abortSignal,
       ...(() => {
         const mainBudget = input.config.thinkingBudget ?? 8192;
         const routerBudget = mainBudget > 0 ? Math.max(256, Math.floor(mainBudget / 16)) : 0;

--- a/src/routing/tool-activation.ts
+++ b/src/routing/tool-activation.ts
@@ -13,6 +13,26 @@
  */
 export const PROVIDER_TOOL_CEILING = 128;
 
+/**
+ * Raised locally — before the AI SDK / provider call — when the explicit
+ * `activeTools` list itself exceeds the provider ceiling. Truncating it would
+ * silently drop tools the turn (or its history) depends on, so the turn fails
+ * loudly instead.
+ */
+export class ProviderToolCeilingError extends Error {
+  readonly ceiling = PROVIDER_TOOL_CEILING;
+  readonly count: number;
+
+  constructor(count: number) {
+    super(
+      `activeTools carries ${count} tools, above the ${PROVIDER_TOOL_CEILING}-tool provider ceiling. ` +
+        `Refusing to truncate: narrow the routed skills or reduce the installed tool registry.`
+    );
+    this.name = "ProviderToolCeilingError";
+    this.count = count;
+  }
+}
+
 export interface FinalizeActiveToolsInput {
   /** Filtered tool names from skill routing (`undefined` = no filter produced). */
   routedActiveTools: string[] | undefined;
@@ -36,6 +56,12 @@ export interface FinalizeActiveToolsInput {
  * instead. Any surviving filter is widened with the tools referenced by history
  * so historical tool_use blocks still resolve. Nothing is ever truncated:
  * the routed filter plus history is the minimum the request needs to be valid.
+ *
+ * Above the ceiling the result is always an explicit array — even when routing
+ * produced no filter at all — because `undefined` there means "send all 291
+ * tools" and the provider rejects that outright. If the explicit list itself
+ * cannot fit the ceiling, the turn fails locally with
+ * `ProviderToolCeilingError` rather than being silently truncated.
  */
 export function finalizeActiveTools(
   input: FinalizeActiveToolsInput
@@ -46,10 +72,19 @@ export function finalizeActiveTools(
       ? undefined
       : input.routedActiveTools;
 
+  // Fail closed: an oversized registry must never resolve to `undefined`. A
+  // first turn gets an empty list; a follow-up is widened with history below,
+  // so its historical tool calls stay defined.
+  if (active === undefined && !registryFitsProvider) active = [];
+
   if (active && input.isFollowUp && input.historyToolNames.length > 0) {
     const merged = new Set(active);
     for (const name of input.historyToolNames) merged.add(name);
     active = Array.from(merged);
+  }
+
+  if (active && active.length > PROVIDER_TOOL_CEILING) {
+    throw new ProviderToolCeilingError(active.length);
   }
 
   return active;

--- a/src/routing/tool-activation.ts
+++ b/src/routing/tool-activation.ts
@@ -20,6 +20,33 @@ export function providerToolCeiling(provider: LLMProvider): number | undefined {
     : undefined;
 }
 
+export interface ResolveParallelAgentRoutedToolsInput {
+  /** Skill-filtered tools for this lane (`undefined` = generalist/no filter). */
+  agentRoutedTools: string[] | undefined;
+  /** Already-finalized, provider-safe tools from the main route. */
+  mainActiveTools: string[] | undefined;
+  /** Size of the full tool registry shared by the parallel lanes. */
+  totalToolCount: number;
+  /** Provider ceiling (`undefined` means the provider is uncapped here). */
+  ceiling?: number;
+}
+
+/**
+ * Preserve a generalist lane's no-filter semantics whenever sending the full
+ * registry is safe. Only a capped, oversized registry reuses the main route's
+ * already-safe filter; `finalizeActiveTools` still performs history widening
+ * and the final ceiling check for every lane.
+ */
+export function resolveParallelAgentRoutedTools(
+  input: ResolveParallelAgentRoutedToolsInput
+): string[] | undefined {
+  if (input.agentRoutedTools !== undefined) return input.agentRoutedTools;
+  if (input.ceiling !== undefined && input.totalToolCount > input.ceiling) {
+    return input.mainActiveTools;
+  }
+  return undefined;
+}
+
 /**
  * Raised locally — before the AI SDK / provider call — when the explicit
  * `activeTools` list itself exceeds the provider ceiling. Truncating it would

--- a/src/routing/tool-activation.ts
+++ b/src/routing/tool-activation.ts
@@ -1,0 +1,56 @@
+/**
+ * Final activeTools decision for a turn.
+ *
+ * The Vercel AI SDK only sends the tool definitions named in `activeTools` to
+ * the provider. Returning `undefined` therefore means "send the entire tool
+ * registry", which is only safe while the registry is small.
+ */
+
+/**
+ * Largest tool array providers accept in one request. Azure Foundry / OpenAI
+ * reject anything above it ("Invalid tools: array too long. Expected maximum
+ * 128, got 291").
+ */
+export const PROVIDER_TOOL_CEILING = 128;
+
+export interface FinalizeActiveToolsInput {
+  /** Filtered tool names from skill routing (`undefined` = no filter produced). */
+  routedActiveTools: string[] | undefined;
+  /** Whether this is a follow-up turn in an existing session. */
+  isFollowUp: boolean;
+  /** Whether routing confidence fell below the clarify threshold. */
+  lowConfidence: boolean;
+  /** Tool names referenced by tool calls already in the session history. */
+  historyToolNames: readonly string[];
+  /** Size of the full tool registry for this turn. */
+  totalToolCount: number;
+}
+
+/**
+ * Resolve the `activeTools` value passed to the AI SDK.
+ *
+ * On low-confidence follow-ups the filter is dropped so the LLM can reach any
+ * tool from conversation context — but only when the whole registry fits under
+ * `PROVIDER_TOOL_CEILING`. Above the ceiling, dropping the filter would send a
+ * tool array the provider rejects outright, so the routed filter is kept
+ * instead. Any surviving filter is widened with the tools referenced by history
+ * so historical tool_use blocks still resolve. Nothing is ever truncated:
+ * the routed filter plus history is the minimum the request needs to be valid.
+ */
+export function finalizeActiveTools(
+  input: FinalizeActiveToolsInput
+): string[] | undefined {
+  const registryFitsProvider = input.totalToolCount <= PROVIDER_TOOL_CEILING;
+  let active =
+    input.isFollowUp && input.lowConfidence && registryFitsProvider
+      ? undefined
+      : input.routedActiveTools;
+
+  if (active && input.isFollowUp && input.historyToolNames.length > 0) {
+    const merged = new Set(active);
+    for (const name of input.historyToolNames) merged.add(name);
+    active = Array.from(merged);
+  }
+
+  return active;
+}

--- a/src/routing/tool-activation.ts
+++ b/src/routing/tool-activation.ts
@@ -7,11 +7,18 @@
  */
 
 /**
- * Largest tool array providers accept in one request. Azure Foundry / OpenAI
- * reject anything above it ("Invalid tools: array too long. Expected maximum
- * 128, got 291").
+ * Largest tool array accepted by the providers with a known request ceiling.
  */
 export const PROVIDER_TOOL_CEILING = 128;
+
+import type { LLMProvider } from "../types.js";
+
+/** Return the provider's tool ceiling, or `undefined` for unlimited legacy behavior. */
+export function providerToolCeiling(provider: LLMProvider): number | undefined {
+  return provider === "openai" || provider === "azure-foundry"
+    ? PROVIDER_TOOL_CEILING
+    : undefined;
+}
 
 /**
  * Raised locally — before the AI SDK / provider call — when the explicit
@@ -20,16 +27,17 @@ export const PROVIDER_TOOL_CEILING = 128;
  * loudly instead.
  */
 export class ProviderToolCeilingError extends Error {
-  readonly ceiling = PROVIDER_TOOL_CEILING;
+  readonly ceiling: number;
   readonly count: number;
 
-  constructor(count: number) {
+  constructor(count: number, ceiling: number = PROVIDER_TOOL_CEILING) {
     super(
-      `activeTools carries ${count} tools, above the ${PROVIDER_TOOL_CEILING}-tool provider ceiling. ` +
-        `Refusing to truncate: narrow the routed skills or reduce the installed tool registry.`
+      `activeTools carries ${count} tools, above the ${ceiling}-tool provider ceiling. ` +
+        `Refusing to truncate. Run /compact or start a fresh session, and narrow the routed skills if the overflow remains.`
     );
     this.name = "ProviderToolCeilingError";
     this.count = count;
+    this.ceiling = ceiling;
   }
 }
 
@@ -44,6 +52,8 @@ export interface FinalizeActiveToolsInput {
   historyToolNames: readonly string[];
   /** Size of the full tool registry for this turn. */
   totalToolCount: number;
+  /** Provider ceiling (`undefined` preserves unlimited legacy behavior). */
+  ceiling?: number;
 }
 
 /**
@@ -51,13 +61,13 @@ export interface FinalizeActiveToolsInput {
  *
  * On low-confidence follow-ups the filter is dropped so the LLM can reach any
  * tool from conversation context — but only when the whole registry fits under
- * `PROVIDER_TOOL_CEILING`. Above the ceiling, dropping the filter would send a
+ * a configured ceiling. Above the ceiling, dropping the filter would send a
  * tool array the provider rejects outright, so the routed filter is kept
  * instead. Any surviving filter is widened with the tools referenced by history
  * so historical tool_use blocks still resolve. Nothing is ever truncated:
  * the routed filter plus history is the minimum the request needs to be valid.
  *
- * Above the ceiling the result is always an explicit array — even when routing
+ * For capped providers, above the ceiling the result is always an explicit array — even when routing
  * produced no filter at all — because `undefined` there means "send all 291
  * tools" and the provider rejects that outright. If the explicit list itself
  * cannot fit the ceiling, the turn fails locally with
@@ -66,7 +76,8 @@ export interface FinalizeActiveToolsInput {
 export function finalizeActiveTools(
   input: FinalizeActiveToolsInput
 ): string[] | undefined {
-  const registryFitsProvider = input.totalToolCount <= PROVIDER_TOOL_CEILING;
+  const registryFitsProvider =
+    input.ceiling === undefined || input.totalToolCount <= input.ceiling;
   let active =
     input.isFollowUp && input.lowConfidence && registryFitsProvider
       ? undefined
@@ -75,7 +86,9 @@ export function finalizeActiveTools(
   // Fail closed: an oversized registry must never resolve to `undefined`. A
   // first turn gets an empty list; a follow-up is widened with history below,
   // so its historical tool calls stay defined.
-  if (active === undefined && !registryFitsProvider) active = [];
+  if (active === undefined && input.ceiling !== undefined && !registryFitsProvider) {
+    active = [];
+  }
 
   if (active && input.isFollowUp && input.historyToolNames.length > 0) {
     const merged = new Set(active);
@@ -83,8 +96,8 @@ export function finalizeActiveTools(
     active = Array.from(merged);
   }
 
-  if (active && active.length > PROVIDER_TOOL_CEILING) {
-    throw new ProviderToolCeilingError(active.length);
+  if (active && input.ceiling !== undefined && active.length > input.ceiling) {
+    throw new ProviderToolCeilingError(active.length, input.ceiling);
   }
 
   return active;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -31,7 +31,8 @@ import { buildSportsSkillsRepairCommand, checkPythonVersion, MIN_PYTHON_VERSION 
 // See https://sports-skills.sh
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_SKILLS = [
+/** Sports installed by default (`sportsclaw init --all`). */
+export const DEFAULT_SPORT_SKILLS = [
   "football",
   "nfl",
   "nba",
@@ -46,12 +47,27 @@ export const DEFAULT_SKILLS = [
   "cricket",
   "volleyball",
   "xctf",
+] as const;
+
+/** Sports available on request but not installed by default. */
+export const OPTIONAL_SPORT_SKILLS = ["esports"] as const;
+
+/** Non-sport modules (markets, news, tooling) installed by default. */
+export const DEFAULT_SUPPORT_SKILLS = [
   "kalshi",
   "polymarket",
   "news",
   "metadata",
   "betting",
   "markets",
+] as const;
+
+/** Non-sport modules available on request but not installed by default. */
+export const OPTIONAL_SUPPORT_SKILLS = ["polymarket-trading"] as const;
+
+export const DEFAULT_SKILLS = [
+  ...DEFAULT_SPORT_SKILLS,
+  ...DEFAULT_SUPPORT_SKILLS,
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -80,6 +96,85 @@ export const SKILL_DESCRIPTIONS: Record<string, string> = {
   betting: "Betting Analysis — odds conversion, de-vigging, edge detection, Kelly criterion",
   markets: "Markets — unified prediction market dashboard connecting ESPN with Kalshi & Polymarket",
 };
+
+// ---------------------------------------------------------------------------
+// Catalog categorization
+// ---------------------------------------------------------------------------
+
+export type SchemaCategory =
+  | "default-sport"
+  | "optional-sport"
+  | "default-support"
+  | "optional-support"
+  | "unknown";
+
+/** Classify a schema name against the known catalog. */
+export function categorizeSchema(name: string): SchemaCategory {
+  if ((DEFAULT_SPORT_SKILLS as readonly string[]).includes(name)) return "default-sport";
+  if ((OPTIONAL_SPORT_SKILLS as readonly string[]).includes(name)) return "optional-sport";
+  if ((DEFAULT_SUPPORT_SKILLS as readonly string[]).includes(name)) return "default-support";
+  if ((OPTIONAL_SUPPORT_SKILLS as readonly string[]).includes(name)) return "optional-support";
+  return "unknown";
+}
+
+export interface InstalledSchemaSummary {
+  defaultSports: string[];
+  optionalSports: string[];
+  defaultSupport: string[];
+  optionalSupport: string[];
+  unknown: string[];
+  totalSports: number;
+  totalSupport: number;
+  totalSchemas: number;
+  totalTools: number;
+}
+
+/**
+ * Categorize installed schemas and count their tools.
+ *
+ * Pure: the caller supplies the schemas (from `loadAllSchemas()` in the CLI,
+ * from fixtures in tests). Tool counts are always summed from the schemas
+ * themselves — never hard-coded.
+ */
+export function summarizeInstalledSchemas(
+  schemas: readonly Pick<SportSchema, "sport" | "tools">[]
+): InstalledSchemaSummary {
+  const summary: InstalledSchemaSummary = {
+    defaultSports: [],
+    optionalSports: [],
+    defaultSupport: [],
+    optionalSupport: [],
+    unknown: [],
+    totalSports: 0,
+    totalSupport: 0,
+    totalSchemas: schemas.length,
+    totalTools: 0,
+  };
+
+  for (const schema of schemas) {
+    summary.totalTools += schema.tools?.length ?? 0;
+    switch (categorizeSchema(schema.sport)) {
+      case "default-sport":
+        summary.defaultSports.push(schema.sport);
+        break;
+      case "optional-sport":
+        summary.optionalSports.push(schema.sport);
+        break;
+      case "default-support":
+        summary.defaultSupport.push(schema.sport);
+        break;
+      case "optional-support":
+        summary.optionalSupport.push(schema.sport);
+        break;
+      default:
+        summary.unknown.push(schema.sport);
+    }
+  }
+
+  summary.totalSports = summary.defaultSports.length + summary.optionalSports.length;
+  summary.totalSupport = summary.defaultSupport.length + summary.optionalSupport.length;
+  return summary;
+}
 
 // ---------------------------------------------------------------------------
 // Skill filter — restrict active skills via SPORTSCLAW_SKILLS env var

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -332,11 +332,16 @@ export function saveSchema(schema: SportSchema): void {
  * only schemas matching the filter are returned. This enables per-user
  * skill selection in multi-tenant relay deployments.
  */
-export function loadAllSchemas(): SportSchema[] {
+export interface LoadAllSchemasOptions {
+  /** Ignore SPORTSCLAW_SKILLS and load every valid schema installed on disk. */
+  installed?: boolean;
+}
+
+export function loadAllSchemas(options: LoadAllSchemasOptions = {}): SportSchema[] {
   const dir = getSchemaDir();
   if (!existsSync(dir)) return [];
 
-  const filter = getSkillFilter();
+  const filter = options.installed ? null : getSkillFilter();
   const schemas: SportSchema[] = [];
   for (const file of readdirSync(dir)) {
     if (!file.endsWith(".json")) continue;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -651,9 +651,14 @@ export async function bootstrapDefaultSchemas(
   const onProgress = options?.onProgress;
   const existing = new Set(listSchemas());
 
-  // Try dynamic discovery; fall back to hardcoded list
+  // Try dynamic discovery, but bootstrap only the default subset. The catalog
+  // also advertises optional (and potentially newer unknown) modules that must
+  // remain explicit installs rather than being pulled in by `init --all`.
   const catalog = discoverAvailableSkills(config);
-  const skills: readonly string[] = catalog?.modules ?? DEFAULT_SKILLS;
+  const discovered = catalog ? new Set(catalog.modules) : null;
+  const skills: readonly string[] = discovered
+    ? DEFAULT_SKILLS.filter((skill) => discovered.has(skill))
+    : DEFAULT_SKILLS;
 
   if (verbose && catalog) {
     console.error(

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -22,8 +22,13 @@
 
 import { generateText, tool as defineTool, jsonSchema, stepCountIs, type ToolSet } from "ai";
 import type { sportsclawConfig, LLMProvider } from "./types.js";
-import { buildProviderOptions } from "./types.js";
+import { buildProviderOptions, DEFAULT_CONFIG } from "./types.js";
 import { ToolRegistry, type ToolCallInput } from "./tools.js";
+import { routePromptToSkills } from "./router.js";
+import {
+  finalizeActiveTools,
+  providerToolCeiling,
+} from "./routing/tool-activation.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -90,6 +95,35 @@ const RESTRICTED_TOOLS = new Set([
   "generate_image",        // no image generation from background
   "generate_video",        // no video generation from background
 ]);
+
+export interface ResolveSubagentActiveToolsInput {
+  provider: LLMProvider;
+  toolNames: readonly string[];
+  selectedSkills: readonly string[];
+  getSkillName: (toolName: string) => string | undefined;
+}
+
+/** Pure selection/finalization seam used by the background subagent path. */
+export function resolveSubagentActiveTools(
+  input: ResolveSubagentActiveToolsInput
+): string[] | undefined {
+  const selectedSkills = new Set(input.selectedSkills);
+  const routedActiveTools = input.toolNames.filter((name) => {
+    if (RESTRICTED_TOOLS.has(name)) return false;
+    if (name.startsWith("mcp__")) return true;
+    const skill = input.getSkillName(name);
+    return skill !== undefined && selectedSkills.has(skill);
+  });
+
+  return finalizeActiveTools({
+    routedActiveTools,
+    isFollowUp: false,
+    lowConfidence: false,
+    historyToolNames: [],
+    totalToolCount: input.toolNames.length,
+    ceiling: providerToolCeiling(input.provider),
+  });
+}
 
 // ---------------------------------------------------------------------------
 // SubagentManager
@@ -243,6 +277,32 @@ export class SubagentManager {
       // Build restricted tool set
       const tools = this.buildRestrictedTools(params.registry, params.config);
 
+      const allowedSpecs = params.registry
+        .getAllToolSpecs()
+        .filter((spec) => !RESTRICTED_TOOLS.has(spec.name));
+      const routed = await routePromptToSkills({
+        prompt: task.prompt,
+        installedSkills: params.registry.getInstalledSkills(),
+        toolSpecs: allowedSpecs,
+        model: params.model as Parameters<typeof generateText>[0]["model"],
+        modelId: params.config.model ?? "subagent",
+        provider: params.provider,
+        config: {
+          routingMode: params.config.routingMode ?? DEFAULT_CONFIG.routingMode,
+          routingMaxSkills: params.config.routingMaxSkills ?? DEFAULT_CONFIG.routingMaxSkills,
+          routingAllowSpillover:
+            params.config.routingAllowSpillover ?? DEFAULT_CONFIG.routingAllowSpillover,
+          thinkingBudget: params.thinkingBudget ?? DEFAULT_CONFIG.thinkingBudget,
+          tokenBudgets: params.config.tokenBudgets ?? DEFAULT_CONFIG.tokenBudgets,
+        },
+      });
+      const activeTools = resolveSubagentActiveTools({
+        provider: params.provider,
+        toolNames: Object.keys(tools),
+        selectedSkills: routed.decision.selectedSkills,
+        getSkillName: (name) => params.registry.getSkillName(name),
+      });
+
       const systemPrompt = params.systemPrompt || buildSubagentSystemPrompt(task.prompt);
       const providerOpts = buildProviderOptions(
         params.provider,
@@ -254,6 +314,7 @@ export class SubagentManager {
         system: systemPrompt,
         prompt: task.prompt,
         tools,
+        ...(activeTools !== undefined ? { activeTools } : {}),
         abortSignal,
         stopWhen: stepCountIs(this.maxTurns),
         maxOutputTokens: this.maxTokens,

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -287,6 +287,7 @@ export class SubagentManager {
         model: params.model as Parameters<typeof generateText>[0]["model"],
         modelId: params.config.model ?? "subagent",
         provider: params.provider,
+        abortSignal,
         config: {
           routingMode: params.config.routingMode ?? DEFAULT_CONFIG.routingMode,
           routingMaxSkills: params.config.routingMaxSkills ?? DEFAULT_CONFIG.routingMaxSkills,

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -110,9 +110,8 @@ export function resolveSubagentActiveTools(
   const selectedSkills = new Set(input.selectedSkills);
   const routedActiveTools = input.toolNames.filter((name) => {
     if (RESTRICTED_TOOLS.has(name)) return false;
-    if (name.startsWith("mcp__")) return true;
     const skill = input.getSkillName(name);
-    return skill !== undefined && selectedSkills.has(skill);
+    return skill === undefined || selectedSkills.has(skill);
   });
 
   return finalizeActiveTools({

--- a/test/cli-health.test.mjs
+++ b/test/cli-health.test.mjs
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { McpManager } from "../dist/mcp.js";
 
 describe("McpManager getHealthDetails", () => {
@@ -13,6 +17,44 @@ describe("McpManager getHealthDetails", () => {
       assert.strictEqual(typeof item.url, "string");
       assert.strictEqual(typeof item.failures, "number");
       assert.strictEqual(typeof item.toolsDiscovered, "number");
+    }
+  });
+});
+
+describe("sportsclaw health schema catalog", () => {
+  it("keeps schemasInstalled and adds installed sport/support totals plus catalog", () => {
+    const home = mkdtempSync(join(tmpdir(), "sportsclaw-health-"));
+    const schemaDir = join(home, ".sportsclaw", "schemas");
+    mkdirSync(schemaDir, { recursive: true });
+    const fixture = (sport) => ({ sport, tools: [] });
+    for (const sport of ["nba", "nfl", "kalshi"]) {
+      writeFileSync(join(schemaDir, `${sport}.json`), JSON.stringify(fixture(sport)));
+    }
+    try {
+      let output;
+      try {
+        output = execFileSync(process.execPath, ["dist/index.js", "health", "--json"], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HOME: home,
+            SPORTSCLAW_PROVIDER: "openai",
+            OPENAI_API_KEY: "health-test-key",
+            SPORTSCLAW_SKILLS: "nba",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (err) {
+        output = err.stdout;
+      }
+      const payload = JSON.parse(output);
+      assert.equal(payload.schemasInstalled, 3);
+      assert.equal(payload.sportsInstalled, 2);
+      assert.equal(payload.supportModulesInstalled, 1);
+      assert.deepEqual(payload.schemaCatalog.defaultSports, ["nba", "nfl"]);
+      assert.deepEqual(payload.schemaCatalog.defaultSupport, ["kalshi"]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
     }
   });
 });

--- a/test/doctor-redaction.test.mjs
+++ b/test/doctor-redaction.test.mjs
@@ -92,6 +92,27 @@ function assertRedacted(output, secret, label) {
 }
 
 describe("sportsclaw doctor credential redaction", () => {
+  it("reports installed schemas as sport and support-module totals even with a runtime filter", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "openai", model: "gpt-4.1" }),
+    });
+    const schemaDir = join(home, ".sportsclaw", "schemas");
+    mkdirSync(schemaDir, { recursive: true });
+    for (const sport of ["nba", "nfl", "kalshi"]) {
+      writeFileSync(join(schemaDir, `${sport}.json`), JSON.stringify({ sport, tools: [] }));
+    }
+    try {
+      const out = runDoctor(home, {
+        OPENAI_API_KEY: OPENAI_KEY,
+        SPORTSCLAW_SKILLS: "nba",
+      });
+      assert.match(out, /3 schemas \(2 sports, 1 support modules\)/);
+      assert.doesNotMatch(out, /3 sport schemas installed/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("does not print Azure Foundry key material or the configured base URL", () => {
     const home = makeHome({
       "config.json": JSON.stringify({ provider: "azure-foundry", model: "gpt-5.2" }),

--- a/test/doctor-redaction.test.mjs
+++ b/test/doctor-redaction.test.mjs
@@ -1,0 +1,216 @@
+/**
+ * Release gate: `sportsclaw doctor` must prove configuration without printing
+ * any credential substring or the configured private endpoint.
+ *
+ * Offline: doctor only shells out to python/machina locally — no network.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Sentinels: first 6 and last 4 characters are unique tokens that cannot occur
+// in doctor output by accident, so a masked `abc123...wxyz` render is detectable.
+const AZURE_KEY = "AZKEY0-sentinel-azure-key-material-9ZQ1";
+const AZURE_BASE_URL = "https://sentinel-endpoint-9f31.invalid/openai/v1";
+const AZURE_HOST = "sentinel-endpoint-9f31";
+// Assembled from fragments so no complete key-shaped literal exists in source
+// (secret scanners flag the joined form); the runtime value is unchanged.
+const ANTHROPIC_ENV_KEY = ["ANTENV", "sentinel", "anthropic", "env", "key", "8XQ2"].join("-");
+const ANTHROPIC_STORED_KEY = "ANTKCH-sentinel-anthropic-stored-7WQ3";
+const OPENAI_KEY = "OAIKEY-sentinel-openai-key-material-6VQ4";
+const DRIFT_SAVED_KEY = "DRIFTA-sentinel-config-json-key-5UQ5";
+// Assembled from fragments for the same reason as ANTHROPIC_ENV_KEY above.
+const DRIFT_DOTENV_KEY = ["DRIFTB", "sentinel", "dotenv", "key", "4TQ6"].join("-");
+
+const STRIPPED_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "AZURE_FOUNDRY_API_KEY",
+  "AZURE_FOUNDRY_BASE_URL",
+  "AZURE_FOUNDRY_API_MODE",
+  "AZURE_FOUNDRY_AUTH_MODE",
+  "SPORTSCLAW_PROVIDER",
+  "SPORTSCLAW_MODEL",
+  "TELEGRAM_BOT_TOKEN",
+  "DISCORD_BOT_TOKEN",
+];
+
+function makeHome(files) {
+  const home = mkdtempSync(join(tmpdir(), "sportsclaw-doctor-"));
+  const dir = join(home, ".sportsclaw");
+  mkdirSync(dir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(dir, name), contents);
+  }
+  return home;
+}
+
+/** Runs `node dist/index.js doctor` and returns stdout+stderr, tolerating a nonzero exit. */
+function runDoctor(home, extraEnv = {}) {
+  const env = { ...process.env, HOME: home, NO_COLOR: "1", ...extraEnv };
+  for (const key of STRIPPED_ENV_KEYS) {
+    if (!(key in extraEnv)) delete env[key];
+  }
+  try {
+    return execFileSync(process.execPath, ["dist/index.js", "doctor"], {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // Python / sports-skills checks can fail on this machine — doctor still
+    // printed the auth section, which is what we assert on.
+    const out = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    if (out.length > 0) return out;
+    throw err;
+  }
+}
+
+/** Asserts no full value, leading/trailing fragment, or masked render leaked. */
+function assertRedacted(output, secret, label) {
+  const first6 = secret.slice(0, 6);
+  const last4 = secret.slice(-4);
+  assert.ok(!output.includes(secret), `${label}: full value leaked`);
+  assert.ok(!output.includes(first6), `${label}: leading fragment "${first6}" leaked`);
+  assert.ok(!output.includes(last4), `${label}: trailing fragment "${last4}" leaked`);
+  assert.ok(
+    !output.includes(`${first6}...${last4}`),
+    `${label}: masked value leaked`,
+  );
+}
+
+describe("sportsclaw doctor credential redaction", () => {
+  it("does not print Azure Foundry key material or the configured base URL", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "azure-foundry", model: "gpt-5.2" }),
+      ".env": [
+        `AZURE_FOUNDRY_BASE_URL=${AZURE_BASE_URL}`,
+        "AZURE_FOUNDRY_AUTH_MODE=api_key",
+        `AZURE_FOUNDRY_API_KEY=${AZURE_KEY}`,
+        "",
+      ].join("\n"),
+    });
+    try {
+      const out = runDoctor(home);
+      assertRedacted(out, AZURE_KEY, "azure api key");
+      assert.ok(!out.includes(AZURE_HOST), "azure base URL host leaked");
+      assert.ok(!out.includes(AZURE_BASE_URL), "azure base URL leaked");
+      assert.match(out, /Azure Foundry API key configured/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not print the configured base URL in Azure Foundry Entra ID mode", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "azure-foundry", model: "gpt-5.2" }),
+      ".env": [
+        `AZURE_FOUNDRY_BASE_URL=${AZURE_BASE_URL}`,
+        "AZURE_FOUNDRY_AUTH_MODE=entra_id",
+        "",
+      ].join("\n"),
+    });
+    try {
+      const out = runDoctor(home);
+      assert.ok(!out.includes(AZURE_HOST), "azure base URL host leaked");
+      assert.ok(!out.includes(AZURE_BASE_URL), "azure base URL leaked");
+      assert.match(out, /Entra ID/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("still reports a missing Azure Foundry base URL", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "azure-foundry", model: "gpt-5.2" }),
+      ".env": "AZURE_FOUNDRY_AUTH_MODE=entra_id\n",
+    });
+    try {
+      const out = runDoctor(home);
+      assert.match(out, /AZURE_FOUNDRY_BASE_URL is not set/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not print Anthropic key material from the environment", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "anthropic", model: "claude-opus-5" }),
+    });
+    try {
+      const out = runDoctor(home, { ANTHROPIC_API_KEY: ANTHROPIC_ENV_KEY });
+      assertRedacted(out, ANTHROPIC_ENV_KEY, "anthropic env key");
+      assert.match(out, /Anthropic API key configured \(source: env\)/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not print Anthropic key material from the credential store", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "anthropic", model: "claude-opus-5" }),
+      "credentials.json": JSON.stringify({ ANTHROPIC_API_KEY: ANTHROPIC_STORED_KEY }),
+    });
+    try {
+      const out = runDoctor(home);
+      assertRedacted(out, ANTHROPIC_STORED_KEY, "anthropic stored key");
+      assert.match(out, /Anthropic API key configured \(source: keychain\)/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("still reports missing Anthropic credentials", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({ provider: "anthropic", model: "claude-opus-5" }),
+    });
+    try {
+      const out = runDoctor(home);
+      assert.match(out, /No Anthropic credentials/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not print key material for other providers", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({
+        provider: "openai",
+        model: "gpt-5.2",
+        apiKey: OPENAI_KEY,
+      }),
+    });
+    try {
+      const out = runDoctor(home);
+      assertRedacted(out, OPENAI_KEY, "openai key");
+      assert.match(out, /openai API key configured/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not print key material in the config drift report", () => {
+    const home = makeHome({
+      "config.json": JSON.stringify({
+        provider: "anthropic",
+        model: "claude-opus-5",
+        apiKey: DRIFT_SAVED_KEY,
+      }),
+      ".env": `ANTHROPIC_API_KEY=${DRIFT_DOTENV_KEY}\n`,
+    });
+    try {
+      const out = runDoctor(home);
+      assert.match(out, /Config drift/);
+      assertRedacted(out, DRIFT_SAVED_KEY, "drift config.json key");
+      assertRedacted(out, DRIFT_DOTENV_KEY, "drift .env key");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/doctor-redaction.test.mjs
+++ b/test/doctor-redaction.test.mjs
@@ -25,6 +25,12 @@ const OPENAI_KEY = "OAIKEY-sentinel-openai-key-material-6VQ4";
 const DRIFT_SAVED_KEY = "DRIFTA-sentinel-config-json-key-5UQ5";
 // Assembled from fragments for the same reason as ANTHROPIC_ENV_KEY above.
 const DRIFT_DOTENV_KEY = ["DRIFTB", "sentinel", "dotenv", "key", "4TQ6"].join("-");
+// Chat-integration drift sentinels — same fragment assembly, so no complete
+// bot-token-shaped literal exists in this source file.
+const DRIFT_TELEGRAM_SAVED = ["DRIFTC", "sentinel", "telegram", "config", "3SQ7"].join("-");
+const DRIFT_TELEGRAM_DOTENV = ["DRIFTD", "sentinel", "telegram", "dotenv", "2RQ8"].join("-");
+const DRIFT_DISCORD_SAVED = ["DRIFTE", "sentinel", "discord", "config", "1PQ9"].join("-");
+const DRIFT_DISCORD_DOTENV = ["DRIFTF", "sentinel", "discord", "dotenv", "0NQ0"].join("-");
 
 const STRIPPED_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
@@ -201,14 +207,27 @@ describe("sportsclaw doctor credential redaction", () => {
         provider: "anthropic",
         model: "claude-opus-5",
         apiKey: DRIFT_SAVED_KEY,
+        chatIntegrations: {
+          telegram: { botToken: DRIFT_TELEGRAM_SAVED },
+          discord: { botToken: DRIFT_DISCORD_SAVED },
+        },
       }),
-      ".env": `ANTHROPIC_API_KEY=${DRIFT_DOTENV_KEY}\n`,
+      ".env": [
+        `ANTHROPIC_API_KEY=${DRIFT_DOTENV_KEY}`,
+        `TELEGRAM_BOT_TOKEN=${DRIFT_TELEGRAM_DOTENV}`,
+        `DISCORD_BOT_TOKEN=${DRIFT_DISCORD_DOTENV}`,
+        "",
+      ].join("\n"),
     });
     try {
       const out = runDoctor(home);
       assert.match(out, /Config drift/);
       assertRedacted(out, DRIFT_SAVED_KEY, "drift config.json key");
       assertRedacted(out, DRIFT_DOTENV_KEY, "drift .env key");
+      assertRedacted(out, DRIFT_TELEGRAM_SAVED, "drift config.json telegram token");
+      assertRedacted(out, DRIFT_TELEGRAM_DOTENV, "drift .env telegram token");
+      assertRedacted(out, DRIFT_DISCORD_SAVED, "drift config.json discord token");
+      assertRedacted(out, DRIFT_DISCORD_DOTENV, "drift .env discord token");
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/test/durability.test.mjs
+++ b/test/durability.test.mjs
@@ -43,22 +43,30 @@ describe("DurableStateStore Substrate", () => {
 
   it("should auto-expire and delete files when TTL has passed", async () => {
     const data = { secret: "ephemeral" };
-    // Set an immediate TTL of 5ms
-    await store.save("memory", "temp_state", data, { ttlMs: 5 });
+    // Long TTL so the immediate read is guaranteed regardless of scheduling load.
+    await store.save("memory", "temp_state", data, { ttlMs: 60_000 });
 
     // Verify it is readable immediately
     const loadedImmediate = await store.load("memory", "temp_state");
     assert.deepEqual(loadedImmediate, data);
 
-    // Wait 20ms for expiration to trigger
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    // Age the record deterministically: rewrite the persisted envelope with an
+    // expiresAt in the past instead of sleeping past a short TTL.
+    const filePath = path.join(tmpRootDir, "memory", "temp_state.json");
+    const envelope = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    assert.strictEqual(envelope.namespace, "memory");
+    assert.strictEqual(envelope.id, "temp_state");
+    assert.deepEqual(envelope.data, data);
+    assert.ok(envelope.expiresAt, "TTL save must persist an expiresAt");
+
+    envelope.expiresAt = new Date(Date.now() - 60_000).toISOString();
+    fs.writeFileSync(filePath, JSON.stringify(envelope, null, 2));
 
     // Try to load again — should return null and the file should be deleted
     const loadedExpired = await store.load("memory", "temp_state");
     assert.strictEqual(loadedExpired, null, "Expired state should return null");
 
     // File should no longer exist on disk
-    const filePath = path.join(tmpRootDir, "memory", "temp_state.json");
     assert.strictEqual(fs.existsSync(filePath), false, "Expired file must be deleted");
   });
 

--- a/test/momentum-certification.test.mjs
+++ b/test/momentum-certification.test.mjs
@@ -207,17 +207,19 @@ describe("2026-08-08 revalidation is blocked, not passing", () => {
   });
 
   for (const sport of LIVE_REPORTED_SPORTS) {
-    it(`${sport} revalidation is recorded as blocked`, () => {
+    it(`${sport} records the revalidation and scoreboard discovery separately`, () => {
       const { revalidation } = bySport.get(sport);
       assert.equal(revalidation.recordedAt, REVALIDATION_AT);
-      assert.equal(revalidation.status, "blocked");
+      assert.ok(["blocked", "resolver-anomaly"].includes(revalidation.status));
+      assert.equal(revalidation.discoveryStatus, "blocked");
       assert.match(revalidation.command, /momentum-replay\.js/);
       assert.ok(revalidation.observedResult.length > 0);
+      assert.match(revalidation.discoveryObservedResult, /403/);
     });
 
     it(`${sport} revalidation claims no success`, () => {
       const { revalidation } = bySport.get(sport);
-      const text = `${revalidation.status} ${revalidation.observedResult}`;
+      const text = `${revalidation.status} ${revalidation.observedResult} ${revalidation.discoveryStatus} ${revalidation.discoveryObservedResult}`;
       assert.equal(
         /\b(passed|success(ful)?|verified|certified|confirmed)\b/i.test(text),
         false,
@@ -227,7 +229,7 @@ describe("2026-08-08 revalidation is blocked, not passing", () => {
 
     it(`${sport} revalidation embeds no HTML body or secret payload`, () => {
       const { revalidation } = bySport.get(sport);
-      const text = revalidation.observedResult;
+      const text = `${revalidation.observedResult} ${revalidation.discoveryObservedResult}`;
       assert.equal(/<[a-z!/]/i.test(text), false, `${sport}: no HTML markup in observedResult`);
       assert.equal(/akamai|reference\s*#/i.test(text), false, `${sport}: no CDN reference in observedResult`);
       assert.equal(
@@ -241,16 +243,20 @@ describe("2026-08-08 revalidation is blocked, not passing", () => {
 
   it("wnba revalidation records the ticker drift and the empty price series", () => {
     const { revalidation } = bySport.get("wnba");
+    assert.equal(revalidation.status, "resolver-anomaly");
     assert.match(revalidation.command, /wnba 401857073/);
     assert.match(revalidation.observedResult, /KXWNBAGAME-26JUL28INDSEA-IND/);
     assert.match(revalidation.observedResult, /0 price points/i);
+    assert.doesNotMatch(revalidation.observedResult, /403/);
   });
 
   it("mlb revalidation records the unresolved market and the ESPN 403", () => {
     const { revalidation } = bySport.get("mlb");
+    assert.equal(revalidation.status, "blocked");
     assert.match(revalidation.command, /mlb 401872178/);
     assert.match(revalidation.observedResult, /no Kalshi winner market/i);
-    assert.match(revalidation.observedResult, /403/);
+    assert.doesNotMatch(revalidation.observedResult, /403/);
+    assert.match(revalidation.discoveryObservedResult, /403/);
   });
 });
 
@@ -273,6 +279,7 @@ describe("markdown companion", () => {
     assert.match(markdown, /live-reported/);
     assert.match(markdown, /synthetic/);
     assert.match(markdown, /blocked/i);
+    assert.match(markdown, /resolver-anomaly/i);
     assert.match(markdown, new RegExp(REVALIDATION_AT));
   });
 

--- a/test/momentum-certification.test.mjs
+++ b/test/momentum-certification.test.mjs
@@ -1,0 +1,289 @@
+/**
+ * Momentum seven-sport certification artifact — honesty checks.
+ *
+ * This suite guards a claim, not a code path. The certification artifact says
+ * what evidence we actually hold for each of the seven momentum sports, and
+ * these tests exist to stop that artifact from quietly upgrading historical or
+ * synthetic evidence into a live certification we cannot produce receipts for.
+ *
+ * Pure file reads — no LLM, no network, no build output required.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const jsonPath = join(repoRoot, "docs/sports-data/momentum-certification.json");
+const mdPath = join(repoRoot, "docs/sports-data/momentum-certification.md");
+const demoReadmePath = join(repoRoot, "demo/vault_data/README.md");
+
+const rawJson = readFileSync(jsonPath, "utf8");
+const cert = JSON.parse(rawJson);
+const markdown = readFileSync(mdPath, "utf8");
+const demoReadme = readFileSync(demoReadmePath, "utf8");
+
+const EXPECTED_SPORTS = ["nfl", "mlb", "nba", "nhl", "wnba", "cfb", "cbb"];
+const LIVE_REPORTED_SPORTS = ["mlb", "wnba"];
+const REVALIDATION_AT = "2026-08-08T14:29:13Z";
+
+const rows = cert.sports;
+const bySport = new Map(rows.map((row) => [row.sport, row]));
+
+describe("certification roster", () => {
+  it("covers exactly the seven momentum sports with no duplicates", () => {
+    const sports = rows.map((row) => row.sport);
+    assert.equal(sports.length, 7);
+    assert.equal(new Set(sports).size, 7);
+    assert.deepEqual([...sports].sort(), [...EXPECTED_SPORTS].sort());
+  });
+
+  it("stamps the artifact with the generation timestamp", () => {
+    assert.equal(cert.generatedAt, REVALIDATION_AT);
+  });
+
+  it("states up front that synthetic proves mechanics and no row is live-certified", () => {
+    assert.match(cert.statement, /synthetic/i);
+    assert.match(cert.statement, /mechanic/i);
+    assert.match(cert.statement, /historical/i);
+    assert.match(cert.statement, /no row is currently live-certified/i);
+  });
+});
+
+describe("no row claims live certification", () => {
+  it("uses only the two honest evidence types", () => {
+    for (const row of rows) {
+      assert.ok(
+        ["live-reported", "synthetic"].includes(row.evidenceType),
+        `${row.sport}: unexpected evidenceType ${row.evidenceType}`,
+      );
+      assert.notEqual(row.evidenceType, "live-certified");
+    }
+  });
+
+  it("uses only pending certification statuses", () => {
+    for (const row of rows) {
+      assert.ok(
+        ["pending-live-revalidation", "pending-live"].includes(row.certificationStatus),
+        `${row.sport}: unexpected certificationStatus ${row.certificationStatus}`,
+      );
+      assert.notEqual(row.certificationStatus, "live-certified");
+    }
+  });
+
+  it("never emits live-certified as a bare value anywhere in the artifact", () => {
+    assert.equal(/:\s*"live-certified"/.test(rawJson), false);
+    assert.equal(/"live-certified"\s*[,\]]/.test(rawJson), false);
+  });
+
+  it("marks every one of the seven sports as pending live", () => {
+    for (const row of rows) {
+      assert.equal(row.pendingLive, true, `${row.sport}: pendingLive must be true`);
+    }
+  });
+
+  it("gives every row the full receipt shape", () => {
+    for (const row of rows) {
+      for (const field of [
+        "evidenceRecordedAt",
+        "espnEventId",
+        "marketResolution",
+        "outputVerdict",
+        "evaluatorVerdict",
+        "latencyMs",
+        "fixturePath",
+        "receiptSources",
+        "pendingLive",
+        "notes",
+      ]) {
+        assert.ok(field in row, `${row.sport}: missing field ${field}`);
+      }
+      assert.ok(Array.isArray(row.receiptSources), `${row.sport}: receiptSources must be an array`);
+      assert.ok(row.notes.length > 0, `${row.sport}: notes must be non-empty`);
+    }
+  });
+});
+
+describe("live-reported rows (mlb, wnba)", () => {
+  it("are exactly mlb and wnba", () => {
+    const live = rows.filter((row) => row.evidenceType === "live-reported").map((row) => row.sport);
+    assert.deepEqual([...live].sort(), [...LIVE_REPORTED_SPORTS].sort());
+  });
+
+  for (const sport of LIVE_REPORTED_SPORTS) {
+    it(`${sport} carries an ESPN event id, market resolution and a receipt source`, () => {
+      const row = bySport.get(sport);
+      assert.ok(row.espnEventId, `${sport}: espnEventId is required for live-reported evidence`);
+      assert.ok(row.marketResolution, `${sport}: marketResolution is required`);
+      assert.ok(row.marketResolution.ticker, `${sport}: marketResolution.ticker is required`);
+      assert.ok(row.receiptSources.length > 0, `${sport}: at least one receipt source is required`);
+      assert.match(row.receiptSources.join(" "), /github\.com\/machina-sports\/sportsclaw\/pull\/135/);
+    });
+
+    it(`${sport} stays pending-live-revalidation even though latency was not retained`, () => {
+      const row = bySport.get(sport);
+      assert.equal(row.certificationStatus, "pending-live-revalidation");
+      // Latency receipts were not retained; null is allowed, a number is not invented.
+      assert.ok(
+        row.latencyMs === null || typeof row.latencyMs === "number",
+        `${sport}: latencyMs must be null or a number`,
+      );
+      assert.equal(row.fixturePath, null, `${sport}: live-reported rows have no fixture`);
+    });
+  }
+
+  it("wnba records the originally reported ticker and the recording commit", () => {
+    const row = bySport.get("wnba");
+    assert.equal(row.espnEventId, "401857073");
+    assert.equal(row.marketResolution.ticker, "KXWNBAGAME-26JUL17SEAIND-IND");
+    assert.equal(row.evidenceRecordedAt, "2026-07-18T15:44:32Z");
+    assert.match(row.receiptSources.join(" "), /21ec5b8854150e067146262df7f0dae1e878e9fe/);
+  });
+
+  it("mlb does not invent output or evaluator counts that were never retained", () => {
+    const row = bySport.get("mlb");
+    assert.equal(row.espnEventId, "401872178");
+    assert.equal(row.marketResolution.ticker, "KXMLBGAME-26JUL171335TBBOSG1-BOS");
+    assert.equal(row.outputVerdict, "not-retained");
+    assert.equal(row.evaluatorVerdict, "not-retained");
+    assert.equal(row.latencyMs, null);
+  });
+});
+
+describe("synthetic rows", () => {
+  const syntheticSports = ["nfl", "nba", "nhl", "cfb", "cbb"];
+
+  it("are exactly the five fixture-backed sports", () => {
+    const synthetic = rows.filter((row) => row.evidenceType === "synthetic").map((row) => row.sport);
+    assert.deepEqual([...synthetic].sort(), [...syntheticSports].sort());
+  });
+
+  for (const sport of syntheticSports) {
+    it(`${sport} points at a fixture that exists on disk and stays pending-live`, () => {
+      const row = bySport.get(sport);
+      assert.ok(row.fixturePath, `${sport}: fixturePath is required for synthetic evidence`);
+      assert.ok(
+        existsSync(join(repoRoot, row.fixturePath)),
+        `${sport}: fixture ${row.fixturePath} does not exist`,
+      );
+      assert.equal(row.certificationStatus, "pending-live");
+      assert.equal(row.marketResolution, null, `${sport}: synthetic rows resolve no live market`);
+      assert.equal(row.espnEventId, null, `${sport}: synthetic rows have no ESPN event`);
+    });
+  }
+
+  it("uses the NFL demo fixture for nfl and the per-sport fixtures elsewhere", () => {
+    assert.equal(bySport.get("nfl").fixturePath, "demo/vault_data/mock_game.json");
+    for (const sport of ["nba", "nhl", "cfb", "cbb"]) {
+      assert.equal(bySport.get(sport).fixturePath, `demo/vault_data/mock_game_${sport}.json`);
+    }
+  });
+
+  it("records accepted cards only for nfl, nba, cfb and cbb", () => {
+    for (const sport of ["nfl", "nba", "cfb", "cbb"]) {
+      assert.equal(bySport.get(sport).evaluatorVerdict, "accepted", `${sport}: expected accepted card`);
+    }
+  });
+});
+
+describe("nhl never becomes an accepted card", () => {
+  it("stays on the held / evaluator-rejection path", () => {
+    const row = bySport.get("nhl");
+    assert.notEqual(row.evaluatorVerdict, "accepted");
+    assert.ok(
+      ["held", "rejected"].includes(row.evaluatorVerdict),
+      `nhl: evaluatorVerdict must be held or rejected, got ${row.evaluatorVerdict}`,
+    );
+    assert.match(row.notes, /held|reject/i);
+  });
+});
+
+describe("2026-08-08 revalidation is blocked, not passing", () => {
+  it("only mlb and wnba carry a fresh revalidation attempt", () => {
+    const withRevalidation = rows.filter((row) => row.revalidation).map((row) => row.sport);
+    assert.deepEqual([...withRevalidation].sort(), [...LIVE_REPORTED_SPORTS].sort());
+  });
+
+  for (const sport of LIVE_REPORTED_SPORTS) {
+    it(`${sport} revalidation is recorded as blocked`, () => {
+      const { revalidation } = bySport.get(sport);
+      assert.equal(revalidation.recordedAt, REVALIDATION_AT);
+      assert.equal(revalidation.status, "blocked");
+      assert.match(revalidation.command, /momentum-replay\.js/);
+      assert.ok(revalidation.observedResult.length > 0);
+    });
+
+    it(`${sport} revalidation claims no success`, () => {
+      const { revalidation } = bySport.get(sport);
+      const text = `${revalidation.status} ${revalidation.observedResult}`;
+      assert.equal(
+        /\b(passed|success(ful)?|verified|certified|confirmed)\b/i.test(text),
+        false,
+        `${sport}: blocked revalidation must not read as a pass`,
+      );
+    });
+
+    it(`${sport} revalidation embeds no HTML body or secret payload`, () => {
+      const { revalidation } = bySport.get(sport);
+      const text = revalidation.observedResult;
+      assert.equal(/<[a-z!/]/i.test(text), false, `${sport}: no HTML markup in observedResult`);
+      assert.equal(/akamai|reference\s*#/i.test(text), false, `${sport}: no CDN reference in observedResult`);
+      assert.equal(
+        /(api[-_ ]?key|bearer\s|authorization:|secret|token)/i.test(text),
+        false,
+        `${sport}: no credential material in observedResult`,
+      );
+      assert.ok(text.length <= 400, `${sport}: observedResult must stay concise`);
+    });
+  }
+
+  it("wnba revalidation records the ticker drift and the empty price series", () => {
+    const { revalidation } = bySport.get("wnba");
+    assert.match(revalidation.command, /wnba 401857073/);
+    assert.match(revalidation.observedResult, /KXWNBAGAME-26JUL28INDSEA-IND/);
+    assert.match(revalidation.observedResult, /0 price points/i);
+  });
+
+  it("mlb revalidation records the unresolved market and the ESPN 403", () => {
+    const { revalidation } = bySport.get("mlb");
+    assert.match(revalidation.command, /mlb 401872178/);
+    assert.match(revalidation.observedResult, /no Kalshi winner market/i);
+    assert.match(revalidation.observedResult, /403/);
+  });
+});
+
+describe("markdown companion", () => {
+  it("has a row for each of the seven sports", () => {
+    for (const sport of EXPECTED_SPORTS) {
+      assert.match(
+        markdown,
+        new RegExp(`\\|\\s*${sport}\\s*\\|`, "i"),
+        `markdown is missing a table row for ${sport}`,
+      );
+    }
+  });
+
+  it("says plainly that no sport is currently live-certified", () => {
+    assert.match(markdown, /no sport[^.]{0,60}live-certified/i);
+  });
+
+  it("names both evidence types and the blocked revalidation", () => {
+    assert.match(markdown, /live-reported/);
+    assert.match(markdown, /synthetic/);
+    assert.match(markdown, /blocked/i);
+    assert.match(markdown, new RegExp(REVALIDATION_AT));
+  });
+
+  it("never asserts a live-certified row", () => {
+    assert.equal(/\bis live-certified\b/i.test(markdown), false);
+  });
+});
+
+describe("demo vault README cross-link", () => {
+  it("links the certification JSON and Markdown", () => {
+    assert.match(demoReadme, /docs\/sports-data\/momentum-certification\.json/);
+    assert.match(demoReadme, /docs\/sports-data\/momentum-certification\.md/);
+  });
+});

--- a/test/operate.test.mjs
+++ b/test/operate.test.mjs
@@ -19,6 +19,7 @@ import {
   resolveExtraFragments,
   resolvePersona,
   runSinkPolledLoop,
+  validateOperatorToolCount,
 } from "../dist/operate.js";
 
 // ---------------------------------------------------------------------------
@@ -68,6 +69,51 @@ describe("operator skill filter", () => {
       applyOperatorSkillFilter(["cfb"]);
       assert.strictEqual(process.env.SPORTSCLAW_SKILLS, "");
     });
+  });
+});
+
+describe("operator provider tool ceiling", () => {
+  it("allows unlimited providers to keep an all-tools job", () => {
+    for (const provider of ["anthropic", "google"]) {
+      assert.doesNotThrow(() => validateOperatorToolCount({
+        provider,
+        toolCount: 291,
+        jobId: "all-sports",
+        skills: undefined,
+      }));
+    }
+  });
+
+  it("allows focused capped-provider jobs at or below 128 tools", () => {
+    for (const provider of ["openai", "azure-foundry"]) {
+      assert.doesNotThrow(() => validateOperatorToolCount({
+        provider,
+        toolCount: 128,
+        jobId: "focused",
+        skills: ["nba"],
+      }));
+    }
+  });
+
+  it("fails capped-provider jobs early without slicing and tells operators to configure skills", () => {
+    for (const provider of ["openai", "azure-foundry"]) {
+      assert.throws(
+        () => validateOperatorToolCount({
+          provider,
+          toolCount: 291,
+          jobId: "all-sports",
+          skills: undefined,
+        }),
+        (err) => {
+          assert.match(err.message, /all-sports/);
+          assert.match(err.message, /291/);
+          assert.match(err.message, /128/);
+          assert.match(err.message, /skills/i);
+          assert.doesNotMatch(err.message, /truncat|slice/i);
+          return true;
+        },
+      );
+    }
   });
 });
 

--- a/test/provider-tool-cap.test.mjs
+++ b/test/provider-tool-cap.test.mjs
@@ -21,11 +21,9 @@ import os from "node:os";
 import { sportsclawEngine } from "../dist/index.js";
 import {
   PROVIDER_TOOL_CEILING,
+  ProviderToolCeilingError,
   finalizeActiveTools,
 } from "../dist/routing/tool-activation.js";
-
-/** Providers cap tool definitions at 128; the registry is far larger. */
-const PROVIDER_CEILING = 128;
 
 const SPORTS = [
   "nba", "nfl", "mlb", "nhl", "football", "tennis", "golf", "cricket",
@@ -41,8 +39,15 @@ const INTERNAL_TOOLS = [
   "cancel_scheduled_task", "consolidate_memory", "run_selftest",
 ];
 
-/** Reproduces the shipped 291-tool registry: 19 internal + 272 sport tools. */
-function buildLargeRegistry() {
+/** Name of the MCP tool used by the MCP-visibility fixture variant. */
+const MCP_TOOL = "mcp__demo__health";
+
+/**
+ * Reproduces the shipped 291-tool registry: 19 internal + 272 sport tools.
+ * With `{ withMcpTool: true }` one sport tool is swapped for an MCP tool, so
+ * the registry stays at 291 while carrying a tool that must survive routing.
+ */
+function buildLargeRegistry({ withMcpTool = false } = {}) {
   const skillOf = new Map();
   const sportTools = [];
   for (let i = 0; i < 272; i++) {
@@ -50,6 +55,11 @@ function buildLargeRegistry() {
     const name = `${sport}_tool_${i}`;
     sportTools.push(name);
     skillOf.set(name, sport);
+  }
+  if (withMcpTool) {
+    const replaced = sportTools[sportTools.length - 1];
+    skillOf.delete(replaced);
+    sportTools[sportTools.length - 1] = MCP_TOOL;
   }
   const toolNames = [...INTERNAL_TOOLS, ...sportTools];
   return {
@@ -81,10 +91,10 @@ const offlineModel = {
   },
 };
 
-function makeEngine() {
+function makeEngine(options) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-tool-cap-"));
   const engine = new sportsclawEngine({ rootDir: tmpDir, verbose: false });
-  const { toolNames, registry } = buildLargeRegistry();
+  const { toolNames, registry } = buildLargeRegistry(options);
   engine.registry = registry;
   engine.mainModel = offlineModel;
   return { engine, toolNames, cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }) };
@@ -107,8 +117,8 @@ describe("Provider tool-cap overflow", () => {
         "activeTools must be present — omitting it makes the AI SDK send all 291 tools and the provider rejects the request",
       );
       assert.ok(
-        routing.activeTools.length <= PROVIDER_CEILING,
-        `activeTools must stay within the ${PROVIDER_CEILING}-tool provider ceiling, got ${routing.activeTools.length}`,
+        routing.activeTools.length <= PROVIDER_TOOL_CEILING,
+        `activeTools must stay within the ${PROVIDER_TOOL_CEILING}-tool provider ceiling, got ${routing.activeTools.length}`,
       );
       assert.deepEqual(
         routing.activeTools.filter((n) => !INTERNAL_TOOLS.includes(n)),
@@ -118,6 +128,37 @@ describe("Provider tool-cap overflow", () => {
       assert.ok(
         routing.activeTools.includes("generate_image"),
         "internal tools must stay available on a conversational turn",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("keeps an MCP tool active on a no-sport route through the 291-tool registry", async () => {
+    const { engine, toolNames, cleanup } = makeEngine({ withMcpTool: true });
+    try {
+      assert.equal(toolNames.length, 291, "fixture must reproduce the 291-tool registry");
+      assert.ok(toolNames.includes(MCP_TOOL), "fixture must carry the MCP tool");
+
+      const routing = await engine.resolveActiveToolsForPrompt(
+        "hey, how are you doing today?",
+        toolNames,
+        undefined,
+      );
+
+      assert.ok(Array.isArray(routing.activeTools), "activeTools must be an explicit list");
+      assert.ok(
+        routing.activeTools.includes(MCP_TOOL),
+        `${MCP_TOOL} must stay active — MCP tools are not sport-schema tools and routing must never drop them`,
+      );
+      assert.ok(
+        routing.activeTools.length <= PROVIDER_TOOL_CEILING,
+        `activeTools must stay within the ${PROVIDER_TOOL_CEILING}-tool provider ceiling, got ${routing.activeTools.length}`,
+      );
+      assert.deepEqual(
+        routing.activeTools.filter((n) => !INTERNAL_TOOLS.includes(n) && n !== MCP_TOOL),
+        [],
+        "no sport-schema tool may be active when routing selected no skill",
       );
     } finally {
       cleanup();
@@ -164,5 +205,128 @@ describe("finalizeActiveTools — provider ceiling boundary", () => {
         `registry of ${totalToolCount} fits the provider ceiling, so the old widen-to-all behavior is preserved`,
       );
     }
+  });
+});
+
+describe("finalizeActiveTools — oversized registry never resolves to undefined", () => {
+  it("fails closed with an empty list on a first turn when routing produced no filter", () => {
+    const active = finalizeActiveTools({
+      routedActiveTools: undefined,
+      isFollowUp: false,
+      lowConfidence: false,
+      historyToolNames: [],
+      totalToolCount: PROVIDER_TOOL_CEILING + 1,
+    });
+
+    assert.deepEqual(
+      active,
+      [],
+      "an oversized registry with no routed filter must send an explicit empty list, not `undefined` (= all tools)",
+    );
+  });
+
+  it("fails closed with the deduped history tools on a follow-up when routing produced no filter", () => {
+    const active = finalizeActiveTools({
+      routedActiveTools: undefined,
+      isFollowUp: true,
+      lowConfidence: false,
+      historyToolNames: ["nba_scores", "reflect", "nba_scores"],
+      totalToolCount: PROVIDER_TOOL_CEILING + 1,
+    });
+
+    assert.ok(Array.isArray(active), "must never fall back to `undefined` above the ceiling");
+    assert.deepEqual(
+      [...active].sort(),
+      ["nba_scores", "reflect"],
+      "historical tool calls must stay defined, deduped, with no other tool added",
+    );
+  });
+
+  it("still allows undefined below the ceiling when routing produced no filter", () => {
+    assert.equal(
+      finalizeActiveTools({
+        routedActiveTools: undefined,
+        isFollowUp: false,
+        lowConfidence: false,
+        historyToolNames: [],
+        totalToolCount: PROVIDER_TOOL_CEILING,
+      }),
+      undefined,
+      "small-registry behavior is unchanged: no filter means the whole registry is safe to send",
+    );
+  });
+});
+
+describe("finalizeActiveTools — explicit list never silently truncates", () => {
+  const toolList = (count, prefix = "tool") =>
+    Array.from({ length: count }, (_, i) => `${prefix}_${i}`);
+
+  it(`accepts an explicit list of exactly ${PROVIDER_TOOL_CEILING} tools`, () => {
+    const routedActiveTools = toolList(PROVIDER_TOOL_CEILING);
+    const active = finalizeActiveTools({
+      routedActiveTools,
+      isFollowUp: false,
+      lowConfidence: false,
+      historyToolNames: [],
+      totalToolCount: 291,
+    });
+
+    assert.equal(active.length, PROVIDER_TOOL_CEILING);
+    assert.deepEqual(active, routedActiveTools);
+  });
+
+  it(`rejects an explicit routed list of ${PROVIDER_TOOL_CEILING + 1} tools before the provider is called`, () => {
+    assert.throws(
+      () =>
+        finalizeActiveTools({
+          routedActiveTools: toolList(PROVIDER_TOOL_CEILING + 1),
+          isFollowUp: false,
+          lowConfidence: false,
+          historyToolNames: [],
+          totalToolCount: 291,
+        }),
+      (err) => {
+        assert.ok(
+          err instanceof ProviderToolCeilingError,
+          "must raise the local pre-provider ceiling error",
+        );
+        assert.match(err.message, new RegExp(String(PROVIDER_TOOL_CEILING)));
+        assert.match(err.message, new RegExp(String(PROVIDER_TOOL_CEILING + 1)));
+        assert.equal(err.ceiling, PROVIDER_TOOL_CEILING);
+        assert.equal(err.count, PROVIDER_TOOL_CEILING + 1);
+        return true;
+      },
+    );
+  });
+
+  it(`rejects a merged routed+history list of ${PROVIDER_TOOL_CEILING + 1} tools`, () => {
+    assert.throws(
+      () =>
+        finalizeActiveTools({
+          routedActiveTools: toolList(PROVIDER_TOOL_CEILING),
+          isFollowUp: true,
+          lowConfidence: false,
+          historyToolNames: ["history_only_tool"],
+          totalToolCount: 291,
+        }),
+      (err) => {
+        assert.ok(err instanceof ProviderToolCeilingError);
+        assert.equal(err.count, PROVIDER_TOOL_CEILING + 1);
+        return true;
+      },
+    );
+  });
+
+  it("accepts a merged list that dedupes back down to the ceiling", () => {
+    const routedActiveTools = toolList(PROVIDER_TOOL_CEILING);
+    const active = finalizeActiveTools({
+      routedActiveTools,
+      isFollowUp: true,
+      lowConfidence: false,
+      historyToolNames: [routedActiveTools[0], routedActiveTools[5]],
+      totalToolCount: 291,
+    });
+
+    assert.equal(active.length, PROVIDER_TOOL_CEILING);
   });
 });

--- a/test/provider-tool-cap.test.mjs
+++ b/test/provider-tool-cap.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * Provider tool-cap overflow — regression suite
+ *
+ * Azure Foundry / OpenAI reject any request carrying more than 128 tool
+ * definitions ("Invalid tools: array too long. Expected maximum 128, got 291").
+ * The Vercel AI SDK only narrows the tool payload when `activeTools` is set —
+ * omitting it sends the WHOLE registry. With all 22 sport schemas installed the
+ * registry is 291 tools, so any route that omits `activeTools` is a hard
+ * provider failure, not a soft degradation.
+ *
+ * These tests are fully offline: the registry is stubbed and the router model
+ * throws, which `routePromptToSkills` catches (deterministic heuristic path).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { sportsclawEngine } from "../dist/index.js";
+import {
+  PROVIDER_TOOL_CEILING,
+  finalizeActiveTools,
+} from "../dist/routing/tool-activation.js";
+
+/** Providers cap tool definitions at 128; the registry is far larger. */
+const PROVIDER_CEILING = 128;
+
+const SPORTS = [
+  "nba", "nfl", "mlb", "nhl", "football", "tennis", "golf", "cricket",
+  "volleyball", "wnba", "cbb", "cfb", "fastf1", "xctf", "news", "metadata",
+  "kalshi", "polymarket", "betting", "markets", "esports", "openshell",
+];
+
+const INTERNAL_TOOLS = [
+  "generate_image", "generate_video", "update_agent_config", "update_context",
+  "update_fan_profile", "update_soul", "reflect", "evolve_strategy",
+  "get_agent_config", "install_sport", "remove_sport", "upgrade_sports_skills",
+  "spawn_subagent", "list_subagents", "schedule_task", "list_scheduled_tasks",
+  "cancel_scheduled_task", "consolidate_memory", "run_selftest",
+];
+
+/** Reproduces the shipped 291-tool registry: 19 internal + 272 sport tools. */
+function buildLargeRegistry() {
+  const skillOf = new Map();
+  const sportTools = [];
+  for (let i = 0; i < 272; i++) {
+    const sport = SPORTS[i % SPORTS.length];
+    const name = `${sport}_tool_${i}`;
+    sportTools.push(name);
+    skillOf.set(name, sport);
+  }
+  const toolNames = [...INTERNAL_TOOLS, ...sportTools];
+  return {
+    toolNames,
+    registry: {
+      getInstalledSkills: () => [...SPORTS],
+      getAllToolSpecs: () =>
+        toolNames.map((name) => ({
+          name,
+          description: `tool ${name}`,
+          parameters: {},
+        })),
+      getSkillName: (name) => skillOf.get(name),
+    },
+  };
+}
+
+/** A model whose calls always fail, so no test ever reaches the network. */
+const offlineModel = {
+  specificationVersion: "v2",
+  provider: "offline-test",
+  modelId: "offline-test",
+  supportedUrls: {},
+  async doGenerate() {
+    throw new Error("offline test model: no network calls in tests");
+  },
+  async doStream() {
+    throw new Error("offline test model: no network calls in tests");
+  },
+};
+
+function makeEngine() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-tool-cap-"));
+  const engine = new sportsclawEngine({ rootDir: tmpDir, verbose: false });
+  const { toolNames, registry } = buildLargeRegistry();
+  engine.registry = registry;
+  engine.mainModel = offlineModel;
+  return { engine, toolNames, cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }) };
+}
+
+describe("Provider tool-cap overflow", () => {
+  it("a no-sport conversational first turn keeps an active tool filter instead of exposing all 291 registry tools", async () => {
+    const { engine, toolNames, cleanup } = makeEngine();
+    try {
+      assert.equal(toolNames.length, 291, "fixture must reproduce the 291-tool registry");
+
+      const routing = await engine.resolveActiveToolsForPrompt(
+        "hey, how are you doing today?",
+        toolNames,
+        undefined,
+      );
+
+      assert.ok(
+        Array.isArray(routing.activeTools),
+        "activeTools must be present — omitting it makes the AI SDK send all 291 tools and the provider rejects the request",
+      );
+      assert.ok(
+        routing.activeTools.length <= PROVIDER_CEILING,
+        `activeTools must stay within the ${PROVIDER_CEILING}-tool provider ceiling, got ${routing.activeTools.length}`,
+      );
+      assert.deepEqual(
+        routing.activeTools.filter((n) => !INTERNAL_TOOLS.includes(n)),
+        [],
+        "no sport-schema tool may be active when routing selected no skill",
+      );
+      assert.ok(
+        routing.activeTools.includes("generate_image"),
+        "internal tools must stay available on a conversational turn",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("finalizeActiveTools — provider ceiling boundary", () => {
+  it("exposes the provider ceiling as 128", () => {
+    assert.equal(PROVIDER_TOOL_CEILING, 128);
+  });
+
+  it("keeps the routed filter and merges history on a low-confidence follow-up when the registry exceeds the ceiling", () => {
+    const active = finalizeActiveTools({
+      routedActiveTools: ["generate_image", "reflect"],
+      isFollowUp: true,
+      lowConfidence: true,
+      historyToolNames: ["nba_scores", "reflect"],
+      totalToolCount: PROVIDER_TOOL_CEILING + 1,
+    });
+
+    assert.ok(
+      Array.isArray(active),
+      "an oversized registry must never fall back to `undefined` (= send all tools)",
+    );
+    assert.deepEqual(
+      [...active].sort(),
+      ["generate_image", "nba_scores", "reflect"],
+      "routed filter is preserved and widened with history tools, deduped, not truncated",
+    );
+  });
+
+  it("returns undefined on a low-confidence follow-up when the registry fits the ceiling", () => {
+    for (const totalToolCount of [PROVIDER_TOOL_CEILING - 1, PROVIDER_TOOL_CEILING]) {
+      assert.equal(
+        finalizeActiveTools({
+          routedActiveTools: ["generate_image"],
+          isFollowUp: true,
+          lowConfidence: true,
+          historyToolNames: ["nba_scores"],
+          totalToolCount,
+        }),
+        undefined,
+        `registry of ${totalToolCount} fits the provider ceiling, so the old widen-to-all behavior is preserved`,
+      );
+    }
+  });
+});

--- a/test/provider-tool-cap.test.mjs
+++ b/test/provider-tool-cap.test.mjs
@@ -24,6 +24,7 @@ import {
   ProviderToolCeilingError,
   finalizeActiveTools,
   providerToolCeiling,
+  resolveParallelAgentRoutedTools,
 } from "../dist/routing/tool-activation.js";
 
 const SPORTS = [
@@ -38,20 +39,26 @@ const INTERNAL_TOOLS = [
   "get_agent_config", "install_sport", "remove_sport", "upgrade_sports_skills",
   "spawn_subagent", "list_subagents", "schedule_task", "list_scheduled_tasks",
   "cancel_scheduled_task", "consolidate_memory", "run_selftest",
+  "ask_user_question", "write_file", "execute_command", "render_chart", "create_task",
+];
+
+const REVIEW_ENGINE_TOOLS = [
+  "ask_user_question", "write_file", "execute_command", "render_chart", "create_task",
 ];
 
 /** Name of the MCP tool used by the MCP-visibility fixture variant. */
 const MCP_TOOL = "mcp__demo__health";
 
 /**
- * Reproduces the shipped 291-tool registry: 19 internal + 272 sport tools.
+ * Reproduces the shipped 291-tool registry with engine-owned and sport tools.
  * With `{ withMcpTool: true }` one sport tool is swapped for an MCP tool, so
  * the registry stays at 291 while carrying a tool that must survive routing.
  */
 function buildLargeRegistry({ withMcpTool = false } = {}) {
   const skillOf = new Map();
   const sportTools = [];
-  for (let i = 0; i < 272; i++) {
+  const sportToolCount = 291 - INTERNAL_TOOLS.length;
+  for (let i = 0; i < sportToolCount; i++) {
     const sport = SPORTS[i % SPORTS.length];
     const name = `${sport}_tool_${i}`;
     sportTools.push(name);
@@ -130,6 +137,12 @@ describe("Provider tool-cap overflow", () => {
         routing.activeTools.includes("generate_image"),
         "internal tools must stay available on a conversational turn",
       );
+      for (const name of REVIEW_ENGINE_TOOLS) {
+        assert.ok(
+          routing.activeTools.includes(name),
+          `${name} must stay active when getSkillName() reports no sport owner`,
+        );
+      }
     } finally {
       cleanup();
     }
@@ -164,6 +177,91 @@ describe("Provider tool-cap overflow", () => {
     } finally {
       cleanup();
     }
+  });
+
+  it("keeps every engine-owned fixture tool and MCP while skill-filtering a specialized agent", () => {
+    const { engine, toolNames, cleanup } = makeEngine({ withMcpTool: true });
+    try {
+      assert.equal(toolNames.length, 291, "fixture must stay at exactly 291 tools");
+      const active = engine.filterToolsForAgent(
+        { id: "nba", name: "NBA", skills: ["nba"], tags: [], body: "" },
+        toolNames,
+      );
+
+      assert.ok(Array.isArray(active));
+      for (const name of REVIEW_ENGINE_TOOLS) {
+        assert.ok(active.includes(name), `${name} must remain active for a skilled agent`);
+      }
+      assert.ok(active.includes(MCP_TOOL), "MCP tools must remain active for a skilled agent");
+      assert.ok(active.some((name) => name.startsWith("nba_tool_")));
+      assert.ok(!active.some((name) => name.startsWith("nfl_tool_")));
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("parallel generalist tool routing", () => {
+  const mainActiveTools = ["generate_image", "nba_scores"];
+
+  it("preserves no-filter semantics for uncapped providers", () => {
+    for (const provider of ["anthropic", "google"]) {
+      assert.equal(
+        resolveParallelAgentRoutedTools({
+          agentRoutedTools: undefined,
+          mainActiveTools,
+          totalToolCount: 291,
+          ceiling: providerToolCeiling(provider),
+        }),
+        undefined,
+        provider,
+      );
+    }
+  });
+
+  it("preserves no-filter semantics when a capped provider can fit the registry", () => {
+    assert.equal(
+      resolveParallelAgentRoutedTools({
+        agentRoutedTools: undefined,
+        mainActiveTools,
+        totalToolCount: PROVIDER_TOOL_CEILING,
+        ceiling: providerToolCeiling("openai"),
+      }),
+      undefined,
+    );
+  });
+
+  it("falls back to the safe main filter only for a capped oversized registry", () => {
+    const routed = resolveParallelAgentRoutedTools({
+      agentRoutedTools: undefined,
+      mainActiveTools,
+      totalToolCount: PROVIDER_TOOL_CEILING + 1,
+      ceiling: providerToolCeiling("azure-foundry"),
+    });
+    assert.deepEqual(routed, mainActiveTools);
+
+    const finalized = finalizeActiveTools({
+      routedActiveTools: routed,
+      isFollowUp: true,
+      lowConfidence: false,
+      historyToolNames: ["history_tool"],
+      totalToolCount: PROVIDER_TOOL_CEILING + 1,
+      ceiling: providerToolCeiling("azure-foundry"),
+    });
+    assert.deepEqual(finalized, [...mainActiveTools, "history_tool"]);
+  });
+
+  it("preserves a specialized agent's own filter", () => {
+    const agentRoutedTools = ["generate_image", "nfl_scores"];
+    assert.equal(
+      resolveParallelAgentRoutedTools({
+        agentRoutedTools,
+        mainActiveTools,
+        totalToolCount: 291,
+        ceiling: providerToolCeiling("openai"),
+      }),
+      agentRoutedTools,
+    );
   });
 });
 
@@ -379,10 +477,10 @@ describe("finalizeActiveTools — explicit list never silently truncates", () =>
 });
 
 describe("no installed skills / no MCP regression", () => {
-  it("keeps the small internal registry available instead of resolving to zero tools", async () => {
+  it("keeps every engine-owned tool explicitly active instead of using a partial allowlist", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-tool-small-"));
     const engine = new sportsclawEngine({ rootDir: tmpDir, verbose: false });
-    const toolNames = ["generate_image", "reflect", "run_selftest"];
+    const toolNames = ["generate_image", "reflect", "run_selftest", ...REVIEW_ENGINE_TOOLS];
     engine.registry = {
       getInstalledSkills: () => [],
       getAllToolSpecs: () => [],
@@ -390,7 +488,7 @@ describe("no installed skills / no MCP regression", () => {
     };
     try {
       const routing = await engine.resolveActiveToolsForPrompt("hello", toolNames);
-      assert.equal(routing.activeTools, undefined);
+      assert.deepEqual(routing.activeTools, toolNames);
       const final = finalizeActiveTools({
         routedActiveTools: routing.activeTools,
         isFollowUp: false,
@@ -399,7 +497,7 @@ describe("no installed skills / no MCP regression", () => {
         totalToolCount: toolNames.length,
         ceiling: providerToolCeiling("openai"),
       });
-      assert.equal(final, undefined, "undefined intentionally exposes the small registry");
+      assert.deepEqual(final, toolNames);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/provider-tool-cap.test.mjs
+++ b/test/provider-tool-cap.test.mjs
@@ -23,6 +23,7 @@ import {
   PROVIDER_TOOL_CEILING,
   ProviderToolCeilingError,
   finalizeActiveTools,
+  providerToolCeiling,
 } from "../dist/routing/tool-activation.js";
 
 const SPORTS = [
@@ -171,6 +172,13 @@ describe("finalizeActiveTools — provider ceiling boundary", () => {
     assert.equal(PROVIDER_TOOL_CEILING, 128);
   });
 
+  it("applies the ceiling only to OpenAI and Azure Foundry", () => {
+    assert.equal(providerToolCeiling("openai"), PROVIDER_TOOL_CEILING);
+    assert.equal(providerToolCeiling("azure-foundry"), PROVIDER_TOOL_CEILING);
+    assert.equal(providerToolCeiling("anthropic"), undefined);
+    assert.equal(providerToolCeiling("google"), undefined);
+  });
+
   it("keeps the routed filter and merges history on a low-confidence follow-up when the registry exceeds the ceiling", () => {
     const active = finalizeActiveTools({
       routedActiveTools: ["generate_image", "reflect"],
@@ -178,6 +186,7 @@ describe("finalizeActiveTools — provider ceiling boundary", () => {
       lowConfidence: true,
       historyToolNames: ["nba_scores", "reflect"],
       totalToolCount: PROVIDER_TOOL_CEILING + 1,
+      ceiling: providerToolCeiling("openai"),
     });
 
     assert.ok(
@@ -200,6 +209,7 @@ describe("finalizeActiveTools — provider ceiling boundary", () => {
           lowConfidence: true,
           historyToolNames: ["nba_scores"],
           totalToolCount,
+          ceiling: providerToolCeiling("azure-foundry"),
         }),
         undefined,
         `registry of ${totalToolCount} fits the provider ceiling, so the old widen-to-all behavior is preserved`,
@@ -216,6 +226,7 @@ describe("finalizeActiveTools — oversized registry never resolves to undefined
       lowConfidence: false,
       historyToolNames: [],
       totalToolCount: PROVIDER_TOOL_CEILING + 1,
+      ceiling: providerToolCeiling("openai"),
     });
 
     assert.deepEqual(
@@ -232,6 +243,7 @@ describe("finalizeActiveTools — oversized registry never resolves to undefined
       lowConfidence: false,
       historyToolNames: ["nba_scores", "reflect", "nba_scores"],
       totalToolCount: PROVIDER_TOOL_CEILING + 1,
+      ceiling: providerToolCeiling("azure-foundry"),
     });
 
     assert.ok(Array.isArray(active), "must never fall back to `undefined` above the ceiling");
@@ -250,6 +262,7 @@ describe("finalizeActiveTools — oversized registry never resolves to undefined
         lowConfidence: false,
         historyToolNames: [],
         totalToolCount: PROVIDER_TOOL_CEILING,
+        ceiling: providerToolCeiling("openai"),
       }),
       undefined,
       "small-registry behavior is unchanged: no filter means the whole registry is safe to send",
@@ -269,6 +282,7 @@ describe("finalizeActiveTools — explicit list never silently truncates", () =>
       lowConfidence: false,
       historyToolNames: [],
       totalToolCount: 291,
+      ceiling: providerToolCeiling("openai"),
     });
 
     assert.equal(active.length, PROVIDER_TOOL_CEILING);
@@ -284,6 +298,7 @@ describe("finalizeActiveTools — explicit list never silently truncates", () =>
           lowConfidence: false,
           historyToolNames: [],
           totalToolCount: 291,
+          ceiling: providerToolCeiling("openai"),
         }),
       (err) => {
         assert.ok(
@@ -294,6 +309,7 @@ describe("finalizeActiveTools — explicit list never silently truncates", () =>
         assert.match(err.message, new RegExp(String(PROVIDER_TOOL_CEILING + 1)));
         assert.equal(err.ceiling, PROVIDER_TOOL_CEILING);
         assert.equal(err.count, PROVIDER_TOOL_CEILING + 1);
+        assert.match(err.message, /\/compact|fresh session/i);
         return true;
       },
     );
@@ -308,6 +324,7 @@ describe("finalizeActiveTools — explicit list never silently truncates", () =>
           lowConfidence: false,
           historyToolNames: ["history_only_tool"],
           totalToolCount: 291,
+          ceiling: providerToolCeiling("azure-foundry"),
         }),
       (err) => {
         assert.ok(err instanceof ProviderToolCeilingError);
@@ -325,8 +342,66 @@ describe("finalizeActiveTools — explicit list never silently truncates", () =>
       lowConfidence: false,
       historyToolNames: [routedActiveTools[0], routedActiveTools[5]],
       totalToolCount: 291,
+      ceiling: providerToolCeiling("openai"),
     });
 
     assert.equal(active.length, PROVIDER_TOOL_CEILING);
+  });
+
+  it("preserves an explicit 291-tool list for unlimited providers", () => {
+    const routedActiveTools = toolList(291);
+    for (const provider of ["anthropic", "google"]) {
+      const active = finalizeActiveTools({
+        routedActiveTools,
+        isFollowUp: false,
+        lowConfidence: false,
+        historyToolNames: [],
+        totalToolCount: 291,
+        ceiling: providerToolCeiling(provider),
+      });
+      assert.deepEqual(active, routedActiveTools, provider);
+    }
+  });
+
+  it("preserves unlimited legacy widening to the whole registry", () => {
+    assert.equal(
+      finalizeActiveTools({
+        routedActiveTools: ["nba_scores"],
+        isFollowUp: true,
+        lowConfidence: true,
+        historyToolNames: ["history_tool"],
+        totalToolCount: 291,
+        ceiling: providerToolCeiling("anthropic"),
+      }),
+      undefined,
+    );
+  });
+});
+
+describe("no installed skills / no MCP regression", () => {
+  it("keeps the small internal registry available instead of resolving to zero tools", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-tool-small-"));
+    const engine = new sportsclawEngine({ rootDir: tmpDir, verbose: false });
+    const toolNames = ["generate_image", "reflect", "run_selftest"];
+    engine.registry = {
+      getInstalledSkills: () => [],
+      getAllToolSpecs: () => [],
+      getSkillName: () => undefined,
+    };
+    try {
+      const routing = await engine.resolveActiveToolsForPrompt("hello", toolNames);
+      assert.equal(routing.activeTools, undefined);
+      const final = finalizeActiveTools({
+        routedActiveTools: routing.activeTools,
+        isFollowUp: false,
+        lowConfidence: false,
+        historyToolNames: [],
+        totalToolCount: toolNames.length,
+        ceiling: providerToolCeiling("openai"),
+      });
+      assert.equal(final, undefined, "undefined intentionally exposes the small registry");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/router-complexity-integration.test.mjs
+++ b/test/router-complexity-integration.test.mjs
@@ -142,4 +142,23 @@ describe("router complexity integration contract", () => {
       `expected no market skills for a simple query, got: ${result.decision.selectedSkills.join(", ")}`
     );
   });
+
+  it("passes the caller abort signal to the router model call", async () => {
+    const mockModel = makeMockModel();
+    const controller = new AbortController();
+
+    await routePromptToSkills({
+      prompt: "lakers score",
+      installedSkills: ["nba"],
+      toolSpecs: [],
+      model: mockModel,
+      modelId: "mock-model",
+      provider: "anthropic",
+      abortSignal: controller.signal,
+      config: baseConfig,
+    });
+
+    assert.equal(mockModel.doGenerateCalls.length, 1);
+    assert.equal(mockModel.doGenerateCalls[0].abortSignal, controller.signal);
+  });
 });

--- a/test/schema-catalog.test.mjs
+++ b/test/schema-catalog.test.mjs
@@ -22,6 +22,7 @@ import {
   DEFAULT_SUPPORT_SKILLS,
   OPTIONAL_SUPPORT_SKILLS,
   categorizeSchema,
+  loadAllSchemas,
   summarizeInstalledSchemas,
 } from "../dist/schema.js";
 
@@ -205,10 +206,10 @@ describe("sportsclaw list (CLI)", () => {
   ];
   const EXPECTED_TOOLS = INSTALLED.reduce((sum, [, n]) => sum + n, 0);
 
-  function runList(args, dir) {
-    const env = { ...process.env, sportsclaw_SCHEMA_DIR: dir };
-    delete env.SPORTSCLAW_SKILLS;
-    delete env.sportsclaw_SKILLS;
+  function runList(args, dir, extraEnv = {}) {
+    const env = { ...process.env, sportsclaw_SCHEMA_DIR: dir, ...extraEnv };
+    if (!("SPORTSCLAW_SKILLS" in extraEnv)) delete env.SPORTSCLAW_SKILLS;
+    if (!("sportsclaw_SKILLS" in extraEnv)) delete env.sportsclaw_SKILLS;
     return execFileSync("node", ["dist/index.js", "list", ...args], {
       encoding: "utf-8",
       env,
@@ -247,6 +248,16 @@ describe("sportsclaw list (CLI)", () => {
     assert.equal(parsed.totals.schemas, 6);
     assert.equal(parsed.totals.tools, EXPECTED_TOOLS);
     assert.equal(parsed.schemaDir, schemaDir);
+  });
+
+  it("reports every valid installed schema even when runtime skills are filtered", () => {
+    const parsed = JSON.parse(runList(["--json"], schemaDir, {
+      SPORTSCLAW_SKILLS: "nba",
+    }));
+    assert.equal(parsed.totals.schemas, INSTALLED.length);
+    assert.equal(parsed.totals.tools, EXPECTED_TOOLS);
+    assert.deepEqual(parsed.defaultSports, ["nba", "nfl"]);
+    assert.deepEqual(parsed.defaultSupport, ["kalshi"]);
   });
 
   it("emits an empty-but-valid JSON shape when nothing is installed", () => {

--- a/test/schema-catalog.test.mjs
+++ b/test/schema-catalog.test.mjs
@@ -1,0 +1,284 @@
+/**
+ * Schema catalog categorization + `sportsclaw list` reporting — test suite
+ *
+ * The catalog is a mix of sports and support modules, each of which may be a
+ * default (installed by `init --all`) or an optional extra. `sportsclaw list`
+ * has to report those categories honestly instead of calling everything a
+ * "sport schema", and the tool count has to come from the schemas on disk —
+ * never from a hard-coded number.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  DEFAULT_SKILLS,
+  DEFAULT_SPORT_SKILLS,
+  OPTIONAL_SPORT_SKILLS,
+  DEFAULT_SUPPORT_SKILLS,
+  OPTIONAL_SUPPORT_SKILLS,
+  categorizeSchema,
+  summarizeInstalledSchemas,
+} from "../dist/schema.js";
+
+// The verified catalog, spelled out here on purpose: if src/schema.ts drifts,
+// these literals are what fail.
+const EXPECTED_DEFAULT_SPORTS = [
+  "football",
+  "nfl",
+  "nba",
+  "nhl",
+  "mlb",
+  "wnba",
+  "tennis",
+  "cfb",
+  "cbb",
+  "golf",
+  "f1",
+  "cricket",
+  "volleyball",
+  "xctf",
+];
+const EXPECTED_OPTIONAL_SPORTS = ["esports"];
+const EXPECTED_DEFAULT_SUPPORT = [
+  "kalshi",
+  "polymarket",
+  "news",
+  "metadata",
+  "betting",
+  "markets",
+];
+const EXPECTED_OPTIONAL_SUPPORT = ["polymarket-trading"];
+
+const ALL_KNOWN = [
+  ...EXPECTED_DEFAULT_SPORTS,
+  ...EXPECTED_OPTIONAL_SPORTS,
+  ...EXPECTED_DEFAULT_SUPPORT,
+  ...EXPECTED_OPTIONAL_SUPPORT,
+];
+
+/** Build a schema object with `n` tools so tool totals are checkable. */
+function fixtureSchema(sport, toolCount) {
+  return {
+    sport,
+    version: "1.0.0",
+    tools: Array.from({ length: toolCount }, (_, i) => ({
+      name: `${sport}_tool_${i}`,
+      command: `cmd_${i}`,
+      description: "fixture tool",
+      parameters: {},
+    })),
+  };
+}
+
+describe("catalog constants", () => {
+  it("exposes exactly the 14 default sports, in order", () => {
+    assert.deepEqual([...DEFAULT_SPORT_SKILLS], EXPECTED_DEFAULT_SPORTS);
+    assert.equal(DEFAULT_SPORT_SKILLS.length, 14);
+  });
+
+  it("exposes esports as the only optional sport", () => {
+    assert.deepEqual([...OPTIONAL_SPORT_SKILLS], EXPECTED_OPTIONAL_SPORTS);
+  });
+
+  it("exposes exactly the 6 default support modules, in order", () => {
+    assert.deepEqual([...DEFAULT_SUPPORT_SKILLS], EXPECTED_DEFAULT_SUPPORT);
+    assert.equal(DEFAULT_SUPPORT_SKILLS.length, 6);
+  });
+
+  it("exposes polymarket-trading as the only optional support module", () => {
+    assert.deepEqual([...OPTIONAL_SUPPORT_SKILLS], EXPECTED_OPTIONAL_SUPPORT);
+  });
+
+  it("keeps the four categories disjoint", () => {
+    const seen = new Set();
+    for (const name of ALL_KNOWN) {
+      assert.ok(!seen.has(name), `${name} appears in more than one category`);
+      seen.add(name);
+    }
+    assert.equal(seen.size, 22);
+  });
+
+  it("keeps DEFAULT_SKILLS backwards compatible: default sports then default support", () => {
+    assert.deepEqual(
+      [...DEFAULT_SKILLS],
+      [...EXPECTED_DEFAULT_SPORTS, ...EXPECTED_DEFAULT_SUPPORT]
+    );
+    assert.equal(DEFAULT_SKILLS.length, 20);
+  });
+});
+
+describe("categorizeSchema", () => {
+  it("classifies every known schema", () => {
+    for (const name of EXPECTED_DEFAULT_SPORTS) {
+      assert.equal(categorizeSchema(name), "default-sport", name);
+    }
+    for (const name of EXPECTED_OPTIONAL_SPORTS) {
+      assert.equal(categorizeSchema(name), "optional-sport", name);
+    }
+    for (const name of EXPECTED_DEFAULT_SUPPORT) {
+      assert.equal(categorizeSchema(name), "default-support", name);
+    }
+    for (const name of EXPECTED_OPTIONAL_SUPPORT) {
+      assert.equal(categorizeSchema(name), "optional-support", name);
+    }
+  });
+
+  it("classifies anything else as unknown", () => {
+    assert.equal(categorizeSchema("quidditch"), "unknown");
+    assert.equal(categorizeSchema(""), "unknown");
+  });
+});
+
+describe("summarizeInstalledSchemas", () => {
+  it("reports 15 sports, 7 support modules, 22 schemas and the summed tool count for a full install", () => {
+    // Distinct per-schema counts so a wrong sum cannot pass by accident.
+    const schemas = ALL_KNOWN.map((name, i) => fixtureSchema(name, i + 1));
+    const expectedTools = schemas.reduce((sum, s) => sum + s.tools.length, 0);
+
+    const summary = summarizeInstalledSchemas(schemas);
+
+    assert.deepEqual(summary.defaultSports, EXPECTED_DEFAULT_SPORTS);
+    assert.deepEqual(summary.optionalSports, EXPECTED_OPTIONAL_SPORTS);
+    assert.deepEqual(summary.defaultSupport, EXPECTED_DEFAULT_SUPPORT);
+    assert.deepEqual(summary.optionalSupport, EXPECTED_OPTIONAL_SUPPORT);
+    assert.deepEqual(summary.unknown, []);
+    assert.equal(summary.totalSports, 15);
+    assert.equal(summary.totalSupport, 7);
+    assert.equal(summary.totalSchemas, 22);
+    assert.equal(summary.totalTools, expectedTools);
+  });
+
+  it("preserves unrecognized schemas as unknown without counting them as sports", () => {
+    const summary = summarizeInstalledSchemas([
+      fixtureSchema("nba", 3),
+      fixtureSchema("quidditch", 2),
+    ]);
+
+    assert.deepEqual(summary.defaultSports, ["nba"]);
+    assert.deepEqual(summary.unknown, ["quidditch"]);
+    assert.equal(summary.totalSports, 1);
+    assert.equal(summary.totalSupport, 0);
+    assert.equal(summary.totalSchemas, 2);
+    assert.equal(summary.totalTools, 5);
+  });
+
+  it("returns empty categories and zero totals for an empty install", () => {
+    const summary = summarizeInstalledSchemas([]);
+    assert.deepEqual(summary.defaultSports, []);
+    assert.deepEqual(summary.optionalSports, []);
+    assert.deepEqual(summary.defaultSupport, []);
+    assert.deepEqual(summary.optionalSupport, []);
+    assert.deepEqual(summary.unknown, []);
+    assert.equal(summary.totalSports, 0);
+    assert.equal(summary.totalSupport, 0);
+    assert.equal(summary.totalSchemas, 0);
+    assert.equal(summary.totalTools, 0);
+  });
+
+  it("tolerates a schema with no tools array", () => {
+    const summary = summarizeInstalledSchemas([{ sport: "nba" }]);
+    assert.equal(summary.totalSchemas, 1);
+    assert.equal(summary.totalTools, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: `sportsclaw list` / `sportsclaw list --json`
+// ---------------------------------------------------------------------------
+
+describe("sportsclaw list (CLI)", () => {
+  let schemaDir;
+  let emptyDir;
+
+  const INSTALLED = [
+    ["nba", 4],
+    ["nfl", 3],
+    ["esports", 2],
+    ["kalshi", 5],
+    ["polymarket-trading", 1],
+    ["quidditch", 6],
+  ];
+  const EXPECTED_TOOLS = INSTALLED.reduce((sum, [, n]) => sum + n, 0);
+
+  function runList(args, dir) {
+    const env = { ...process.env, sportsclaw_SCHEMA_DIR: dir };
+    delete env.SPORTSCLAW_SKILLS;
+    delete env.sportsclaw_SKILLS;
+    return execFileSync("node", ["dist/index.js", "list", ...args], {
+      encoding: "utf-8",
+      env,
+    });
+  }
+
+  before(() => {
+    const root = mkdtempSync(join(tmpdir(), "sportsclaw-catalog-"));
+    schemaDir = join(root, "schemas");
+    emptyDir = join(root, "empty");
+    mkdirSync(schemaDir, { recursive: true });
+    mkdirSync(emptyDir, { recursive: true });
+    for (const [name, count] of INSTALLED) {
+      writeFileSync(
+        join(schemaDir, `${name}.json`),
+        JSON.stringify(fixtureSchema(name, count)),
+        "utf-8"
+      );
+    }
+  });
+
+  after(() => {
+    rmSync(join(schemaDir, ".."), { recursive: true, force: true });
+  });
+
+  it("emits parseable JSON with exact categories and totals", () => {
+    const parsed = JSON.parse(runList(["--json"], schemaDir));
+
+    assert.deepEqual(parsed.defaultSports, ["nba", "nfl"]);
+    assert.deepEqual(parsed.optionalSports, ["esports"]);
+    assert.deepEqual(parsed.defaultSupport, ["kalshi"]);
+    assert.deepEqual(parsed.optionalSupport, ["polymarket-trading"]);
+    assert.deepEqual(parsed.unknown, ["quidditch"]);
+    assert.equal(parsed.totals.sports, 3);
+    assert.equal(parsed.totals.support, 2);
+    assert.equal(parsed.totals.schemas, 6);
+    assert.equal(parsed.totals.tools, EXPECTED_TOOLS);
+    assert.equal(parsed.schemaDir, schemaDir);
+  });
+
+  it("emits an empty-but-valid JSON shape when nothing is installed", () => {
+    const parsed = JSON.parse(runList(["--json"], emptyDir));
+
+    assert.deepEqual(parsed.defaultSports, []);
+    assert.deepEqual(parsed.optionalSports, []);
+    assert.deepEqual(parsed.defaultSupport, []);
+    assert.deepEqual(parsed.optionalSupport, []);
+    assert.deepEqual(parsed.unknown, []);
+    assert.equal(parsed.totals.schemas, 0);
+    assert.equal(parsed.totals.tools, 0);
+  });
+
+  it("separates sports from support modules in human output", () => {
+    const out = runList([], schemaDir);
+
+    assert.match(out, /Sports/);
+    assert.match(out, /Support/);
+    assert.match(out, /Optional/);
+    assert.match(out, /Unknown/);
+    assert.match(out, /quidditch/);
+    assert.match(out, /polymarket-trading/);
+    assert.ok(
+      out.includes("6") && out.includes(String(EXPECTED_TOOLS)),
+      `expected schema and tool totals in:\n${out}`
+    );
+  });
+
+  it("says schemas/modules — not sports only — when nothing is installed", () => {
+    const out = runList([], emptyDir);
+    assert.match(out, /schemas|modules/i);
+    assert.doesNotMatch(out, /^No sport schemas installed\.$/m);
+  });
+});

--- a/test/schema-catalog.test.mjs
+++ b/test/schema-catalog.test.mjs
@@ -11,7 +11,14 @@
 import assert from "node:assert/strict";
 import { describe, it, before, after } from "node:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -21,6 +28,7 @@ import {
   OPTIONAL_SPORT_SKILLS,
   DEFAULT_SUPPORT_SKILLS,
   OPTIONAL_SUPPORT_SKILLS,
+  bootstrapDefaultSchemas,
   categorizeSchema,
   loadAllSchemas,
   summarizeInstalledSchemas,
@@ -76,6 +84,64 @@ function fixtureSchema(sport, toolCount) {
   };
 }
 
+function createFakeSportsSkills(root, catalogModules) {
+  const executable = join(root, "fake-sports-skills");
+  const catalog = catalogModules === null
+    ? null
+    : { version: "offline-test", modules: catalogModules };
+  writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] !== "-m" || args[1] !== "sports_skills") process.exit(2);
+if (args[2] === "catalog") {
+  const catalog = ${JSON.stringify(catalog)};
+  if (catalog === null) process.exit(1);
+  process.stdout.write(JSON.stringify(catalog));
+  process.exit(0);
+}
+if (args[3] === "schema") {
+  process.stdout.write(JSON.stringify({ sport: args[2], version: "offline-test", tools: [] }));
+  process.exit(0);
+}
+process.exit(2);
+`,
+    "utf-8",
+  );
+  chmodSync(executable, 0o755);
+  return executable;
+}
+
+async function runOfflineBootstrap(catalogModules) {
+  const root = mkdtempSync(join(tmpdir(), "sportsclaw-bootstrap-"));
+  const schemaDir = join(root, "schemas");
+  const pythonPath = createFakeSportsSkills(root, catalogModules);
+  const envKeys = ["sportsclaw_SCHEMA_DIR", "SPORTSCLAW_SKILLS", "sportsclaw_SKILLS"];
+  const previousEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+  const progress = [];
+
+  process.env.sportsclaw_SCHEMA_DIR = schemaDir;
+  delete process.env.SPORTSCLAW_SKILLS;
+  delete process.env.sportsclaw_SKILLS;
+
+  try {
+    const count = await bootstrapDefaultSchemas(
+      { pythonPath },
+      { onProgress: (skill, ok) => progress.push([skill, ok]) },
+    );
+    const installed = readdirSync(schemaDir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => name.slice(0, -5));
+    return { count, installed, progress };
+  } finally {
+    for (const [key, value] of previousEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 describe("catalog constants", () => {
   it("exposes exactly the 14 default sports, in order", () => {
     assert.deepEqual([...DEFAULT_SPORT_SKILLS], EXPECTED_DEFAULT_SPORTS);
@@ -110,6 +176,38 @@ describe("catalog constants", () => {
       [...EXPECTED_DEFAULT_SPORTS, ...EXPECTED_DEFAULT_SUPPORT]
     );
     assert.equal(DEFAULT_SKILLS.length, 20);
+  });
+});
+
+describe("bootstrapDefaultSchemas", () => {
+  it("installs only defaults when offline discovery includes optional and unknown extras", async () => {
+    const extras = ["esports", "polymarket-trading", "quidditch"];
+    const result = await runOfflineBootstrap([
+      extras[0],
+      ...[...DEFAULT_SKILLS].reverse(),
+      ...extras.slice(1),
+    ]);
+
+    assert.equal(result.count, DEFAULT_SKILLS.length);
+    assert.deepEqual(result.installed.sort(), [...DEFAULT_SKILLS].sort());
+    assert.deepEqual(
+      result.progress.map(([skill]) => skill).sort(),
+      [...DEFAULT_SKILLS].sort(),
+    );
+    assert.ok(result.progress.every(([, ok]) => ok));
+    assert.ok(extras.every((extra) => !result.installed.includes(extra)));
+  });
+
+  it("falls back to every default when offline catalog discovery is unavailable", async () => {
+    const result = await runOfflineBootstrap(null);
+
+    assert.equal(result.count, DEFAULT_SKILLS.length);
+    assert.deepEqual(result.installed.sort(), [...DEFAULT_SKILLS].sort());
+    assert.deepEqual(
+      result.progress.map(([skill]) => skill).sort(),
+      [...DEFAULT_SKILLS].sort(),
+    );
+    assert.ok(result.progress.every(([, ok]) => ok));
   });
 });
 

--- a/test/subagent-tool-routing.test.mjs
+++ b/test/subagent-tool-routing.test.mjs
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { resolveSubagentActiveTools } from "../dist/subagent.js";
+import { resolveSubagentActiveTools, SubagentManager } from "../dist/subagent.js";
 import { ProviderToolCeilingError } from "../dist/routing/tool-activation.js";
+import { MockLanguageModelV3 } from "ai/test";
 
 const SKILLS = [
   "nba", "nfl", "mlb", "nhl", "wnba", "cbb", "cfb", "football",
@@ -76,5 +77,77 @@ describe("subagent provider-safe tool routing", () => {
       getSkillName: () => "nba",
     });
     assert.deepEqual(active, ["nba_scores", "mcp__demo__health"]);
+  });
+});
+
+describe("subagent cancellation", () => {
+  it("threads the subagent abort signal into its router model call", async () => {
+    let signalSeen;
+    let markRouterStarted;
+    const routerStarted = new Promise((resolve) => {
+      markRouterStarted = resolve;
+    });
+    const model = new MockLanguageModelV3({
+      doGenerate: async (options) => {
+        signalSeen = options.abortSignal;
+        markRouterStarted();
+        if (!signalSeen) throw new Error("router call did not receive an abort signal");
+        await new Promise((_, reject) => {
+          if (signalSeen.aborted) {
+            reject(new Error("router aborted"));
+            return;
+          }
+          signalSeen.addEventListener(
+            "abort",
+            () => reject(new Error("router aborted")),
+            { once: true },
+          );
+        });
+        throw new Error("unreachable");
+      },
+    });
+
+    let deliverResult;
+    const resultDelivered = new Promise((resolve) => {
+      deliverResult = resolve;
+    });
+    const manager = new SubagentManager({ onResult: deliverResult });
+    const registry = {
+      getInstalledSkills: () => ["nba"],
+      getAllToolSpecs: () => [{
+        name: "nba_scores",
+        description: "NBA scores",
+        input_schema: { type: "object", properties: {} },
+      }],
+      getSkillName: () => "nba",
+      dispatchToolCall: async () => ({ isError: false, content: "ok" }),
+    };
+
+    try {
+      manager.spawn({
+        prompt: "get nba scores",
+        userId: "abort-test",
+        model,
+        provider: "anthropic",
+        config: {},
+        registry,
+      });
+
+      await routerStarted;
+      assert.ok(signalSeen instanceof AbortSignal);
+      assert.equal(signalSeen.aborted, false);
+      manager.shutdown();
+
+      const result = await resultDelivered;
+      assert.equal(signalSeen.aborted, true);
+      assert.equal(result.status, "failed");
+      assert.ok(model.doGenerateCalls.length >= 1);
+      assert.ok(
+        model.doGenerateCalls.every((call) => call.abortSignal === signalSeen),
+        "the router and any aborted fallback generation must share the subagent signal",
+      );
+    } finally {
+      manager.shutdown();
+    }
   });
 });

--- a/test/subagent-tool-routing.test.mjs
+++ b/test/subagent-tool-routing.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resolveSubagentActiveTools } from "../dist/subagent.js";
+import { ProviderToolCeilingError } from "../dist/routing/tool-activation.js";
+
+const SKILLS = [
+  "nba", "nfl", "mlb", "nhl", "wnba", "cbb", "cfb", "football",
+  "tennis", "golf", "cricket", "volleyball", "f1", "xctf", "news",
+  "metadata", "kalshi", "polymarket", "betting", "markets", "esports",
+  "polymarket-trading",
+];
+
+function buildRegistry291() {
+  const skillByTool = new Map();
+  const toolNames = [];
+  for (let i = 0; i < 290; i++) {
+    const skill = SKILLS[i % SKILLS.length];
+    const name = `${skill}_tool_${i}`;
+    toolNames.push(name);
+    skillByTool.set(name, skill);
+  }
+  toolNames.push("mcp__demo__health");
+  return { toolNames, skillByTool };
+}
+
+describe("subagent provider-safe tool routing", () => {
+  it("routes a deterministic 291-tool registry below the cap for OpenAI and Azure", () => {
+    const { toolNames, skillByTool } = buildRegistry291();
+    assert.equal(toolNames.length, 291);
+    for (const provider of ["openai", "azure-foundry"]) {
+      const active = resolveSubagentActiveTools({
+        provider,
+        toolNames,
+        selectedSkills: ["nba"],
+        getSkillName: (name) => skillByTool.get(name),
+      });
+      assert.ok(Array.isArray(active), provider);
+      assert.ok(active.length > 0 && active.length <= 128, `${provider}: ${active.length}`);
+      assert.ok(active.includes("mcp__demo__health"), provider);
+      assert.ok(active.every((name) =>
+        name.startsWith("mcp__") || skillByTool.get(name) === "nba"
+      ));
+    }
+  });
+
+  it("allows all 291 explicitly routed tools for Anthropic", () => {
+    const { toolNames, skillByTool } = buildRegistry291();
+    const active = resolveSubagentActiveTools({
+      provider: "anthropic",
+      toolNames,
+      selectedSkills: SKILLS,
+      getSkillName: (name) => skillByTool.get(name),
+    });
+    assert.equal(active.length, 291);
+  });
+
+  it("throws locally rather than slicing an oversized capped route", () => {
+    const { toolNames, skillByTool } = buildRegistry291();
+    assert.throws(
+      () => resolveSubagentActiveTools({
+        provider: "openai",
+        toolNames,
+        selectedSkills: SKILLS,
+        getSkillName: (name) => skillByTool.get(name),
+      }),
+      ProviderToolCeilingError,
+    );
+  });
+
+  it("preserves restricted exclusions even when a restricted name maps to a selected skill", () => {
+    const active = resolveSubagentActiveTools({
+      provider: "anthropic",
+      toolNames: ["nba_scores", "spawn_subagent", "generate_image", "mcp__demo__health"],
+      selectedSkills: ["nba"],
+      getSkillName: () => "nba",
+    });
+    assert.deepEqual(active, ["nba_scores", "mcp__demo__health"]);
+  });
+});

--- a/test/subagent-tool-routing.test.mjs
+++ b/test/subagent-tool-routing.test.mjs
@@ -15,12 +15,13 @@ const SKILLS = [
 function buildRegistry291() {
   const skillByTool = new Map();
   const toolNames = [];
-  for (let i = 0; i < 290; i++) {
+  for (let i = 0; i < 289; i++) {
     const skill = SKILLS[i % SKILLS.length];
     const name = `${skill}_tool_${i}`;
     toolNames.push(name);
     skillByTool.set(name, skill);
   }
+  toolNames.push("run_selftest");
   toolNames.push("mcp__demo__health");
   return { toolNames, skillByTool };
 }
@@ -38,9 +39,10 @@ describe("subagent provider-safe tool routing", () => {
       });
       assert.ok(Array.isArray(active), provider);
       assert.ok(active.length > 0 && active.length <= 128, `${provider}: ${active.length}`);
+      assert.ok(active.includes("run_selftest"), provider);
       assert.ok(active.includes("mcp__demo__health"), provider);
       assert.ok(active.every((name) =>
-        name.startsWith("mcp__") || skillByTool.get(name) === "nba"
+        skillByTool.get(name) === undefined || skillByTool.get(name) === "nba"
       ));
     }
   });
@@ -77,6 +79,28 @@ describe("subagent provider-safe tool routing", () => {
       getSkillName: () => "nba",
     });
     assert.deepEqual(active, ["nba_scores", "mcp__demo__health"]);
+  });
+
+  it("keeps safe ownerless tools while filtering tools owned by unselected skills", () => {
+    const skillByTool = new Map([
+      ["nba_scores", "nba"],
+      ["nfl_scores", "nfl"],
+    ]);
+    const active = resolveSubagentActiveTools({
+      provider: "anthropic",
+      toolNames: [
+        "run_selftest",
+        "nba_scores",
+        "nfl_scores",
+        "spawn_subagent",
+        "generate_image",
+        "mcp__demo__health",
+      ],
+      selectedSkills: ["nba"],
+      getSkillName: (name) => skillByTool.get(name),
+    });
+
+    assert.deepEqual(active, ["run_selftest", "nba_scores", "mcp__demo__health"]);
   });
 });
 

--- a/test/version-help.test.mjs
+++ b/test/version-help.test.mjs
@@ -16,4 +16,13 @@ describe("CLI --help version", () => {
       `Expected help output to contain "v${pkg.version}" but got:\n${output.split("\n")[0]}`
     );
   });
+
+  it("documents list --json and the full installed schema catalog", () => {
+    const output = execFileSync("node", ["dist/index.js", "--help"], {
+      encoding: "utf-8",
+    });
+    assert.match(output, /sportsclaw list \[--json\]/);
+    assert.match(output, /installed schemas/i);
+    assert.doesNotMatch(output, /List installed sport schemas/);
+  });
 });


### PR DESCRIPTION
## Summary
- fix provider tool-cap routing across main, parallel-agent, subagent, and operator paths
- separate sport/support/optional catalog reporting with JSON output
- add honest seven-sport momentum certification and blocked/anomaly receipts
- redact credentials/endpoints from doctor output
- bump package to v0.29.2

## Verification
- npm build passed
- 1067/1067 tests passed locally
- live Azure Foundry generic query passed with 22 schemas installed
- npm pack --dry-run passed for sportsclaw-engine-core@0.29.2
- staged gitleaks scan found no new leaks
- exact final Codex review found no actionable regressions

## Known external blockers
- npm publish requires renewed npm maintainer auth (current npm whoami is E401)
- site tag workflow has a pre-existing invalid Azure client secret
- MLB/WNBA current live replay revalidation remains pending; WNBA resolver anomaly and ESPN discovery 403 are recorded, not presented as certification