### PR TITLE
fix(relay): cut v0.29.3 with production hardening

### DIFF
--- a/docker/relay/Dockerfile
+++ b/docker/relay/Dockerfile
@@ -42,7 +42,15 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN python3 -c "import sys; assert sys.version_info >= (3, 10), f'Python too old: {sys.version_info}'"
 
 # --- Python packages: sports data + relay server -----------------------------
-RUN pip install --no-cache-dir sports-skills aiohttp
+# sports-skills is pinned exactly: an unpinned install floats to whatever PyPI
+# serves at build time, so two builds of the same commit could ship different
+# tool catalogs. Override with --build-arg SPORTS_SKILLS_VERSION=x.y.z.
+ARG SPORTS_SKILLS_VERSION=0.31.0
+RUN pip install --no-cache-dir "sports-skills==${SPORTS_SKILLS_VERSION}" aiohttp
+
+# Build-time assertion: the resolver must have installed the exact pin, so a
+# substituted or cached wheel fails the build instead of shipping silently.
+RUN python3 -c "import importlib.metadata as md; got = md.version('sports-skills'); want = '${SPORTS_SKILLS_VERSION}'; assert got == want, f'sports-skills mismatch: installed {got}, expected {want}'"
 
 WORKDIR /app
 
@@ -59,10 +67,11 @@ RUN npx tsc
 RUN npm prune --omit=dev
 
 # --- Bootstrap default sport schemas -----------------------------------------
+# Fails closed: an image with missing or partial schemas is not shippable, so a
+# failed bootstrap must fail the build rather than log a warning and continue.
 ENV SPORTSCLAW_SCHEMA_DIR=/app/.sportsclaw/schemas
-RUN mkdir -p /app/.sportsclaw/schemas && \
-    node dist/index.js init --all --verbose 2>&1 || \
-    echo "[sportsclaw-relay] Warning: schema bootstrap incomplete."
+RUN mkdir -p /app/.sportsclaw/schemas
+RUN node dist/index.js init --all --verbose
 
 # --- Relay server & entrypoint ------------------------------------------------
 COPY docker/relay/relay_server.py /opt/sportsclaw/relay_server.py

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sportsclaw-engine-core",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/sdk": "^2.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, Google, and Azure Foundry.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -478,6 +478,147 @@ export function stripInternalEvidenceArtifacts(text: string): string {
   return out.trim();
 }
 
+/**
+ * Stable, non-secret sentinel returned only when every extraction strategy
+ * fails closed — i.e. envelope introspection, JSON serialization, and String()
+ * coercion all throw (hostile Proxy traps, hostile toJSON/toString/
+ * Symbol.toPrimitive). It must never leak internal state.
+ */
+const UNSERIALIZABLE_TOOL_OUTPUT = "[unserializable tool output]";
+
+/**
+ * extractEvidenceString — pull a string out of an arbitrary tool output without
+ * ever throwing. Direct strings and legacy {content:string} envelopes are
+ * returned verbatim; anything else is JSON-stringified. Every introspection
+ * and coercion step is guarded so that hostile inputs — Proxies whose has/get
+ * traps throw, objects whose toJSON/toString/Symbol.toPrimitive throw — fail
+ * closed to a deterministic sentinel instead of propagating.
+ */
+function extractEvidenceString(output: unknown): string {
+  if (typeof output === "string") return output;
+
+  // Legacy contract: {content:string}. Once presence is established, read the
+  // property exactly once. Primitive values retain the historical safe
+  // conversion, while objects/functions fail closed without any introspection;
+  // they could alias this envelope and route serialization back into its traps.
+  if (output && typeof output === "object") {
+    let hasContent: boolean;
+    try {
+      hasContent = "content" in output;
+    } catch {
+      return UNSERIALIZABLE_TOOL_OUTPUT;
+    }
+
+    if (hasContent) {
+      let content: unknown;
+      try {
+        content = (output as { content?: unknown }).content;
+      } catch {
+        return UNSERIALIZABLE_TOOL_OUTPUT;
+      }
+      if ((typeof content === "object" && content !== null) || typeof content === "function") {
+        return UNSERIALIZABLE_TOOL_OUTPUT;
+      }
+      return safelySerializeOrCoerce(content);
+    }
+  }
+
+  return safelySerializeOrCoerce(output);
+}
+
+function safelySerializeOrCoerce(value: unknown): string {
+  if (typeof value === "string") return value;
+
+  try {
+    const json = JSON.stringify(value);
+    if (typeof json === "string") return json;
+  } catch {
+    // BigInt / cyclic structures / hostile toJSON — fall through to coercion.
+  }
+
+  // Final fail-closed coercion. String()/`??` can themselves throw via hostile
+  // Symbol.toPrimitive/toString/valueOf, so guard and fall back to a sentinel.
+  try {
+    return String(value ?? "");
+  } catch {
+    return UNSERIALIZABLE_TOOL_OUTPUT;
+  }
+}
+
+/** Trim only the four whitespace code points permitted by the JSON grammar. */
+function trimJsonWhitespace(raw: string): string {
+  return raw.replace(/^[\u0020\u0009\u000d\u000a]+|[\u0020\u0009\u000d\u000a]+$/g, "");
+}
+
+/** Losslessly remove JSON whitespace outside strings from objects/arrays only. */
+function compactStructuredJson(raw: string): string {
+  const trimmed = trimJsonWhitespace(raw);
+  const first = trimmed[0];
+  const last = trimmed[trimmed.length - 1];
+  if (!((first === "{" && last === "}") || (first === "[" && last === "]"))) {
+    return raw;
+  }
+
+  try {
+    JSON.parse(trimmed);
+  } catch {
+    return raw;
+  }
+
+  let compact = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of trimmed) {
+    if (inString) {
+      compact += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+    } else if (char === '"') {
+      compact += char;
+      inString = true;
+    } else if (char !== " " && char !== "\t" && char !== "\r" && char !== "\n") {
+      compact += char;
+    }
+  }
+  return compact;
+}
+
+/**
+ * summarizeToolOutputForEvidence — condense a raw tool output into a bounded
+ * string used for evidence validation. When the raw output is a pretty-printed
+ * JSON string, it is compacted first so the whole payload can survive within
+ * the budget; if it is still too long (or non-JSON), it is truncated with a
+ * balanced head + tail so facts at both ends are retained. A head-only slice
+ * incorrectly dropped the final venue from oversized worldcup-get-schedule
+ * payloads (pretty JSON >4000 chars, compact <2500).
+ */
+export function summarizeToolOutputForEvidence(output: unknown): string {
+  const MAX_CHARS = 4_000;
+
+  // Centralized safe extraction: always yields a string, never throws — even
+  // for top-level undefined/function/symbol (JSON.stringify returns undefined)
+  // or BigInt/cyclic values (JSON.stringify throws).
+  let raw = extractEvidenceString(output);
+
+  // Compact only object/array JSON, directly from its original lexical form.
+  // JSON.parse validates the document but its value is never stringified, so
+  // unsafe integer tokens and whitespace inside quoted strings remain exact.
+  raw = compactStructuredJson(raw);
+
+  const trimmed = trimJsonWhitespace(raw);
+  if (!trimmed) return "";
+  if (trimmed.length <= MAX_CHARS) return trimmed;
+
+  const marker = "\n...[truncated middle]...\n";
+  const budget = MAX_CHARS - marker.length;
+  const headLen = Math.floor(budget / 2);
+  const tailLen = budget - headLen;
+  const head = trimmed.slice(0, headLen);
+  const tail = trimmed.slice(trimmed.length - tailLen);
+  return `${head}${marker}${tail}`;
+}
+
 // ---------------------------------------------------------------------------
 // Engine class
 // ---------------------------------------------------------------------------
@@ -811,30 +952,7 @@ export class sportsclawEngine {
   }
 
   private summarizeToolOutput(output: unknown): string {
-    const MAX_CHARS = 4_000;
-    let raw = "";
-
-    if (typeof output === "string") {
-      raw = output;
-    } else if (
-      output &&
-      typeof output === "object" &&
-      "content" in output &&
-      typeof (output as { content?: unknown }).content === "string"
-    ) {
-      raw = (output as { content: string }).content;
-    } else {
-      try {
-        raw = JSON.stringify(output);
-      } catch {
-        raw = String(output ?? "");
-      }
-    }
-
-    const trimmed = raw.trim();
-    if (!trimmed) return "";
-    if (trimmed.length <= MAX_CHARS) return trimmed;
-    return `${trimmed.slice(0, MAX_CHARS)}\n...[truncated]`;
+    return summarizeToolOutputForEvidence(output);
   }
 
   private collectToolOutputSnippets(

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import {
   summarizeInstalledSchemas,
   getSchemaDir,
   bootstrapDefaultSchemas,
+  assertDefaultBootstrapComplete,
   ensureSportsSkills,
   getInstalledSportsSkillsVersion,
   getCachedSchemaVersion,
@@ -1547,6 +1548,16 @@ async function cmdInit(args: string[], _opts?: { fromChat?: boolean }): Promise<
         "Some schemas could not be fetched. Ensure sports-skills is up to date:"
       );
       console.log(`  ${buildSportsSkillsRepairCommand(pythonPath)}`);
+    }
+
+    // Fail closed: docker/relay/Dockerfile runs `init --all --verbose` unguarded,
+    // so a partial/empty bootstrap must exit nonzero instead of shipping an
+    // image with a missing schema catalog.
+    try {
+      assertDefaultBootstrapComplete(count, DEFAULT_SKILLS.length);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
     }
   } else {
     // Interactive sport selection

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -717,3 +717,28 @@ export async function bootstrapDefaultSchemas(
 
   return succeeded;
 }
+
+/**
+ * Fail-closed guard for a `--all` bootstrap.
+ *
+ * `bootstrapDefaultSchemas` uses `Promise.allSettled`, so a partial (or empty)
+ * install resolves normally with a lower count. The relay image bootstraps with
+ * an unguarded `RUN node dist/index.js init --all --verbose`
+ * (docker/relay/Dockerfile), so anything short of the full default catalog has
+ * to raise instead of being reported as success.
+ *
+ * Throws unless `count` is exactly `expected` — a non-integer, NaN, negative or
+ * over-count value is never treated as complete.
+ */
+export function assertDefaultBootstrapComplete(
+  count: number,
+  expected: number = DEFAULT_SKILLS.length
+): void {
+  const actual =
+    Number.isSafeInteger(count) && (count as number) >= 0 ? (count as number) : null;
+  if (actual === expected) return;
+  const reported = actual === null ? `an invalid count (${String(count)})` : String(actual);
+  throw new Error(
+    `Default schema bootstrap incomplete: installed ${reported} of ${expected} required default schemas.`
+  );
+}

--- a/test/evidence-artifact-cleanup.test.mjs
+++ b/test/evidence-artifact-cleanup.test.mjs
@@ -8,7 +8,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { stripInternalEvidenceArtifacts } from "../dist/engine.js";
+import {
+  stripInternalEvidenceArtifacts,
+  summarizeToolOutputForEvidence,
+} from "../dist/engine.js";
 
 describe("stripInternalEvidenceArtifacts", () => {
   it("removes the self-correction warning banner", () => {
@@ -56,3 +59,405 @@ describe("stripInternalEvidenceArtifacts", () => {
     assert.equal(stripInternalEvidenceArtifacts(input), input);
   });
 });
+
+describe("summarizeToolOutputForEvidence", () => {
+  it("rejects non-JSON whitespace around otherwise valid structured JSON", () => {
+    const prettyValues = [
+      `{
+  "team": "Norway",
+  "score": 3
+}`,
+      `[
+  "Norway",
+  "England"
+]`,
+    ];
+    const invalidBoundaryWhitespace = [
+      ["NBSP U+00A0", "\u00a0"],
+      ["form-feed U+000C", "\u000c"],
+      ["vertical-tab U+000B", "\u000b"],
+      ["BOM U+FEFF", "\ufeff"],
+      ["Ogham space mark U+1680", "\u1680"],
+      ["en quad U+2000", "\u2000"],
+      ["line separator U+2028", "\u2028"],
+      ["paragraph separator U+2029", "\u2029"],
+      ["ideographic space U+3000", "\u3000"],
+    ];
+
+    for (const pretty of prettyValues) {
+      const compact = pretty.replace(/[ \t\r\n]/g, "");
+      for (const [label, boundary] of invalidBoundaryWhitespace) {
+        const input = `${boundary}${pretty}${boundary}`;
+        const out = summarizeToolOutputForEvidence(input);
+        assert.equal(out, input, `${label} and the pretty JSON must be preserved byte-for-byte`);
+        assert.notEqual(out, compact, `${label} must preserve interior pretty whitespace`);
+      }
+    }
+  });
+
+  it("accepts only JSON whitespace around structured JSON and losslessly minifies it", () => {
+    const unsafeInteger = "9007199254740993";
+    const prettyObject = `{\n  "id": ${unsafeInteger},\n  "label": "kept   spacing"\n}`;
+    const prettyArray = `[\n  { "id": ${unsafeInteger} }\n]`;
+    const outerJsonWhitespace = " \t\r\n";
+
+    assert.equal(
+      summarizeToolOutputForEvidence(`${outerJsonWhitespace}${prettyObject}${outerJsonWhitespace}`),
+      `{"id":${unsafeInteger},"label":"kept   spacing"}`
+    );
+    assert.equal(
+      summarizeToolOutputForEvidence({
+        content: `${outerJsonWhitespace}${prettyArray}${outerJsonWhitespace}`,
+      }),
+      `[{"id":${unsafeInteger}}]`
+    );
+  });
+
+  it("preserves unsafe integer digits and only losslessly compacts object/array JSON strings", () => {
+    const unsafeInteger = "9007199254740993";
+    const prettyObject = `{\n  "id": ${unsafeInteger},\n  "label": "kept   spacing\\tand \\\"escapes\\\""\n}`;
+    const prettyArray = `[\n  { "id": ${unsafeInteger} }\n]`;
+
+    assert.equal(summarizeToolOutputForEvidence(9007199254740993n), unsafeInteger);
+    assert.equal(summarizeToolOutputForEvidence({ content: unsafeInteger }), unsafeInteger);
+    assert.equal(
+      summarizeToolOutputForEvidence(prettyObject),
+      `{"id":${unsafeInteger},"label":"kept   spacing\\tand \\\"escapes\\\""}`
+    );
+    assert.equal(
+      summarizeToolOutputForEvidence({ content: prettyArray }),
+      `[{"id":${unsafeInteger}}]`
+    );
+    assert.equal(
+      summarizeToolOutputForEvidence("  9007199254740993  "),
+      unsafeInteger,
+      "arbitrary JSON scalar strings must never be parsed/stringified"
+    );
+  });
+
+  it("compacts an oversized pretty-JSON string, keeping beginning and end facts under the limit", () => {
+    // Mirrors the production worldcup-get-schedule payload: pretty JSON is
+    // >4000 chars while its compact form is well under, so a head-only slice
+    // would drop the final venue.
+    const matches = Array.from({ length: 26 }, (_, i) => ({
+      matchId: 1000 + i,
+      stage: "group",
+      home: `Team Home ${i}`,
+      away: `Team Away ${i}`,
+      kickoff: "2026-06-15T18:00:00Z",
+      venue: `Stadium ${i}`,
+    }));
+    const payload = {
+      tournament: "World Cup",
+      firstVenue: "Hard Rock Stadium",
+      matches,
+      finalVenue: "New York New Jersey Stadium",
+    };
+    const pretty = JSON.stringify(payload, null, 2);
+    const compact = JSON.stringify(payload);
+
+    // Precondition: reproduces the production shape (pretty > limit, compact within).
+    assert.ok(pretty.length > 4000, `pretty JSON must exceed 4000 (was ${pretty.length})`);
+    assert.ok(compact.length <= 4000, `compact JSON must be within 4000 (was ${compact.length})`);
+
+    const out = summarizeToolOutputForEvidence(pretty);
+
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.includes("Hard Rock Stadium"), "beginning fact preserved");
+    assert.ok(
+      out.includes("New York New Jersey Stadium"),
+      "ending fact preserved (the final venue must survive)"
+    );
+  });
+
+  it("balances head and tail when truncating an oversized non-JSON string", () => {
+    const prefix = "PREFIX_MARKER_START";
+    const suffix = "SUFFIX_MARKER_END";
+    const input = `${prefix} ${"filler ".repeat(1000)} ${suffix}`;
+    assert.ok(input.length > 4000, "input must exceed 4000 to force truncation");
+    assert.ok(!isJson(input), "input must not be valid JSON");
+
+    const out = summarizeToolOutputForEvidence(input);
+
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.includes(prefix), "head prefix preserved");
+    assert.ok(out.includes(suffix), "tail suffix preserved");
+  });
+
+  it("compacts pretty JSON carried inside a legacy {content:string} envelope", () => {
+    // Legacy supported envelope: the payload is a pretty-printed JSON string
+    // nested under `content`. It must go through the same compaction as a bare
+    // string so the whole payload survives instead of a head+tail slice that
+    // drops the middle.
+    const matches = Array.from({ length: 26 }, (_, i) => ({
+      matchId: 1000 + i,
+      stage: "group",
+      home: `Team Home ${i}`,
+      away: `Team Away ${i}`,
+      kickoff: "2026-06-15T18:00:00Z",
+      venue: `Stadium ${i}`,
+    }));
+    const payload = {
+      tournament: "World Cup",
+      firstVenue: "Hard Rock Stadium",
+      matches,
+      finalVenue: "New York New Jersey Stadium",
+    };
+    const pretty = JSON.stringify(payload, null, 2);
+    const compact = JSON.stringify(payload);
+    assert.ok(pretty.length > 4000, `pretty JSON must exceed 4000 (was ${pretty.length})`);
+    assert.ok(compact.length <= 4000, `compact JSON must be within 4000 (was ${compact.length})`);
+
+    const out = summarizeToolOutputForEvidence({ content: pretty });
+
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.includes("Hard Rock Stadium"), "beginning fact preserved");
+    assert.ok(out.includes("Stadium 13"), "middle fact preserved (compaction kept the whole payload)");
+    assert.ok(
+      out.includes("New York New Jersey Stadium"),
+      "late fact preserved (the final venue must survive)"
+    );
+  });
+
+  it("balanced-truncates a {content:string} JSON payload that stays oversized after compaction", () => {
+    const matches = Array.from({ length: 60 }, (_, i) => ({
+      matchId: 1000 + i,
+      stage: "group",
+      home: `TeamHome${i}`,
+      away: `TeamAway${i}`,
+      kickoff: "2026-06-15T18:00:00Z",
+      venue: `Stadium${i}`,
+    }));
+    const payload = {
+      headMarker: "HARDROCKSTADIUM",
+      matches,
+      tailMarker: "NEWYORKNEWJERSEYSTADIUM",
+    };
+    const pretty = JSON.stringify(payload, null, 2);
+    const compact = JSON.stringify(payload);
+    assert.ok(compact.length > 4000, `compact JSON must exceed 4000 (was ${compact.length})`);
+
+    const out = summarizeToolOutputForEvidence({ content: pretty });
+
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.includes("HARDROCKSTADIUM"), "head marker preserved");
+    assert.ok(out.includes("NEWYORKNEWJERSEYSTADIUM"), "tail marker preserved");
+    // Compaction must have run: pretty-print indentation must not survive.
+    assert.ok(!out.includes("  "), "no pretty-print indentation should remain (payload was compacted)");
+  });
+
+  it("never throws for unexpected top-level values", () => {
+    const cyclic = {};
+    cyclic.self = cyclic;
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(undefined), "undefined must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(() => 42), "function must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(Symbol("x")), "symbol must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(10n), "BigInt must not throw");
+    assert.doesNotThrow(() => summarizeToolOutputForEvidence(cyclic), "cyclic object must not throw");
+    // Each must yield a string (the safe deterministic fallback).
+    assert.equal(typeof summarizeToolOutputForEvidence(undefined), "string");
+    assert.equal(typeof summarizeToolOutputForEvidence(10n), "string");
+    assert.equal(typeof summarizeToolOutputForEvidence(cyclic), "string");
+  });
+
+  it("never throws for a hostile proxy whose has/get traps throw", () => {
+    // Envelope inspection (`"content" in output` and reading `.content`) trips
+    // the proxy traps. Extraction must fail closed rather than propagate.
+    const hostile = new Proxy(
+      {},
+      {
+        has() {
+          throw new Error("hostile has trap");
+        },
+        get() {
+          throw new Error("hostile get trap");
+        },
+      }
+    );
+    let out;
+    assert.doesNotThrow(() => {
+      out = summarizeToolOutputForEvidence(hostile);
+    }, "hostile proxy must not throw");
+    assert.equal(typeof out, "string", "must return a string fallback");
+  });
+
+  it("reads legacy envelope content exactly once", () => {
+    let contentReads = 0;
+    const stateful = new Proxy(
+      {},
+      {
+        has(_target, property) {
+          return property === "content";
+        },
+        get(_target, property) {
+          if (property !== "content") return undefined;
+          contentReads += 1;
+          return contentReads === 1 ? "legacy evidence" : Symbol("changed");
+        },
+      }
+    );
+    let out;
+    assert.doesNotThrow(() => {
+      out = summarizeToolOutputForEvidence(stateful);
+    }, "stateful content getter must not throw");
+    assert.equal(typeof out, "string", "must return a string");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+  });
+
+  it("fails closed without re-entering a self-referential legacy envelope", () => {
+    let contentReads = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    let toJSONReads = 0;
+    let envelope;
+    envelope = new Proxy({}, {
+      has(_target, property) {
+        return property === "content";
+      },
+      get(_target, property) {
+        if (property === "content") {
+          contentReads += 1;
+          return envelope;
+        }
+        if (property === "toJSON") toJSONReads += 1;
+        return undefined;
+      },
+      ownKeys() {
+        ownKeysCalls += 1;
+        return [];
+      },
+      getOwnPropertyDescriptor() {
+        descriptorCalls += 1;
+        return undefined;
+      },
+    });
+
+    assert.equal(summarizeToolOutputForEvidence(envelope), "[unserializable tool output]");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+    assert.equal(ownKeysCalls, 0, "original envelope ownKeys must not be invoked");
+    assert.equal(descriptorCalls, 0, "original envelope descriptors must not be inspected");
+    assert.equal(toJSONReads, 0, "original envelope toJSON must not be inspected");
+  });
+
+  it("fails closed without inspecting object content that aliases the legacy envelope", () => {
+    let contentReads = 0;
+    let ownKeysCalls = 0;
+    let descriptorCalls = 0;
+    let toJSONReads = 0;
+    let envelope;
+    envelope = new Proxy({}, {
+      has(_target, property) {
+        return property === "content";
+      },
+      get(_target, property) {
+        if (property === "content") {
+          contentReads += 1;
+          return { nested: envelope };
+        }
+        if (property === "toJSON") toJSONReads += 1;
+        return undefined;
+      },
+      ownKeys() {
+        ownKeysCalls += 1;
+        return [];
+      },
+      getOwnPropertyDescriptor() {
+        descriptorCalls += 1;
+        return undefined;
+      },
+    });
+
+    assert.equal(summarizeToolOutputForEvidence(envelope), "[unserializable tool output]");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+    assert.equal(ownKeysCalls, 0, "original envelope ownKeys must not be invoked");
+    assert.equal(descriptorCalls, 0, "original envelope descriptors must not be inspected");
+    assert.equal(toJSONReads, 0, "original envelope toJSON must not be inspected");
+  });
+
+  it("serializes a cached non-string legacy content value without rereading its getter", () => {
+    let contentReads = 0;
+    const stateful = {
+      get content() {
+        contentReads += 1;
+        return contentReads === 1 ? 9007199254740993n : "changed on second read";
+      },
+    };
+
+    const out = summarizeToolOutputForEvidence(stateful);
+
+    assert.equal(out, "9007199254740993");
+    assert.equal(contentReads, 1, "content must be read exactly once");
+  });
+
+  it("attempts a throwing content getter once and returns the stable sentinel", () => {
+    let contentReads = 0;
+    const hostile = {
+      get content() {
+        contentReads += 1;
+        throw new Error("content getter failed");
+      },
+      toJSON() {
+        throw new Error("original envelope must not be re-serialized");
+      },
+    };
+
+    assert.equal(
+      summarizeToolOutputForEvidence(hostile),
+      "[unserializable tool output]"
+    );
+    assert.equal(contentReads, 1, "throwing content getter must be attempted once");
+  });
+
+  it("never throws when toJSON and toString both throw", () => {
+    // JSON.stringify trips toJSON; the String() coercion fallback then trips
+    // Symbol.toPrimitive/toString. Both paths must be caught, yielding the
+    // stable non-secret sentinel.
+    const hostile = {
+      toJSON() {
+        throw new Error("hostile toJSON");
+      },
+      toString() {
+        throw new Error("hostile toString");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("hostile Symbol.toPrimitive");
+      },
+    };
+    let out;
+    assert.doesNotThrow(() => {
+      out = summarizeToolOutputForEvidence(hostile);
+    }, "hostile toJSON/toString object must not throw");
+    assert.equal(typeof out, "string", "must return a string fallback");
+    assert.equal(
+      out,
+      "[unserializable tool output]",
+      "must return the deterministic sentinel"
+    );
+  });
+
+  it("returns an exactly-4000-char string unchanged", () => {
+    const input = "x".repeat(4000);
+    assert.equal(input.length, 4000);
+    const out = summarizeToolOutputForEvidence(input);
+    assert.equal(out, input);
+    assert.equal(out.length, 4000);
+  });
+
+  it("bounds a 4001-char string to <=4000 while preserving both ends", () => {
+    const input = `HEAD${"x".repeat(3993)}TAIL`;
+    assert.equal(input.length, 4001);
+    const out = summarizeToolOutputForEvidence(input);
+    assert.ok(out.length <= 4000, `summary must stay within 4000 (was ${out.length})`);
+    assert.ok(out.startsWith("HEAD"), "head preserved");
+    assert.ok(out.endsWith("TAIL"), "tail preserved");
+  });
+});
+
+function isJson(value) {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/relay-container-contract.test.mjs
+++ b/test/relay-container-contract.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * Relay container contract — reproducible-image test suite
+ *
+ * The relay image must be byte-reproducible with respect to its sports data
+ * backend: an unpinned `pip install sports-skills` silently floats to whatever
+ * version PyPI serves at build time, so two builds of the same commit can ship
+ * different tool catalogs. These tests pin the Dockerfile contract:
+ *
+ *   1. a single declared ARG carries the sports-skills version;
+ *   2. pip installs that exact version (==), not a floating range;
+ *   3. the build asserts the *installed* metadata version matches the ARG, so a
+ *      resolver substitution fails the build instead of shipping;
+ *   4. schema bootstrap fails closed — no `|| echo` warning fallback that turns
+ *      a broken bootstrap into a green image with no schemas.
+ *
+ * The Dockerfile is asserted as text (never built here) so the contract is
+ * enforced on every CI run without a Docker daemon or cross-arch emulation.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const dockerfilePath = join(repoRoot, "docker/relay/Dockerfile");
+
+const EXPECTED_SPORTS_SKILLS_VERSION = "0.31.0";
+
+let dockerfile;
+/** Non-comment, non-blank Dockerfile lines with line continuations joined. */
+let instructions;
+
+before(() => {
+  dockerfile = readFileSync(dockerfilePath, "utf8");
+
+  const joined = dockerfile.replace(/\\\r?\n\s*/g, " ");
+  instructions = joined
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+});
+
+describe("relay container contract", () => {
+  it("declares ARG SPORTS_SKILLS_VERSION pinned to the release version", () => {
+    const argLines = instructions.filter((line) => /^ARG\s+SPORTS_SKILLS_VERSION\b/.test(line));
+
+    assert.equal(
+      argLines.length,
+      1,
+      `exactly one ARG SPORTS_SKILLS_VERSION must be declared (found ${argLines.length})`
+    );
+    assert.equal(
+      argLines[0],
+      `ARG SPORTS_SKILLS_VERSION=${EXPECTED_SPORTS_SKILLS_VERSION}`,
+      "ARG must carry the pinned default version"
+    );
+  });
+
+  it("declares the version ARG before the pip installation that consumes it", () => {
+    const argIndex = instructions.findIndex((line) => /^ARG\s+SPORTS_SKILLS_VERSION\b/.test(line));
+    const pipIndex = instructions.findIndex(
+      (line) => /^RUN\b/.test(line) && /pip install/.test(line) && /sports-skills/.test(line)
+    );
+
+    assert.ok(argIndex >= 0, "ARG SPORTS_SKILLS_VERSION must exist");
+    assert.ok(pipIndex >= 0, "a RUN pip install of sports-skills must exist");
+    assert.ok(
+      argIndex < pipIndex,
+      `ARG (line index ${argIndex}) must be declared before the pip install (line index ${pipIndex})`
+    );
+  });
+
+  it("pip installs sports-skills at the exact ARG version", () => {
+    const pipLine = instructions.find(
+      (line) => /^RUN\b/.test(line) && /pip install/.test(line) && /sports-skills/.test(line)
+    );
+
+    assert.ok(pipLine, "a RUN pip install of sports-skills must exist");
+    assert.match(
+      pipLine,
+      /sports-skills==\$\{SPORTS_SKILLS_VERSION\}/,
+      "sports-skills must be pinned to ==${SPORTS_SKILLS_VERSION}"
+    );
+    assert.ok(
+      !/(?:^|\s)sports-skills(?=\s|$)/.test(pipLine),
+      "sports-skills must never be installed unpinned"
+    );
+  });
+
+  it("keeps aiohttp as a separate installed dependency", () => {
+    const aiohttpLines = instructions.filter(
+      (line) => /^RUN\b/.test(line) && /pip install/.test(line) && /\baiohttp\b/.test(line)
+    );
+
+    assert.ok(aiohttpLines.length >= 1, "aiohttp must still be installed via pip");
+    assert.ok(
+      !/aiohttp==\$\{SPORTS_SKILLS_VERSION\}/.test(aiohttpLines.join("\n")),
+      "aiohttp must not inherit the sports-skills version pin"
+    );
+  });
+
+  it("asserts the installed sports-skills version equals the ARG at build time", () => {
+    const assertLines = instructions.filter(
+      (line) => /^RUN\b/.test(line) && /importlib\.metadata/.test(line)
+    );
+
+    assert.equal(
+      assertLines.length,
+      1,
+      `exactly one build-time version assertion is expected (found ${assertLines.length})`
+    );
+
+    const assertLine = assertLines[0];
+    assert.match(
+      assertLine,
+      /importlib\.metadata/,
+      "assertion must read the installed distribution metadata"
+    );
+    assert.match(
+      assertLine,
+      /version\((['"])sports-skills\1\)/,
+      "assertion must query importlib.metadata.version('sports-skills')"
+    );
+    assert.match(
+      assertLine,
+      /\$\{?SPORTS_SKILLS_VERSION\}?/,
+      "assertion must compare against the SPORTS_SKILLS_VERSION argument"
+    );
+    assert.match(assertLine, /\bassert\b/, "assertion must actually assert (fail the build)");
+  });
+
+  it("bootstraps schemas with a fail-closed init and no warning fallback", () => {
+    const initLines = instructions.filter(
+      (line) => /^RUN\b/.test(line) && /dist\/index\.js\s+init\b/.test(line)
+    );
+
+    assert.equal(
+      initLines.length,
+      1,
+      `exactly one schema bootstrap RUN is expected (found ${initLines.length})`
+    );
+
+    const initLine = initLines[0];
+    assert.equal(
+      initLine,
+      "RUN node dist/index.js init --all --verbose",
+      "schema bootstrap must be an unguarded, fail-closed init"
+    );
+    assert.ok(!initLine.includes("||"), "no `||` fallback may swallow a failed bootstrap");
+    assert.ok(!/\becho\b/.test(initLine), "no `echo` warning fallback may mask a failed bootstrap");
+    assert.ok(!/2>&1/.test(initLine), "no stderr redirection should hide bootstrap failures");
+  });
+
+  it("never masks a schema bootstrap failure anywhere in the Dockerfile", () => {
+    const masked = instructions.filter(
+      (line) => /init\b/.test(line) && /\|\|/.test(line) && /echo/.test(line)
+    );
+
+    assert.deepEqual(masked, [], "no instruction may `|| echo` over a schema bootstrap failure");
+    assert.ok(
+      !/Warning: schema bootstrap incomplete/.test(dockerfile),
+      "the schema bootstrap warning fallback must be gone"
+    );
+  });
+});

--- a/test/schema-catalog.test.mjs
+++ b/test/schema-catalog.test.mjs
@@ -10,7 +10,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it, before, after } from "node:test";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   chmodSync,
   mkdtempSync,
@@ -84,7 +84,7 @@ function fixtureSchema(sport, toolCount) {
   };
 }
 
-function createFakeSportsSkills(root, catalogModules) {
+function createFakeSportsSkills(root, catalogModules, failingSkills = []) {
   const executable = join(root, "fake-sports-skills");
   const catalog = catalogModules === null
     ? null
@@ -101,6 +101,11 @@ if (args[2] === "catalog") {
   process.exit(0);
 }
 if (args[3] === "schema") {
+  const failing = ${JSON.stringify(failingSkills)};
+  if (failing.includes(args[2])) {
+    process.stderr.write("simulated schema outage for " + args[2]);
+    process.exit(1);
+  }
   process.stdout.write(JSON.stringify({ sport: args[2], version: "offline-test", tools: [] }));
   process.exit(0);
 }
@@ -208,6 +213,125 @@ describe("bootstrapDefaultSchemas", () => {
       [...DEFAULT_SKILLS].sort(),
     );
     assert.ok(result.progress.every(([, ok]) => ok));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed bootstrap completeness
+//
+// docker/relay/Dockerfile runs `RUN node dist/index.js init --all --verbose`
+// unguarded, so `init --all` is the only thing standing between a partial
+// bootstrap and a green image with a partial/empty schema catalog.
+// ---------------------------------------------------------------------------
+
+describe("assertDefaultBootstrapComplete", () => {
+  let assertDefaultBootstrapComplete;
+
+  before(async () => {
+    ({ assertDefaultBootstrapComplete } = await import("../dist/schema.js"));
+  });
+
+  it("accepts a complete bootstrap", () => {
+    assert.doesNotThrow(() =>
+      assertDefaultBootstrapComplete(DEFAULT_SKILLS.length)
+    );
+    assert.doesNotThrow(() => assertDefaultBootstrapComplete(3, 3));
+  });
+
+  it("rejects a partial bootstrap and reports actual vs expected counts", () => {
+    assert.throws(
+      () => assertDefaultBootstrapComplete(DEFAULT_SKILLS.length - 1),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, new RegExp(String(DEFAULT_SKILLS.length - 1)));
+        assert.match(err.message, new RegExp(String(DEFAULT_SKILLS.length)));
+        return true;
+      }
+    );
+  });
+
+  it("rejects a zero-schema bootstrap", () => {
+    assert.throws(() => assertDefaultBootstrapComplete(0));
+  });
+
+  it("rejects counts that are not whole non-negative numbers", () => {
+    for (const bogus of [Number.NaN, -1, 19.5, Infinity, "20", null, undefined]) {
+      assert.throws(
+        () => assertDefaultBootstrapComplete(bogus, DEFAULT_SKILLS.length),
+        `expected ${String(bogus)} to be rejected`
+      );
+    }
+  });
+
+  it("rejects an over-count instead of treating it as complete", () => {
+    assert.throws(() =>
+      assertDefaultBootstrapComplete(DEFAULT_SKILLS.length + 1)
+    );
+  });
+});
+
+describe("sportsclaw init --all (CLI, fail-closed)", () => {
+  function runInitAll(failingSkills) {
+    const root = mkdtempSync(join(tmpdir(), "sportsclaw-init-all-"));
+    const schemaDir = join(root, "schemas");
+    const home = join(root, "home");
+    mkdirSync(schemaDir, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    const pythonPath = createFakeSportsSkills(
+      root,
+      [...DEFAULT_SKILLS],
+      failingSkills
+    );
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      PYTHON_PATH: pythonPath,
+      sportsclaw_SCHEMA_DIR: schemaDir,
+    };
+    delete env.SPORTSCLAW_SKILLS;
+    delete env.sportsclaw_SKILLS;
+
+    try {
+      const result = spawnSync(
+        "node",
+        ["dist/index.js", "init", "--all", "--verbose"],
+        { encoding: "utf-8", env }
+      );
+      const installed = readdirSync(schemaDir).filter((n) => n.endsWith(".json"));
+      return {
+        status: result.status,
+        output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+        installed,
+      };
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it("exits nonzero when some default schemas cannot be installed", () => {
+    const failing = ["nba", "kalshi"];
+    const expected = DEFAULT_SKILLS.length;
+    const run = runInitAll(failing);
+
+    assert.equal(run.installed.length, expected - failing.length);
+    assert.notEqual(
+      run.status,
+      0,
+      `a partial bootstrap must not exit 0; output:\n${run.output}`
+    );
+    assert.match(run.output, new RegExp(String(expected - failing.length)));
+    assert.match(run.output, new RegExp(String(expected)));
+    // The repair hint stays, so the operator still knows what to do.
+    assert.match(run.output, /sports-skills/);
+  });
+
+  it("exits zero when every default schema installs", () => {
+    const run = runInitAll([]);
+
+    assert.equal(run.installed.length, DEFAULT_SKILLS.length);
+    assert.equal(run.status, 0, `expected exit 0; output:\n${run.output}`);
   });
 });
 


### PR DESCRIPTION
## Summary
- port the production `relay-v0.28.3` evidence-normalization hardening onto current main
- pin the relay image to `sports-skills==0.31.0` and assert the installed version
- make `sportsclaw init --all` and the Docker build fail closed on partial schema bootstrap
- release package metadata as `0.29.3`

## TDD evidence
- evidence hardening RED: 16 failing subtests against base behavior after a minimal export seam
- Docker contract RED: 6 of 7 failing subtests against the base Dockerfile
- native bootstrap RED: real `init --all` CLI exited zero on an 18/20 partial bootstrap before the guard was wired

## Verification
- `npm run build`
- full native suite: **1098 passed, 0 failed**
- `SPORTSCLAW_MEMORY_BACKEND=file npm run test:ci-smoke`
- `npm pack --dry-run`: `sportsclaw-engine-core@0.29.3`, 462 entries
- `git diff --check`
- added-line static secret scan: 0 findings

## Independent exact-SHA reviews
Candidate: `027b639a094b5761326c2d95faf2de4b0524e014`
- specification: **PASS**
- code quality/security: **APPROVED**, zero P0/P1

## Release boundary
Merging does not deploy. After merge, the separate `relay-v0.29.3` tag builds the image. AKS promotion will use only the workflow-produced immutable digest after an isolated canary.
