### PR TITLE
fix(relay): parse structured skills catalog

### DIFF
--- a/docker/relay/Dockerfile
+++ b/docker/relay/Dockerfile
@@ -69,12 +69,17 @@ RUN npm prune --omit=dev
 # --- Bootstrap default sport schemas -----------------------------------------
 # Fails closed: an image with missing or partial schemas is not shippable, so a
 # failed bootstrap must fail the build rather than log a warning and continue.
-ENV SPORTSCLAW_SCHEMA_DIR=/app/.sportsclaw/schemas
+# The env name is case-sensitive and intentionally lowercase-prefixed: the engine
+# reads `process.env.sportsclaw_SCHEMA_DIR` (src/schema.ts). An uppercase spelling
+# is silently ignored, and the bootstrap below would write to
+# /root/.sportsclaw/schemas — outside the runtime schema dir.
+ENV sportsclaw_SCHEMA_DIR=/app/.sportsclaw/schemas
 RUN mkdir -p /app/.sportsclaw/schemas
 RUN node dist/index.js init --all --verbose
 
 # --- Relay server & entrypoint ------------------------------------------------
 COPY docker/relay/relay_server.py /opt/sportsclaw/relay_server.py
+COPY docker/relay/skills_catalog.py /opt/sportsclaw/skills_catalog.py
 COPY docker/relay/entrypoint.sh /opt/sportsclaw/entrypoint.sh
 RUN chmod +x /opt/sportsclaw/entrypoint.sh
 

--- a/docker/relay/relay_server.py
+++ b/docker/relay/relay_server.py
@@ -36,6 +36,8 @@ import time
 
 from aiohttp import web
 
+from skills_catalog import parse_catalog
+
 
 PORT = int(os.environ.get("RELAY_PORT", 8080))
 SPORTSCLAW_BIN = os.environ.get("SPORTSCLAW_BIN", "node")
@@ -64,23 +66,27 @@ async def health(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 
 async def list_skills(request: web.Request) -> web.Response:
-    """Return installed sport schemas."""
+    """
+    Return the installed catalog as a flat list of schema/module names.
+
+    Reads the CLI's structured `list --json` output. Human output is categorized
+    prose, so the old line scrape matched nothing and reported a successful empty
+    catalog; a nonzero exit or an unparseable payload is now an error instead.
+    """
     try:
         proc = await asyncio.create_subprocess_exec(
-            SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "list",
+            SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "list", "--json",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=_build_env(),
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-        lines = stdout.decode().strip().splitlines()
-        skills = [
-            l.strip().lstrip("- ").strip()
-            for l in lines
-            if l.strip().startswith("- ")
-        ]
+        stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+        skills = parse_catalog(stdout.decode(), proc.returncode)
         return web.json_response({"status": True, "skills": skills})
     except Exception as e:
+        # Only the parser's own message is surfaced — child stderr is never
+        # forwarded to the client.
+        log(f"skills: {e}")
         return web.json_response(
             {"status": False, "error": str(e)}, status=500
         )

--- a/docker/relay/skills_catalog.py
+++ b/docker/relay/skills_catalog.py
@@ -1,0 +1,84 @@
+"""
+Structured parsing of `sportsclaw list --json` for the relay skills endpoint.
+
+Stdlib only, and deliberately free of any aiohttp import: the relay's HTTP layer
+needs aiohttp, this parsing contract does not, so it stays executable in tests
+without the web dependency installed.
+
+Why this module exists: the relay used to run `sportsclaw list` in *human* mode
+and scrape lines beginning with "- ". The human renderer emits categorized,
+comma-separated prose, so the scrape matched nothing and `GET /api/skills`
+returned a successful *empty* catalog while the 0.29.3 canary container actually
+held 20 schema files and 291 tools. Structured output is now the contract, and
+anything unexpected fails loudly instead of degrading to an empty list.
+
+The `/api/skills` response stays flat (a single `skills` array). Categories are
+combined in a fixed order so the payload is deterministic across calls.
+"""
+
+import json
+
+# Category order defines the order of the flattened response.
+CATEGORY_KEYS = (
+    "defaultSports",
+    "optionalSports",
+    "defaultSupport",
+    "optionalSupport",
+    "unknown",
+)
+
+
+class CatalogError(Exception):
+    """The CLI did not produce a usable structured catalog."""
+
+
+def parse_catalog(stdout: str, returncode: int = 0) -> list[str]:
+    """
+    Turn `sportsclaw list --json` output into a flat, deduplicated skill list.
+
+    Names keep their first-occurrence position; duplicates across or within
+    categories are dropped. Raises CatalogError on a failed child process, on
+    malformed JSON, or on any category that is not an array of non-blank strings.
+    """
+    if returncode != 0:
+        raise CatalogError(f"sportsclaw list --json exited with code {returncode}")
+
+    try:
+        payload = json.loads(stdout)
+    except (TypeError, ValueError) as exc:
+        raise CatalogError(f"sportsclaw list --json emitted invalid JSON: {exc}") from None
+
+    if not isinstance(payload, dict):
+        raise CatalogError(
+            "sportsclaw list --json must emit a JSON object, "
+            f"got {type(payload).__name__}"
+        )
+
+    skills: list[str] = []
+    seen: set[str] = set()
+
+    for key in CATEGORY_KEYS:
+        if key not in payload:
+            raise CatalogError(f"sportsclaw list --json is missing the '{key}' category")
+
+        names = payload[key]
+        if not isinstance(names, list):
+            raise CatalogError(
+                f"category '{key}' must be a JSON array, got {type(names).__name__}"
+            )
+
+        for index, name in enumerate(names):
+            if not isinstance(name, str):
+                raise CatalogError(
+                    f"category '{key}'[{index}] must be a string, "
+                    f"got {type(name).__name__}"
+                )
+            cleaned = name.strip()
+            if not cleaned:
+                raise CatalogError(f"category '{key}'[{index}] is blank")
+            if cleaned in seen:
+                continue
+            seen.add(cleaned)
+            skills.append(cleaned)
+
+    return skills

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sportsclaw-engine-core",
-      "version": "0.29.3",
+      "version": "0.29.4",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/sdk": "^2.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsclaw-engine-core",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "A CLI and bot scaffold that connects any LLM to live sports data via sports-skills. Supports Anthropic, OpenAI, Google, and Azure Foundry.",
   "type": "module",
   "main": "dist/index.js",

--- a/test/relay-container-contract.test.mjs
+++ b/test/relay-container-contract.test.mjs
@@ -11,20 +11,28 @@
  *   3. the build asserts the *installed* metadata version matches the ARG, so a
  *      resolver substitution fails the build instead of shipping;
  *   4. schema bootstrap fails closed — no `|| echo` warning fallback that turns
- *      a broken bootstrap into a green image with no schemas.
+ *      a broken bootstrap into a green image with no schemas;
+ *   5. the bootstrap writes to the directory the engine actually reads — the env
+ *      name is case-sensitive (`sportsclaw_SCHEMA_DIR`), so an uppercase ENV
+ *      silently sends build-time schemas to `/root/.sportsclaw/schemas`;
+ *   6. every Python module the relay server imports is COPYed into the image.
  *
  * The Dockerfile is asserted as text (never built here) so the contract is
  * enforced on every CI run without a Docker daemon or cross-arch emulation.
+ * Where a value must agree with the engine, it is derived from the engine source
+ * rather than restated, so drift on either side fails.
  */
 
 import assert from "node:assert/strict";
 import { describe, it, before } from "node:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "docker/relay/Dockerfile");
+const relayServerPath = join(repoRoot, "docker/relay/relay_server.py");
+const schemaSourcePath = join(repoRoot, "src/schema.ts");
 
 const EXPECTED_SPORTS_SKILLS_VERSION = "0.31.0";
 
@@ -151,6 +159,83 @@ describe("relay container contract", () => {
     assert.ok(!initLine.includes("||"), "no `||` fallback may swallow a failed bootstrap");
     assert.ok(!/\becho\b/.test(initLine), "no `echo` warning fallback may mask a failed bootstrap");
     assert.ok(!/2>&1/.test(initLine), "no stderr redirection should hide bootstrap failures");
+  });
+
+  it("sets the schema dir under the exact env name the engine reads", () => {
+    const engineSource = readFileSync(schemaSourcePath, "utf-8");
+    const engineEnv = engineSource.match(/process\.env\.(\w*SCHEMA_DIR)\b/);
+
+    assert.ok(engineEnv, "src/schema.ts must resolve the schema dir from an env var");
+    const envName = engineEnv[1];
+
+    const envLines = instructions.filter((line) => /^ENV\s+\w*SCHEMA_DIR=/.test(line));
+    assert.equal(
+      envLines.length,
+      1,
+      `exactly one schema-dir ENV is expected (found ${envLines.length}: ${envLines.join(" | ")})`
+    );
+    assert.equal(
+      envLines[0],
+      `ENV ${envName}=/app/.sportsclaw/schemas`,
+      `the ENV name must match the engine's \`process.env.${envName}\` byte for byte — ` +
+        "env var names are case-sensitive, so a mismatch sends build-time schemas to " +
+        "/root/.sportsclaw/schemas and ships an image whose runtime catalog is empty"
+    );
+  });
+
+  it("never uses a differently-cased schema dir env name", () => {
+    const engineSource = readFileSync(schemaSourcePath, "utf-8");
+    const envName = engineSource.match(/process\.env\.(\w*SCHEMA_DIR)\b/)[1];
+
+    const wrongCase = [...dockerfile.matchAll(/\b(\w*SCHEMA_DIR)\b/g)]
+      .map((m) => m[1])
+      .filter((name) => name !== envName);
+
+    assert.deepEqual(
+      [...new Set(wrongCase)],
+      [],
+      `only \`${envName}\` may appear; other casings are silently ignored by the engine`
+    );
+  });
+
+  it("declares the schema dir env before the bootstrap init consumes it", () => {
+    const envIndex = instructions.findIndex((line) => /^ENV\s+\w*SCHEMA_DIR=/.test(line));
+    const initIndex = instructions.findIndex(
+      (line) => /^RUN\b/.test(line) && /dist\/index\.js\s+init\b/.test(line)
+    );
+
+    assert.ok(envIndex >= 0, "a schema-dir ENV must exist");
+    assert.ok(initIndex >= 0, "the schema bootstrap RUN must exist");
+    assert.ok(
+      envIndex < initIndex,
+      `ENV (index ${envIndex}) must precede the bootstrap init (index ${initIndex})`
+    );
+  });
+
+  it("ships every local Python module the relay server imports", () => {
+    const relaySource = readFileSync(relayServerPath, "utf-8");
+    const relayDir = dirname(relayServerPath);
+
+    const localImports = [...relaySource.matchAll(/^(?:from|import)\s+(\w+)/gm)]
+      .map((m) => m[1])
+      .filter((name) => existsSync(join(relayDir, `${name}.py`)));
+
+    assert.ok(
+      localImports.length >= 1,
+      "the relay server must import its catalog parser as a local module"
+    );
+
+    const copyLines = instructions.filter((line) => /^COPY\s+docker\/relay\//.test(line));
+
+    for (const moduleName of new Set(localImports)) {
+      assert.ok(
+        copyLines.some((line) =>
+          new RegExp(`^COPY\\s+docker/relay/${moduleName}\\.py\\s+/opt/sportsclaw/${moduleName}\\.py$`).test(line)
+        ),
+        `docker/relay/${moduleName}.py must be COPYed next to relay_server.py ` +
+          `(otherwise the relay crashes on import at container start). COPY lines: ${copyLines.join(" | ")}`
+      );
+    }
   });
 
   it("never masks a schema bootstrap failure anywhere in the Dockerfile", () => {

--- a/test/relay-skills-catalog.test.mjs
+++ b/test/relay-skills-catalog.test.mjs
@@ -1,0 +1,392 @@
+/**
+ * Relay `/api/skills` catalog contract — regression suite for the 0.29.3 canary
+ *
+ * Production evidence (relay-v0.29.3 canary): the container shipped 20 schema
+ * files / 291 tools and `node /app/dist/index.js list --json` returned correct
+ * categorized arrays, yet `GET /api/skills` returned `{"skills": []}`. The relay
+ * ran `sportsclaw list` in *human* mode and scraped only lines starting with
+ * `- `; the human renderer emits categorized, comma-separated prose, so nothing
+ * matched and the endpoint reported a successful empty catalog.
+ *
+ * These tests execute the real parsing behaviour rather than asserting on source
+ * text. The parser (`docker/relay/skills_catalog.py`) is stdlib-only, so it runs
+ * here without aiohttp; the endpoint itself is exercised by importing
+ * `relay_server.py` with a stub `aiohttp` module and a fake `node` binary, which
+ * proves the handler really invokes `list --json` and really validates the child
+ * return code.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const relayDir = join(repoRoot, "docker/relay");
+const PYTHON = process.env.PYTHON_PATH || "python3";
+
+// --- Python drivers ---------------------------------------------------------
+// Written to a temp dir so nothing test-only ships inside docker/relay.
+
+const PARSE_DRIVER = `
+import json, sys
+
+sys.path.insert(0, sys.argv[1])
+from skills_catalog import CatalogError, parse_catalog
+
+payload = json.loads(sys.stdin.read())
+try:
+    skills = parse_catalog(payload["stdout"], payload["returncode"])
+    print(json.dumps({"ok": True, "skills": skills}))
+except CatalogError as exc:
+    # Any other exception type escapes on purpose: the driver exits nonzero and
+    # the test fails, which pins CatalogError as the declared failure mode.
+    print(json.dumps({"ok": False, "error": str(exc)}))
+`;
+
+const ENDPOINT_DRIVER = `
+"""Call relay_server.list_skills() with a stubbed aiohttp and a fake node."""
+import asyncio, json, sys, types
+
+
+class _Response:
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+
+def _json_response(data, status=200):
+    return _Response(data, status)
+
+
+_web = types.SimpleNamespace(
+    Request=object,
+    Response=_Response,
+    StreamResponse=object,
+    Application=object,
+    json_response=_json_response,
+    run_app=None,
+)
+_aiohttp = types.ModuleType("aiohttp")
+_aiohttp.web = _web
+sys.modules["aiohttp"] = _aiohttp
+
+sys.path.insert(0, sys.argv[1])
+import relay_server
+
+response = asyncio.run(relay_server.list_skills(object()))
+print(json.dumps({"status_code": response.status, "body": response.data}))
+`;
+
+const FAKE_NODE = `#!/usr/bin/env python3
+"""Stands in for \`node\` so the handler's argv, exit code and stderr are ours."""
+import os, sys
+
+with open(os.environ["ARGV_LOG"], "w") as handle:
+    handle.write("\\n".join(sys.argv[1:]))
+
+stderr_text = os.environ.get("FAKE_STDERR", "")
+if stderr_text:
+    sys.stderr.write(stderr_text)
+
+with open(os.environ["FAKE_STDOUT_FILE"]) as handle:
+    sys.stdout.write(handle.read())
+
+sys.exit(int(os.environ.get("FAKE_EXIT", "0")))
+`;
+
+let workDir;
+let parseDriver;
+let endpointDriver;
+let fakeNode;
+let argvLog;
+let stdoutFile;
+
+before(() => {
+  workDir = mkdtempSync(join(tmpdir(), "sportsclaw-relay-skills-"));
+  parseDriver = join(workDir, "driver_parse.py");
+  endpointDriver = join(workDir, "driver_endpoint.py");
+  fakeNode = join(workDir, "fake_node.py");
+  argvLog = join(workDir, "argv.log");
+  stdoutFile = join(workDir, "stdout.txt");
+
+  writeFileSync(parseDriver, PARSE_DRIVER, "utf-8");
+  writeFileSync(endpointDriver, ENDPOINT_DRIVER, "utf-8");
+  writeFileSync(fakeNode, FAKE_NODE, "utf-8");
+  chmodSync(fakeNode, 0o755);
+});
+
+after(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/** Run the stdlib parser over raw CLI output. Returns {ok, skills|error}. */
+function parseCatalog(stdout, returncode = 0) {
+  const run = spawnSync(PYTHON, [parseDriver, relayDir], {
+    input: JSON.stringify({ stdout, returncode }),
+    encoding: "utf-8",
+  });
+  assert.equal(
+    run.status,
+    0,
+    `parser driver must exit cleanly:\n${run.stdout ?? ""}\n${run.stderr ?? ""}`
+  );
+  return JSON.parse(lastJsonLine(run.stdout));
+}
+
+/** Drive the real /api/skills handler against a fake CLI. */
+function callSkillsEndpoint({ stdout = "", exitCode = 0, stderr = "" } = {}) {
+  writeFileSync(stdoutFile, stdout, "utf-8");
+  writeFileSync(argvLog, "", "utf-8");
+
+  const run = spawnSync(PYTHON, [endpointDriver, relayDir], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      SPORTSCLAW_BIN: fakeNode,
+      SPORTSCLAW_ENTRY: "/app/dist/index.js",
+      ARGV_LOG: argvLog,
+      FAKE_STDOUT_FILE: stdoutFile,
+      FAKE_EXIT: String(exitCode),
+      FAKE_STDERR: stderr,
+    },
+  });
+  assert.equal(
+    run.status,
+    0,
+    `endpoint driver must exit cleanly:\n${run.stdout ?? ""}\n${run.stderr ?? ""}`
+  );
+
+  return {
+    ...JSON.parse(lastJsonLine(run.stdout)),
+    argv: readFileSync(argvLog, "utf-8").split("\n").filter(Boolean),
+  };
+}
+
+function lastJsonLine(text) {
+  const lines = (text ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
+  assert.ok(lines.length > 0, "driver produced no output");
+  return lines[lines.length - 1];
+}
+
+/** A structurally valid `list --json` payload. */
+function catalogPayload(overrides = {}) {
+  return JSON.stringify({
+    schemaDir: "/app/.sportsclaw/schemas",
+    defaultSports: [],
+    optionalSports: [],
+    defaultSupport: [],
+    optionalSupport: [],
+    unknown: [],
+    totals: { sports: 0, support: 0, schemas: 0, tools: 0 },
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parser behaviour
+// ---------------------------------------------------------------------------
+
+describe("relay skills catalog parser", () => {
+  it("flattens the five categories in declared order, first occurrence wins", () => {
+    const result = parseCatalog(
+      catalogPayload({
+        defaultSports: ["nba", "nfl", "nba"],
+        optionalSports: ["esports", "nba"],
+        defaultSupport: ["kalshi", "news"],
+        optionalSupport: ["polymarket-trading", "news"],
+        unknown: ["quidditch"],
+      })
+    );
+
+    assert.equal(result.ok, true, `expected success, got ${result.error}`);
+    assert.deepEqual(result.skills, [
+      "nba",
+      "nfl",
+      "esports",
+      "kalshi",
+      "news",
+      "polymarket-trading",
+      "quidditch",
+    ]);
+  });
+
+  it("trims surrounding whitespace on names", () => {
+    const result = parseCatalog(catalogPayload({ defaultSports: ["  nba  "] }));
+
+    assert.equal(result.ok, true, `expected success, got ${result.error}`);
+    assert.deepEqual(result.skills, ["nba"]);
+  });
+
+  it("returns an empty list for a valid but empty catalog", () => {
+    const result = parseCatalog(catalogPayload());
+
+    assert.equal(result.ok, true, `expected success, got ${result.error}`);
+    assert.deepEqual(result.skills, []);
+  });
+
+  it("rejects malformed JSON instead of reporting an empty catalog", () => {
+    const result = parseCatalog("Installed schemas (20) — 291 tools\n  Default (14)\n");
+
+    assert.equal(result.ok, false, "human output must not parse as a catalog");
+    assert.match(result.error, /json/i);
+  });
+
+  it("rejects a JSON payload that is not an object", () => {
+    const result = parseCatalog("[1, 2, 3]");
+
+    assert.equal(result.ok, false, "a non-object payload must fail");
+  });
+
+  it("rejects a category that is not an array", () => {
+    const result = parseCatalog(catalogPayload({ defaultSports: { nba: 4 } }));
+
+    assert.equal(result.ok, false, "an object-valued category must fail");
+    assert.match(result.error, /defaultSports/);
+  });
+
+  it("rejects a non-string entry inside a category", () => {
+    const result = parseCatalog(catalogPayload({ optionalSupport: ["kalshi", 7] }));
+
+    assert.equal(result.ok, false, "a numeric entry must fail");
+    assert.match(result.error, /optionalSupport/);
+  });
+
+  it("rejects a blank entry inside a category", () => {
+    const result = parseCatalog(catalogPayload({ unknown: ["   "] }));
+
+    assert.equal(result.ok, false, "a blank name must fail");
+    assert.match(result.error, /unknown/);
+  });
+
+  it("rejects a payload missing a category key", () => {
+    const partial = JSON.parse(catalogPayload());
+    delete partial.defaultSupport;
+    const result = parseCatalog(JSON.stringify(partial));
+
+    assert.equal(result.ok, false, "a missing category must fail, not silently vanish");
+    assert.match(result.error, /defaultSupport/);
+  });
+
+  it("fails on a nonzero return code even when stdout is a valid catalog", () => {
+    const result = parseCatalog(catalogPayload({ defaultSports: ["nba"] }), 3);
+
+    assert.equal(result.ok, false, "a failed child must never yield a success payload");
+    assert.match(result.error, /3/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Endpoint wiring
+// ---------------------------------------------------------------------------
+
+describe("relay /api/skills endpoint", () => {
+  it("invokes the CLI in structured mode, never human mode", () => {
+    const result = callSkillsEndpoint({
+      stdout: catalogPayload({ defaultSports: ["nba"] }),
+    });
+
+    assert.deepEqual(result.argv, ["/app/dist/index.js", "list", "--json"]);
+  });
+
+  it("returns the flat combined catalog on success", () => {
+    const result = callSkillsEndpoint({
+      stdout: catalogPayload({
+        defaultSports: ["nba", "nfl"],
+        defaultSupport: ["kalshi"],
+        unknown: ["quidditch"],
+      }),
+    });
+
+    assert.equal(result.status_code, 200);
+    assert.deepEqual(result.body, {
+      status: true,
+      skills: ["nba", "nfl", "kalshi", "quidditch"],
+    });
+  });
+
+  it("returns HTTP 500 when the CLI exits nonzero, not a false empty success", () => {
+    const result = callSkillsEndpoint({
+      stdout: "",
+      exitCode: 1,
+      stderr: "ANTHROPIC_API_KEY=sk-ant-secret leaked into stderr",
+    });
+
+    assert.equal(result.status_code, 500);
+    assert.equal(result.body.status, false);
+    assert.ok(result.body.error, "an error message is part of the contract");
+    assert.ok(
+      !result.body.error.includes("sk-ant-secret"),
+      `child stderr must not be echoed to the client: ${result.body.error}`
+    );
+  });
+
+  it("returns HTTP 500 when the CLI emits human output instead of JSON", () => {
+    const result = callSkillsEndpoint({
+      stdout: "Installed schemas (20) — 291 tools\n  Default (14)\n    football, nfl, nba\n",
+    });
+
+    assert.equal(result.status_code, 500);
+    assert.equal(result.body.status, false);
+    assert.ok(!("skills" in result.body), "a parse failure must not report a catalog");
+  });
+
+  it("no longer scrapes bullet lines out of human output", () => {
+    const source = readFileSync(join(relayDir, "relay_server.py"), "utf-8");
+    const listSkills = source.slice(source.indexOf("async def list_skills"));
+    const body = listSkills.slice(0, listSkills.indexOf("async def query_stream"));
+
+    assert.ok(!/lstrip\(/.test(body), "the `- ` bullet scraper must be gone");
+    assert.ok(!/startswith\("- "\)/.test(body), "the `- ` bullet filter must be gone");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine env-name contract (the /root/.sportsclaw/schemas bug)
+// ---------------------------------------------------------------------------
+
+describe("engine schema-dir env name", () => {
+  const distEntry = join(repoRoot, "dist/index.js");
+
+  function listJson(env) {
+    const run = spawnSync("node", [distEntry, "list", "--json"], {
+      encoding: "utf-8",
+      env: { ...process.env, ...env },
+    });
+    assert.equal(run.status, 0, `list --json failed: ${run.stderr}`);
+    return JSON.parse(run.stdout);
+  }
+
+  it("honours the exact lowercase `sportsclaw_SCHEMA_DIR` spelling", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sportsclaw-schemadir-"));
+    try {
+      const parsed = listJson({
+        sportsclaw_SCHEMA_DIR: dir,
+        SPORTSCLAW_SCHEMA_DIR: undefined,
+      });
+      assert.equal(parsed.schemaDir, dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores the uppercase `SPORTSCLAW_SCHEMA_DIR` spelling", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sportsclaw-schemadir-upper-"));
+    try {
+      const parsed = listJson({
+        SPORTSCLAW_SCHEMA_DIR: dir,
+        sportsclaw_SCHEMA_DIR: undefined,
+      });
+      assert.notEqual(
+        parsed.schemaDir,
+        dir,
+        "if this ever passes, the Dockerfile ENV name must be revisited"
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fix the canary-proven `/api/skills` false-empty regression by consuming `sportsclaw list --json`
- validate child exit and structured category shapes; never forward child stderr
- preserve the flat skills API contract with deterministic first-occurrence deduplication
- correct the case-sensitive Docker schema directory env and ship the parser module
- cut package metadata as `0.29.4`

## Canary evidence
`relay-v0.29.3` was rejected before production promotion:
- engine `0.29.3`, sports-skills `0.31.0`
- 20 schema files / 291 tools existed in the image
- `node dist/index.js list --json` was correct
- GET `/api/skills` returned `skills: []` because the relay scraped obsolete human output

The failed canary was deleted. Production remains on the prior immutable digest.

## TDD evidence
- parser/endpoint RED: **15 failures, 2 passes**, including 200 instead of 500 on child failure and human output falsely producing an empty success
- Docker contract RED: **3 failures** for env casing and missing parser module
- focused GREEN: parser/endpoint **17/17**, release-focused suites **59/59**

## Final verification
- `npm ci && npm run build`
- full native suite: **1119 passed, 0 failed**
- file-memory CI smoke: PASS
- Python `py_compile`: PASS
- pack dry-run: `sportsclaw-engine-core@0.29.4`, 462 entries
- `git diff --check`: clean
- added-line secret scan: zero findings

## Independent exact-SHA reviews
Candidate `12433f72a23575e8eea61b751c0b7999b1754d22`:
- specification: **PASS**
- quality/security: **APPROVED**, zero P0/P1

Merging does not deploy. The separate `relay-v0.29.4` tag will build a new image, which must pass an isolated AKS canary before digest-only production promotion.
