### PR TITLE
docs: sanitize public repository references

### DIFF
--- a/docker/docs/DEPLOY.md
+++ b/docker/docs/DEPLOY.md
@@ -143,7 +143,8 @@ patches:
         value:
           - name: clone-skills
             image: alpine/git
-            command: ["sh", "-c", "git clone --depth 1 https://github.com/machina-sports/adidas-templates.git /skill-guides/adidas"]
+            # Replace with a repository your deployment is authorized to access.
+            command: ["sh", "-c", "git clone --depth 1 https://github.com/your-org/skill-guides.git /skill-guides/custom"]
             volumeMounts:
               - name: skill-guides
                 mountPath: /skill-guides

--- a/docker/relay/k8s/overlays/example/kustomization.yaml
+++ b/docker/relay/k8s/overlays/example/kustomization.yaml
@@ -66,7 +66,8 @@ secretGenerator:
 #         value:
 #           - name: clone-skills
 #             image: alpine/git
-#             command: ["sh", "-c", "git clone --depth 1 https://github.com/machina-sports/adidas-templates.git /skill-guides/adidas"]
+#             # Replace with a repository your deployment is authorized to access.
+#             command: ["sh", "-c", "git clone --depth 1 https://github.com/your-org/skill-guides.git /skill-guides/custom"]
 #             volumeMounts:
 #               - name: skill-guides
 #                 mountPath: /skill-guides

--- a/docs/advanced/operator.md
+++ b/docs/advanced/operator.md
@@ -87,8 +87,7 @@ without a pod: `npm run test:operator-sync`.
 
 ::: warning Dispatch needs the MCP redeploy
 operator-sync starts the loop via MCP `execute_agent` **by name** (`loop-runner`) — the same path
-as `machina_loop`. The deployed pod MCP must support agent-by-name
-([machina-client-api#287](https://github.com/machina-sports/machina-client-api/issues/287)); on a
-stale MCP the dispatch returns `status:error` and operator-sync stays inert (it never silently
-passes). The read path (`search_documents`) is unaffected.
+as `machina_loop`. The deployed pod MCP must support agent-by-name. On a stale MCP the dispatch
+returns `status:error` and operator-sync stays inert (it never silently passes). The read path
+(`search_documents`) is unaffected.
 :::

--- a/test/public-surface-sanitization.test.mjs
+++ b/test/public-surface-sanitization.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const forbidden = [
+  /app\.clickup\.com/i,
+  /github\.com\/machina-sports\/(?:machina-client-api|adidas-templates)(?:\/|\b)/i,
+  /(?:^|[\s"'`])\/Users\/bender(?:\/|\b)/im,
+  /chief-of-staff/i,
+  /Company Brain/i,
+];
+
+test("tracked public files do not expose restricted links or local paths", () => {
+  const files = execFileSync("git", ["ls-files", "-z"], { encoding: "buffer" })
+    .toString("utf8").split("\0").filter(Boolean);
+  const violations = [];
+  for (const file of files) {
+    let text;
+    try { text = readFileSync(file, "utf8"); } catch { continue; }
+    for (const pattern of forbidden) {
+      if (pattern.test(text)) violations.push(`${file}: ${pattern}`);
+    }
+  }
+  assert.deepEqual(violations, []);
+});

--- a/test/public-surface-sanitization.test.mjs
+++ b/test/public-surface-sanitization.test.mjs
@@ -16,6 +16,7 @@ test("tracked public files do not expose restricted links or local paths", () =>
     .toString("utf8").split("\0").filter(Boolean);
   const violations = [];
   for (const file of files) {
+    if (file === "test/public-surface-sanitization.test.mjs") continue;
     let text;
     try { text = readFileSync(file, "utf8"); } catch { continue; }
     for (const pattern of forbidden) {


### PR DESCRIPTION
## Summary
- remove links from public documentation to non-public repositories and issue trackers
- replace the tenant-specific skill-repository example with a neutral placeholder
- add a regression test that rejects restricted links and local personal paths in tracked public files

## Verification
- `node --test test/public-surface-sanitization.test.mjs`
- `npm run build`
- `git diff --check`