### PR TITLE
feat(agents): add native agent lifecycle and relay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ const engine = new sportsclawEngine();
 const answer = await engine.run("Who leads the Premier League?");
 ```
 
+Select one file-backed native agent explicitly with `sportsclaw --agent analyst "Compare today's odds"`, or pass `agentIds: ["analyst"]` to `engine.run`. Agent definitions can be managed through the exported `createAgent`, `updateAgent`, `inactivateAgent`, and `listAgents` functions. Selected agents keep SOUL and conversation memory isolated under `memory/<userId>/agents/<agentId>/`.
+
 **Docker in one command.** Ship the whole thing — Node.js engine + Python data layer — as a single container:
 
 ```bash

--- a/docker/docs/DEPLOY.md
+++ b/docker/docs/DEPLOY.md
@@ -59,6 +59,7 @@ overlays/<tenant>/
 | `SPORTSCLAW_PROVIDER` | **yes** | — | LLM provider: `google`, `anthropic`, `openai` |
 | `SPORTSCLAW_MODEL` | no | provider default | Model override (e.g. `gemini-2.0-flash`) |
 | `SPORTSCLAW_MEMORY_DIR` | no | `/data/memory` | Persistent memory path (mapped to PVC) |
+| `SPORTSCLAW_AGENTS_DIR` | no | `/data/memory/native-agents` | Native agent definitions (same PVC) |
 | `SPORTSCLAW_MCP_SERVERS` | no | — | MCP server connections (JSON, see below) |
 | `SPORTSCLAW_SKILL_GUIDES_DIR` | no | — | Path to SKILL.md guides in container |
 | `RELAY_PORT` | no | `8080` | HTTP port inside container |

--- a/docker/docs/FRONTEND.md
+++ b/docker/docs/FRONTEND.md
@@ -14,6 +14,9 @@ https://<relay-host>:8080
 | `GET` | `/api/skills` | JSON | List installed skills |
 | `POST` | `/api/query` | NDJSON stream | Real-time progress + result |
 | `POST` | `/api/query/sync` | JSON | Simple request/response |
+| `GET`, `POST` | `/api/agents` | JSON | List or create native agents |
+| `GET`, `PATCH` | `/api/agents/{id}` | JSON | Read, update, or inactivate an agent |
+| `POST` | `/api/agents/delegate` | JSON | One-hop delegation to another agent |
 
 ## Request Body (`POST /api/query` and `/api/query/sync`)
 
@@ -21,6 +24,7 @@ https://<relay-host>:8080
 {
   "prompt": "Who is top of the Premier League?",
   "user_id": "user-123",
+  "agent_id": "scoreboard",
   "stream": true
 }
 ```
@@ -29,6 +33,7 @@ https://<relay-host>:8080
 |-------|------|----------|-------------|
 | `prompt` | string | yes | The user's query |
 | `user_id` | string | no | Enables per-user memory. Default: `api-anonymous` |
+| `agent_id` | string | no | Select exactly one active native agent |
 | `provider` | string | no | Override LLM provider (`anthropic`, `openai`, `google`) |
 | `model` | string | no | Override model ID |
 | `verbose` | boolean | no | Enable debug output |
@@ -144,6 +149,23 @@ const data = await res.json();
 ```json
 { "status": false, "error": "Query timed out after 180s" }
 ```
+
+## Agent Delegation
+
+```typescript
+await fetch("/api/agents/delegate", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    prompt: "Prepare a concise NBA injury brief",
+    user_id: "user-123",
+    source_agent_id: "scoreboard",
+    agent_id: "analyst",
+  }),
+});
+```
+
+The source and target must be different active agents. Delegation cannot recurse and does not accept `system_prompt`.
 
 ## CORS
 

--- a/docker/docs/RELAY.md
+++ b/docker/docs/RELAY.md
@@ -21,6 +21,11 @@ Version: **v0.9.4** | Image: `machinasports/sportsclaw-relay`
 | `GET` | `/api/skills` | `application/json` | List installed sport schemas |
 | `POST` | `/api/query` | `application/x-ndjson` | **Streaming** — real-time progress events |
 | `POST` | `/api/query/sync` | `application/json` | **Buffered** — single JSON response |
+| `GET` | `/api/agents` | `application/json` | List native agents, including inactive agents |
+| `POST` | `/api/agents` | `application/json` | Create a native agent |
+| `GET` | `/api/agents/{id}` | `application/json` | Get one native agent |
+| `PATCH` | `/api/agents/{id}` | `application/json` | Update or inactivate a native agent |
+| `POST` | `/api/agents/delegate` | `application/json` | Run a one-hop query with a target native agent |
 
 ### `GET /health`
 
@@ -49,6 +54,7 @@ Both `/api/query` and `/api/query/sync` accept the same JSON body:
   "timeout": 180,
   "provider": "google",
   "model": "gemini-3-flash-preview",
+  "agent_id": "analyst",
   "verbose": false,
   "format": "markdown"
 }
@@ -61,6 +67,7 @@ Both `/api/query` and `/api/query/sync` accept the same JSON body:
 | `timeout` | number | no | `180` | Max seconds before timeout |
 | `provider` | string | no | env default | Override LLM provider (`anthropic`, `openai`, `google`) |
 | `model` | string | no | provider default | Override model ID |
+| `agent_id` | string | no | automatic routing | Select exactly one active native agent |
 | `api_key` | string | no | env default | Override API key for the provider |
 | `verbose` | boolean | no | `false` | Include debug events in output |
 | `format` | string | no | — | Output format hint |
@@ -155,6 +162,38 @@ Waits for the full engine execution and returns a single JSON response.
 ```
 
 Use sync mode for simple integrations that don't need real-time progress (scripts, Slack bots, etc.). Use streaming for any interactive UI.
+
+## Native Agents
+
+Create an agent with a lowercase slug, display name, optional title, markdown directives, and optional skill/tag filters:
+
+```json
+POST /api/agents
+{
+  "id": "match-reader",
+  "name": "Match Reader",
+  "title": "Football Briefing Specialist",
+  "skills": ["football", "news"],
+  "tags": ["briefing"],
+  "body": "## Directives\n\nProduce concise match briefs."
+}
+```
+
+Update fields with `PATCH /api/agents/match-reader`. Inactivation is non-destructive and must be sent alone as `{"active": false}`. Built-in agents cannot be changed or inactivated.
+
+Delegation requires distinct source and target agents:
+
+```json
+POST /api/agents/delegate
+{
+  "prompt": "Summarize today's transfer news",
+  "user_id": "dashboard-user-42",
+  "source_agent_id": "analyst",
+  "agent_id": "newsdesk"
+}
+```
+
+Delegation is one hop. Recursive markers and `system_prompt` are rejected. The target uses its own `memory/<userId>/agents/<agentId>/` namespace.
 
 ---
 
@@ -280,6 +319,7 @@ Provider and model can be overridden per-request via the query body.
 | `SPORTSCLAW_PROVIDER` | no | `anthropic` | LLM provider |
 | `SPORTSCLAW_MODEL` | no | provider default | Model override |
 | `SPORTSCLAW_MEMORY_DIR` | no | `/data/memory` | Persistent memory path |
+| `SPORTSCLAW_AGENTS_DIR` | no | `/data/memory/native-agents` | Persistent native agent definitions |
 | `SPORTSCLAW_MCP_SERVERS` | no | — | MCP server config (JSON) |
 | `SPORTSCLAW_SKILL_GUIDES_DIR` | no | — | Path to skill guides directory |
 | `RELAY_PORT` | no | `8080` | HTTP listen port |

--- a/docker/relay/Dockerfile
+++ b/docker/relay/Dockerfile
@@ -90,7 +90,8 @@ RUN chmod +x /opt/sportsclaw/entrypoint.sh
 
 # --- Persistent memory volume ------------------------------------------------
 ENV SPORTSCLAW_MEMORY_DIR=/data/memory
-RUN mkdir -p /data/memory
+ENV SPORTSCLAW_AGENTS_DIR=/data/memory/native-agents
+RUN mkdir -p /data/memory/native-agents
 VOLUME /data/memory
 
 # --- Highlights job workspace (overridable) -----------------------------------

--- a/docker/relay/relay_server.py
+++ b/docker/relay/relay_server.py
@@ -20,6 +20,11 @@ Endpoints:
     GET  /api/skills       → List installed sport schemas
     POST /api/query        → Streaming NDJSON response (real-time progress)
     POST /api/query/sync   → Buffered JSON response (waits for result)
+    GET  /api/agents       → List native agents
+    POST /api/agents       → Create a native agent
+    GET  /api/agents/{id}  → Get a native agent
+    PATCH /api/agents/{id} → Update or inactivate a native agent
+    POST /api/agents/delegate → One-hop query delegated to another native agent
     POST /api/highlights/jobs                     → Create a typed highlights job
     GET  /api/highlights/jobs/{job_id}            → Job status
     POST /api/highlights/jobs/{job_id}/cancel     → Cancel a job (terminal state)
@@ -31,6 +36,7 @@ Query body:
         "user_id": "discord-12345",        // optional, enables memory
         "provider": "anthropic",           // optional, override provider
         "model": "claude-sonnet-4-5-...",  // optional, override model
+        "agent_id": "analyst",             // optional, exact native agent
         "verbose": false                   // optional, enable debug output
     }
 """
@@ -38,6 +44,7 @@ Query body:
 import asyncio
 import json
 import os
+import re
 import secrets
 import time
 
@@ -57,6 +64,8 @@ PORT = int(os.environ.get("RELAY_PORT", 8080))
 SPORTSCLAW_BIN = os.environ.get("SPORTSCLAW_BIN", "node")
 SPORTSCLAW_ENTRY = os.environ.get("SPORTSCLAW_ENTRY", "/app/dist/index.js")
 DEFAULT_TIMEOUT = int(os.environ.get("RELAY_TIMEOUT", 180))
+AGENT_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+AGENTS_AUTH_HEADER = "X-Auth-Token"
 
 
 def log(msg: str) -> None:
@@ -107,6 +116,255 @@ async def list_skills(request: web.Request) -> web.Response:
 
 
 # ---------------------------------------------------------------------------
+# Native agents
+# ---------------------------------------------------------------------------
+
+class AgentApiError(Exception):
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
+def _agents_auth_error(request: web.Request) -> web.Response | None:
+    expected = os.environ.get("AGENTS_API_TOKEN", "")
+    if not expected:
+        return web.json_response(
+            {"status": False, "error": "agents API is unavailable — no API token is configured"},
+            status=503,
+        )
+    supplied = request.headers.get(AGENTS_AUTH_HEADER, "")
+    if not supplied or not secrets.compare_digest(
+        supplied.encode("utf-8"), expected.encode("utf-8")
+    ):
+        return web.json_response(
+            {"status": False, "error": f"invalid or missing {AGENTS_AUTH_HEADER}"},
+            status=401,
+        )
+    return None
+
+
+def _query_agent_auth_error(
+    request: web.Request, body: dict
+) -> web.Response | None:
+    """Keep legacy queries public, but authenticate explicit agent selection."""
+    if body.get("agent_id") is None:
+        return None
+    return _agents_auth_error(request)
+
+
+def _validate_agent_id(agent_id: object) -> str:
+    if (not isinstance(agent_id, str) or not agent_id
+            or len(agent_id) > 64 or not AGENT_ID_PATTERN.fullmatch(agent_id)):
+        raise AgentApiError(
+            "invalid agent_id: expected a lowercase slug using letters, numbers, and single hyphens"
+        )
+    return agent_id
+
+
+def _validate_agent_payload(body: object, *, create: bool) -> dict:
+    if not isinstance(body, dict):
+        raise AgentApiError("request body must be a JSON object")
+    allowed = {"id", "name", "title", "body", "skills", "tags"} if create else {
+        "name", "title", "body", "skills", "tags", "active"
+    }
+    unknown = set(body) - allowed
+    if unknown:
+        raise AgentApiError(f"unsupported agent fields: {', '.join(sorted(unknown))}")
+    if create:
+        _validate_agent_id(body.get("id"))
+        for required in ("name", "body"):
+            if required not in body:
+                raise AgentApiError(f"{required} is required")
+    if "name" in body:
+        name = body["name"]
+        if (not isinstance(name, str) or not name or len(name) > 80
+                or name != name.strip() or any(ord(ch) < 32 for ch in name)):
+            raise AgentApiError("invalid agent name")
+    if "title" in body:
+        title = body["title"]
+        if (not isinstance(title, str) or len(title) > 120
+                or title != title.strip()
+                or any(ord(ch) < 32 or ord(ch) == 127 for ch in title)):
+            raise AgentApiError("invalid agent title")
+    if "body" in body:
+        text = body["body"]
+        if (not isinstance(text, str) or not text.strip()
+                or len(text) > 100_000 or "\0" in text):
+            raise AgentApiError("invalid agent body")
+    for field in ("skills", "tags"):
+        if field not in body:
+            continue
+        values = body[field]
+        if not isinstance(values, list) or len(values) > 64:
+            raise AgentApiError(f"invalid agent {field}")
+        if any(not isinstance(value, str)
+               or len(value) > 64
+               or not AGENT_ID_PATTERN.fullmatch(value)
+               for value in values):
+            raise AgentApiError(f"invalid agent {field}")
+        if len(values) != len(set(values)):
+            raise AgentApiError(f"invalid agent {field}: duplicate values")
+    if "active" in body and not isinstance(body["active"], bool):
+        raise AgentApiError("invalid agent active status: expected a boolean")
+    return body
+
+
+async def _read_json_object(request: web.Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise AgentApiError("request body must be valid JSON") from exc
+    if not isinstance(body, dict):
+        raise AgentApiError("request body must be a JSON object")
+    return body
+
+
+async def _run_agent_cli(args: list[str], payload: dict | None = None):
+    cmd = [SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "agents", *args, "--json"]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE if payload is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_build_env(),
+    )
+    stdin = json.dumps(payload).encode() if payload is not None else None
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(stdin), timeout=10)
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        await proc.communicate()
+        raise AgentApiError("agent operation timed out", 504) from exc
+    if proc.returncode != 0:
+        detail = stderr.decode().strip().splitlines()
+        message = detail[-1] if detail else "agent operation failed"
+        status = 404 if "not found" in message.lower() else 409 if "exists" in message.lower() else 400
+        raise AgentApiError(message, status)
+    try:
+        result = json.loads(stdout.decode())
+        return result["data"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise AgentApiError("agent operation returned an invalid response", 500) from exc
+
+
+def _agent_error_response(error: Exception) -> web.Response:
+    status = error.status if isinstance(error, AgentApiError) else 500
+    message = str(error) if isinstance(error, AgentApiError) else "internal error"
+    return web.json_response({"status": False, "error": message}, status=status)
+
+
+async def agents_list(request: web.Request) -> web.Response:
+    denied = _agents_auth_error(request)
+    if denied is not None:
+        return denied
+    try:
+        agents = await _run_agent_cli(["list", "--all"])
+        return web.json_response({"status": True, "agents": agents})
+    except Exception as error:
+        return _agent_error_response(error)
+
+
+async def agents_get(request: web.Request) -> web.Response:
+    denied = _agents_auth_error(request)
+    if denied is not None:
+        return denied
+    try:
+        agent_id = _validate_agent_id(request.match_info.get("agent_id"))
+        agent = await _run_agent_cli(["get", agent_id])
+        return web.json_response({"status": True, "agent": agent})
+    except Exception as error:
+        return _agent_error_response(error)
+
+
+async def agents_create(request: web.Request) -> web.Response:
+    denied = _agents_auth_error(request)
+    if denied is not None:
+        return denied
+    try:
+        body = _validate_agent_payload(await _read_json_object(request), create=True)
+        agent = await _run_agent_cli(["create"], body)
+        return web.json_response({"status": True, "agent": agent}, status=201)
+    except Exception as error:
+        return _agent_error_response(error)
+
+
+async def agents_patch(request: web.Request) -> web.Response:
+    denied = _agents_auth_error(request)
+    if denied is not None:
+        return denied
+    try:
+        agent_id = _validate_agent_id(request.match_info.get("agent_id"))
+        body = _validate_agent_payload(await _read_json_object(request), create=False)
+        if "active" in body:
+            if len(body) != 1 or body["active"] is not False:
+                raise AgentApiError("active may only be set to false as a standalone inactivation")
+            agent = await _run_agent_cli(["inactivate", agent_id])
+        else:
+            if not body:
+                raise AgentApiError("at least one update field is required")
+            agent = await _run_agent_cli(["update", agent_id], body)
+        return web.json_response({"status": True, "agent": agent})
+    except Exception as error:
+        return _agent_error_response(error)
+
+
+def _build_delegated_body(body: object) -> dict:
+    if not isinstance(body, dict):
+        raise AgentApiError("request body must be a JSON object")
+    forbidden = {"system_prompt", "delegation_depth", "delegated", "source_chain"}
+    if forbidden.intersection(body):
+        raise AgentApiError("recursive delegation and delegated system_prompt are not allowed")
+    prompt = body.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise AgentApiError("prompt is required")
+    source_id = _validate_agent_id(body.get("source_agent_id"))
+    target_id = _validate_agent_id(body.get("agent_id"))
+    if source_id == target_id:
+        raise AgentApiError("self-delegation is not allowed")
+    delegated = {"prompt": prompt, "agent_id": target_id, "_delegated": True}
+    for key in ("user_id", "provider", "model", "verbose", "format", "timeout", "api_key"):
+        if key in body:
+            delegated[key] = body[key]
+    return delegated
+
+
+class _DelegatedRequest:
+    def __init__(self, body: dict, headers):
+        self._body = body
+        self.headers = headers
+
+    async def json(self) -> dict:
+        return self._body
+
+
+async def agents_delegate(request: web.Request) -> web.Response:
+    denied = _agents_auth_error(request)
+    if denied is not None:
+        return denied
+    try:
+        original = await _read_json_object(request)
+        delegated = _build_delegated_body(original)
+        source = await _run_agent_cli(["get", original["source_agent_id"]])
+        target = await _run_agent_cli(["get", delegated["agent_id"]])
+        if not source.get("active"):
+            raise AgentApiError(f'Agent "{source["id"]}" is inactive', 403)
+        if not target.get("active"):
+            raise AgentApiError(f'Agent "{target["id"]}" is inactive', 403)
+        return await query_sync(_DelegatedRequest(delegated, request.headers))
+    except Exception as error:
+        return _agent_error_response(error)
+
+
+async def _require_active_query_agent(body: dict) -> None:
+    if body.get("agent_id") is None:
+        return
+    agent_id = _validate_agent_id(body["agent_id"])
+    agent = await _run_agent_cli(["get", agent_id])
+    if not agent.get("active"):
+        raise AgentApiError(f'Agent "{agent_id}" is inactive', 403)
+
+
+# ---------------------------------------------------------------------------
 # Query — streaming NDJSON (forwards engine events in real-time)
 # ---------------------------------------------------------------------------
 
@@ -127,6 +385,15 @@ async def query_stream(request: web.Request) -> web.StreamResponse:
 
     user_id = body.get("user_id", "api-anonymous")
     timeout = body.get("timeout", DEFAULT_TIMEOUT)
+
+    denied = _query_agent_auth_error(request, body)
+    if denied is not None:
+        return denied
+
+    try:
+        await _require_active_query_agent(body)
+    except Exception as error:
+        return _agent_error_response(error)
 
     cmd = _build_cmd(body)
     env = _build_env(body)
@@ -213,6 +480,15 @@ async def query_sync(request: web.Request) -> web.Response:
 
     user_id = body.get("user_id", "api-anonymous")
     timeout = body.get("timeout", DEFAULT_TIMEOUT)
+
+    denied = _query_agent_auth_error(request, body)
+    if denied is not None:
+        return denied
+
+    try:
+        await _require_active_query_agent(body)
+    except Exception as error:
+        return _agent_error_response(error)
 
     cmd = _build_cmd(body)
     env = _build_env(body)
@@ -465,6 +741,13 @@ def _build_cmd(body: dict) -> list[str]:
     if user_id:
         cmd.extend(["--user", user_id])
 
+    agent_id = body.get("agent_id")
+    if agent_id is not None:
+        cmd.extend(["--agent", _validate_agent_id(agent_id)])
+
+    if body.get("_delegated") is True:
+        cmd.append("--delegated")
+
     system_prompt = body.get("system_prompt")
     if system_prompt:
         cmd.extend(["--system-prompt", system_prompt])
@@ -519,6 +802,11 @@ def create_app() -> web.Application:
     app.router.add_get("/api/skills", list_skills)
     app.router.add_post("/api/query", query_stream)
     app.router.add_post("/api/query/sync", query_sync)
+    app.router.add_get("/api/agents", agents_list)
+    app.router.add_post("/api/agents", agents_create)
+    app.router.add_post("/api/agents/delegate", agents_delegate)
+    app.router.add_get("/api/agents/{agent_id}", agents_get)
+    app.router.add_patch("/api/agents/{agent_id}", agents_patch)
 
     app["highlights_manager"] = HighlightsJobManager(
         jobs_root=os.environ.get("HIGHLIGHTS_JOBS_ROOT", "/data/highlights-jobs"),

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -21,20 +21,42 @@
  * ---
  * name: The Analyst
  * skills: [kalshi, polymarket, nfl, nba, football]
+ * active: true
  * ---
  * ## Directives
  * ...
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import lockfile from "proper-lockfile";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const AGENTS_DIR = join(homedir(), ".sportsclaw", "agents");
+const DEFAULT_AGENTS_DIR = join(homedir(), ".sportsclaw", "agents");
+const AGENT_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_AGENT_ID_LENGTH = 64;
+const MAX_AGENT_NAME_LENGTH = 80;
+const MAX_AGENT_TITLE_LENGTH = 120;
+const MAX_AGENT_BODY_LENGTH = 100_000;
+const MAX_AGENT_LIST_LENGTH = 64;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -45,6 +67,8 @@ export interface AgentDef {
   id: string;
   /** Display name (from frontmatter) */
   name: string;
+  /** Optional display title (from frontmatter). Empty when omitted. */
+  title: string;
   /** Skills this agent can use. Empty = all skills (no filter). */
   skills: string[];
   /**
@@ -55,6 +79,27 @@ export interface AgentDef {
   tags: string[];
   /** The full markdown body (directives + voice), injected into system prompt */
   body: string;
+  /** Inactive agents remain on disk but cannot be selected or routed. */
+  active: boolean;
+  /** Built-ins are reserved and cannot be modified or inactivated. */
+  builtin: boolean;
+}
+
+export interface CreateAgentInput {
+  id: string;
+  name: string;
+  title?: string;
+  body: string;
+  skills?: string[];
+  tags?: string[];
+}
+
+export interface UpdateAgentInput {
+  name?: string;
+  title?: string;
+  body?: string;
+  skills?: string[];
+  tags?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -68,10 +113,20 @@ export interface AgentDef {
  * (name: string, skills: [list]) to parse with regex.
  */
 function parseAgentFile(id: string, raw: string): AgentDef {
+  validateAgentId(id);
   const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!fmMatch) {
     // No frontmatter — treat entire file as body
-    return { id, name: id, skills: [], tags: [], body: raw.trim() };
+    return {
+      id,
+      name: id,
+      title: "",
+      skills: [],
+      tags: [],
+      body: validateBody(raw),
+      active: true,
+      builtin: isBuiltinAgent(id),
+    };
   }
 
   const frontmatter = fmMatch[1];
@@ -79,7 +134,11 @@ function parseAgentFile(id: string, raw: string): AgentDef {
 
   // Parse name
   const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
-  const name = nameMatch ? nameMatch[1].trim() : id;
+  const name = validateName(nameMatch ? nameMatch[1].trim() : id);
+
+  // Parse optional title. Legacy files without it normalize to an empty title.
+  const titleMatch = frontmatter.match(/^title:\s*(.*)$/m);
+  const title = validateTitle(titleMatch ? titleMatch[1].trim() : "");
 
   // Parse a YAML list field (inline `[a, b, c]` or block `\n  - a\n  - b`)
   const parseList = (key: string): string[] => {
@@ -97,10 +156,24 @@ function parseAgentFile(id: string, raw: string): AgentDef {
     return [];
   };
 
-  const skills = parseList("skills");
-  const tags = parseList("tags");
+  const skills = validateSlugList(parseList("skills"), "skills");
+  const tags = validateSlugList(parseList("tags"), "tags");
+  const activeLine = frontmatter.match(/^active:\s*(.+)$/m);
+  if (activeLine && activeLine[1] !== "true" && activeLine[1] !== "false") {
+    throw new Error('Invalid agent active status: expected "true" or "false"');
+  }
+  const active = activeLine?.[1] !== "false";
 
-  return { id, name, skills, tags, body };
+  return {
+    id,
+    name,
+    title,
+    skills,
+    tags,
+    body: validateBody(body),
+    active,
+    builtin: isBuiltinAgent(id),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -108,54 +181,198 @@ function parseAgentFile(id: string, raw: string): AgentDef {
 // ---------------------------------------------------------------------------
 
 /** Ensure the agents directory exists */
-function ensureAgentsDir(): void {
-  if (!existsSync(AGENTS_DIR)) {
-    mkdirSync(AGENTS_DIR, { recursive: true });
+function agentsDir(): string {
+  return process.env.SPORTSCLAW_AGENTS_DIR || DEFAULT_AGENTS_DIR;
+}
+
+function ensureAgentsDir(): string {
+  const dir = agentsDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  if (!lstatSync(dir).isDirectory()) {
+    throw new Error("Agents path must be a real directory");
+  }
+  return dir;
+}
+
+function validateAgentId(id: unknown): string {
+  if (
+    typeof id !== "string" ||
+    id.length === 0 ||
+    id.length > MAX_AGENT_ID_LENGTH ||
+    !AGENT_ID_PATTERN.test(id)
+  ) {
+    throw new Error(
+      "Invalid agent id: expected a lowercase slug using letters, numbers, and single hyphens"
+    );
+  }
+  return id;
+}
+
+function validateName(name: unknown): string {
+  if (
+    typeof name !== "string" ||
+    name.length === 0 ||
+    name.length > MAX_AGENT_NAME_LENGTH ||
+    name !== name.trim() ||
+    /[\u0000-\u001f\u007f]/.test(name)
+  ) {
+    throw new Error(`Invalid agent name: expected 1-${MAX_AGENT_NAME_LENGTH} printable characters`);
+  }
+  return name;
+}
+
+function validateTitle(title: unknown): string {
+  if (
+    typeof title !== "string" ||
+    title.length > MAX_AGENT_TITLE_LENGTH ||
+    title !== title.trim() ||
+    /[\u0000-\u001f\u007f]/.test(title)
+  ) {
+    throw new Error(`Invalid agent title: expected at most ${MAX_AGENT_TITLE_LENGTH} printable characters`);
+  }
+  return title;
+}
+
+function validateBody(body: unknown): string {
+  if (
+    typeof body !== "string" ||
+    body.trim().length === 0 ||
+    body.length > MAX_AGENT_BODY_LENGTH ||
+    body.includes("\0")
+  ) {
+    throw new Error(`Invalid agent body: expected 1-${MAX_AGENT_BODY_LENGTH} characters`);
+  }
+  return body.trim();
+}
+
+function validateSlugList(value: unknown, field: "skills" | "tags"): string[] {
+  if (!Array.isArray(value) || value.length > MAX_AGENT_LIST_LENGTH) {
+    throw new Error(`Invalid agent ${field}: expected an array of at most ${MAX_AGENT_LIST_LENGTH} slugs`);
+  }
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string" || item.length > MAX_AGENT_ID_LENGTH || !AGENT_ID_PATTERN.test(item)) {
+      throw new Error(`Invalid agent ${field}: every value must be a lowercase slug`);
+    }
+    if (seen.has(item)) {
+      throw new Error(`Invalid agent ${field}: duplicate value "${item}"`);
+    }
+    seen.add(item);
+    result.push(item);
+  }
+  return result;
+}
+
+function agentPath(id: string): string {
+  return join(ensureAgentsDir(), `${validateAgentId(id)}.md`);
+}
+
+function assertRegularAgentFile(path: string): void {
+  if (existsSync(path) && !lstatSync(path).isFile()) {
+    throw new Error("Agent definition must be a regular file");
+  }
+}
+
+function readAgentContents(path: string): string {
+  assertRegularAgentFile(path);
+  const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    if (!fstatSync(fd).isFile()) throw new Error("Agent definition must be a regular file");
+    return readFileSync(fd, "utf-8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function withAgentLock<T>(path: string, operation: () => T): T {
+  const release = lockfile.lockSync(path, {
+    realpath: false,
+  });
+  try {
+    return operation();
+  } finally {
+    release();
+  }
+}
+
+function serializeAgent(agent: Pick<AgentDef, "name" | "title" | "skills" | "tags" | "body" | "active">): string {
+  return [
+    "---",
+    `name: ${agent.name}`,
+    `title: ${agent.title}`,
+    `skills: [${agent.skills.join(", ")}]`,
+    `tags: [${agent.tags.join(", ")}]`,
+    `active: ${agent.active}`,
+    "---",
+    "",
+    agent.body,
+    "",
+  ].join("\n");
+}
+
+function writeAgentAtomic(path: string, content: string, createOnly = false): void {
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  try {
+    writeFileSync(tmp, content, { encoding: "utf-8", flag: "wx", mode: 0o600 });
+    if (createOnly) {
+      linkSync(tmp, path);
+      unlinkSync(tmp);
+    } else {
+      renameSync(tmp, path);
+    }
+  } catch (error) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // The temp file may already have been linked and removed.
+    }
+    throw error;
   }
 }
 
 /** Load all agent definitions from disk */
 export function loadAgents(): AgentDef[] {
-  ensureAgentsDir();
-  const agents: AgentDef[] = [];
+  return listAgents();
+}
 
-  for (const file of readdirSync(AGENTS_DIR)) {
+/** List native agent definitions, excluding inactive agents by default. */
+export function listAgents(options?: { includeInactive?: boolean }): AgentDef[] {
+  const dir = ensureAgentsDir();
+  const agents: AgentDef[] = [];
+  for (const file of readdirSync(dir).sort()) {
     if (!file.endsWith(".md")) continue;
     const id = file.replace(/\.md$/, "");
+    if (!AGENT_ID_PATTERN.test(id)) continue;
     try {
-      const raw = readFileSync(join(AGENTS_DIR, file), "utf-8");
-      agents.push(parseAgentFile(id, raw));
+      const path = join(dir, file);
+      const agent = parseAgentFile(id, readAgentContents(path));
+      if (agent.active || options?.includeInactive) agents.push(agent);
     } catch {
-      // Skip unreadable files
+      // Skip unreadable or unsafe files during bulk listing.
     }
   }
-
   return agents;
 }
 
 /** Load a single agent by ID, or undefined if not found */
 export function loadAgent(id: string): AgentDef | undefined {
-  const filePath = join(AGENTS_DIR, `${id}.md`);
+  const filePath = agentPath(id);
   if (!existsSync(filePath)) return undefined;
-  try {
-    const raw = readFileSync(filePath, "utf-8");
-    return parseAgentFile(id, raw);
-  } catch {
-    return undefined;
-  }
+  const raw = readAgentContents(filePath);
+  return parseAgentFile(id, raw);
 }
 
 /** List agent IDs on disk */
 export function listAgentIds(): string[] {
-  ensureAgentsDir();
-  return readdirSync(AGENTS_DIR)
-    .filter((f) => f.endsWith(".md"))
-    .map((f) => f.replace(/\.md$/, ""));
+  return loadAgents().map((agent) => agent.id);
 }
 
 /** Get the agents directory path */
 export function getAgentsDir(): string {
-  return AGENTS_DIR;
+  return ensureAgentsDir();
 }
 
 // ---------------------------------------------------------------------------
@@ -254,6 +471,105 @@ Time-stamp major stories.
 `,
 };
 
+export function isBuiltinAgent(id: string): boolean {
+  return Object.hasOwn(BUILTIN_AGENTS, id);
+}
+
+export function createAgent(input: CreateAgentInput): AgentDef {
+  const id = validateAgentId(input?.id);
+  if (isBuiltinAgent(id)) {
+    throw new Error(`Agent "${id}" is a reserved built-in agent`);
+  }
+  const filePath = agentPath(id);
+  if (existsSync(filePath)) throw new Error(`Agent "${id}" already exists`);
+
+  const agent: AgentDef = {
+    id,
+    name: validateName(input?.name),
+    title: validateTitle(input?.title ?? ""),
+    skills: validateSlugList(input?.skills ?? [], "skills"),
+    tags: validateSlugList(input?.tags ?? [], "tags"),
+    body: validateBody(input?.body),
+    active: true,
+    builtin: false,
+  };
+  try {
+    writeAgentAtomic(filePath, serializeAgent(agent), true);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(`Agent "${id}" already exists`);
+    }
+    throw error;
+  }
+  return agent;
+}
+
+export function updateAgent(id: string, updates: UpdateAgentInput): AgentDef {
+  validateAgentId(id);
+  if (isBuiltinAgent(id)) throw new Error(`Built-in agent "${id}" cannot be modified`);
+  if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
+    throw new Error("Agent updates must be an object");
+  }
+  const allowed = new Set(["name", "title", "body", "skills", "tags"]);
+  const keys = Object.keys(updates);
+  if (keys.length === 0 || keys.some((key) => !allowed.has(key))) {
+    throw new Error("Agent updates may contain only name, title, body, skills, and tags");
+  }
+  const filePath = agentPath(id);
+  if (!existsSync(filePath)) throw new Error(`Agent "${id}" not found`);
+  return withAgentLock(filePath, () => {
+    const current = parseAgentFile(id, readAgentContents(filePath));
+    const agent: AgentDef = {
+      ...current,
+      ...(updates.name !== undefined ? { name: validateName(updates.name) } : {}),
+      ...(updates.title !== undefined ? { title: validateTitle(updates.title) } : {}),
+      ...(updates.body !== undefined ? { body: validateBody(updates.body) } : {}),
+      ...(updates.skills !== undefined ? { skills: validateSlugList(updates.skills, "skills") } : {}),
+      ...(updates.tags !== undefined ? { tags: validateSlugList(updates.tags, "tags") } : {}),
+    };
+    writeAgentAtomic(filePath, serializeAgent(agent));
+    return agent;
+  });
+}
+
+export function inactivateAgent(id: string): AgentDef {
+  validateAgentId(id);
+  if (isBuiltinAgent(id)) throw new Error(`Built-in agent "${id}" cannot be inactivated`);
+  const filePath = agentPath(id);
+  if (!existsSync(filePath)) throw new Error(`Agent "${id}" not found`);
+  return withAgentLock(filePath, () => {
+    const current = parseAgentFile(id, readAgentContents(filePath));
+    const agent = { ...current, active: false };
+    writeAgentAtomic(filePath, serializeAgent(agent));
+    return agent;
+  });
+}
+
+/** Resolve one caller-selected active agent without falling back to routing. */
+export function selectExplicitAgents(agents: AgentDef[], agentIds: readonly string[]): AgentDef[] {
+  if (agentIds.length !== 1) throw new Error("Explicit agent selection requires exactly one agent id");
+  const id = validateAgentId(agentIds[0]);
+  const agent = agents.find((candidate) => candidate.id === id);
+  if (!agent) throw new Error(`Agent "${id}" not found`);
+  if (!agent.active) throw new Error(`Agent "${id}" is inactive`);
+  return [agent];
+}
+
+/** Restrict skill-owned tools while preserving safe engine and MCP tools. */
+export function filterToolNamesForAgent(
+  agent: AgentDef,
+  allToolNames: readonly string[],
+  getSkillName: (toolName: string) => string | undefined,
+): string[] | undefined {
+  if (agent.skills.length === 0) return undefined;
+  const skills = new Set(agent.skills);
+  return allToolNames.filter((name) => {
+    if (name.startsWith("mcp__")) return true;
+    const skill = getSkillName(name);
+    return skill === undefined || skills.has(skill);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Bootstrap
 // ---------------------------------------------------------------------------
@@ -264,14 +580,20 @@ Time-stamp major stories.
  * Returns the number of agents bootstrapped.
  */
 export function bootstrapDefaultAgents(): number {
-  ensureAgentsDir();
+  const dir = ensureAgentsDir();
   let count = 0;
 
   for (const [id, content] of Object.entries(BUILTIN_AGENTS)) {
-    const filePath = join(AGENTS_DIR, `${id}.md`);
+    const filePath = join(dir, `${id}.md`);
     if (!existsSync(filePath)) {
-      writeFileSync(filePath, content, "utf-8");
-      count++;
+      try {
+        writeAgentAtomic(filePath, content, true);
+        count++;
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "EEXIST")) {
+          throw error;
+        }
+      }
     }
   }
 
@@ -280,7 +602,6 @@ export function bootstrapDefaultAgents(): number {
 
 /** Check if default agents need bootstrapping */
 export function needsAgentBootstrap(): boolean {
-  ensureAgentsDir();
-  const existing = readdirSync(AGENTS_DIR).filter((f) => f.endsWith(".md"));
-  return existing.length === 0;
+  const dir = ensureAgentsDir();
+  return Object.keys(BUILTIN_AGENTS).some((id) => !existsSync(join(dir, `${id}.md`)));
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -54,7 +54,12 @@ import {
   providerToolCeiling,
   resolveParallelAgentRoutedTools,
 } from "./routing/tool-activation.js";
-import { loadAgents, type AgentDef } from "./agents.js";
+import {
+  filterToolNamesForAgent,
+  listAgents,
+  selectExplicitAgents,
+  type AgentDef,
+} from "./agents.js";
 import { McpManager, summarizeMcpServers } from "./mcp.js";
 import { loadSkillGuides } from "./skill-guides.js";
 import type { SkillGuide } from "./types.js";
@@ -401,6 +406,19 @@ export class SessionStore {
 /** Global session store — shared across all engine instances. */
 export const sessionStore = new SessionStore();
 
+/** Keep one platform session from crossing native-agent boundaries. */
+export function scopeSessionId(sessionId: string, agentId?: string): string {
+  return agentId ? `${sessionId}::agent::${agentId}` : sessionId;
+}
+
+export function conversationNamespace(
+  userId?: string,
+  agentId?: string,
+  sessionId?: string,
+): string {
+  return [userId ?? "anonymous", agentId ?? "auto", sessionId ?? "no-session"].join("::");
+}
+
 // ---------------------------------------------------------------------------
 // Halt sentinel guard
 // ---------------------------------------------------------------------------
@@ -636,6 +654,7 @@ export class sportsclawEngine {
   private skillGuides: SkillGuide[] = [];
   private _mcpReady = false;
   private _threadLoaded = false;
+  private _conversationNamespace?: string;
   private _loggedMemoryBackend?: string;
   private _lastUsage: TokenUsage | null = null;
 
@@ -676,7 +695,7 @@ export class sportsclawEngine {
       ttlMs: this.config.cacheTtlMs,
     });
     this.loadDynamicSchemas();
-    this.agents = loadAgents();
+    this.agents = listAgents({ includeInactive: true });
     this.mcpManager = new McpManager(
       this.config.verbose,
       process.argv.includes("--refresh-mcp")
@@ -886,13 +905,7 @@ export class sportsclawEngine {
   }
 
   private filterToolsForAgent(agent: AgentDef, allToolNames: string[]): string[] | undefined {
-    if (agent.skills.length === 0) return undefined;
-    const agentSkillSet = new Set(agent.skills);
-    return allToolNames.filter((name) => {
-      if (name.startsWith("mcp__")) return true;
-      const skill = this.registry.getSkillName(name);
-      return skill !== undefined ? agentSkillSet.has(skill) : true;
-    });
+    return filterToolNamesForAgent(agent, allToolNames, (name) => this.registry.getSkillName(name));
   }
 
   private isLowSignalResponse(text: string): boolean {
@@ -3419,6 +3432,25 @@ export class sportsclawEngine {
     this._generatedVideos = [];
     this._lastUsage = null;
 
+    this.agents = listAgents({ includeInactive: true });
+    const explicitAgents = options?.agentIds
+      ? selectExplicitAgents(this.agents, options.agentIds)
+      : undefined;
+    const nativeAgentId = explicitAgents?.[0]?.id;
+    const activeConversationNamespace = conversationNamespace(
+      options?.userId,
+      nativeAgentId,
+      options?.sessionId,
+    );
+    if (
+      this._conversationNamespace &&
+      this._conversationNamespace !== activeConversationNamespace
+    ) {
+      this.messages = [];
+      this._threadLoaded = false;
+    }
+    this._conversationNamespace = activeConversationNamespace;
+
     // --- Security: Sanitize input FIRST ---
     const sanitization = sanitizeInput(userPrompt);
     const sanitizedPrompt = sanitization.sanitized;
@@ -3470,7 +3502,9 @@ export class sportsclawEngine {
     }
 
     // --- Session: restore prior conversation history ---
-    const sessionId = options?.sessionId;
+    const sessionId = options?.sessionId
+      ? scopeSessionId(options.sessionId, nativeAgentId)
+      : undefined;
     if (sessionId) {
       const prior = await sessionStore.load(sessionId);
       if (prior.length > 0) {
@@ -3522,7 +3556,7 @@ export class sportsclawEngine {
         this._loggedMemoryBackend = memoryLogKey;
       }
 
-      memory = new MemoryManager(options.userId, podStorage);
+      memory = new MemoryManager(options.userId, podStorage, nativeAgentId);
       options?.onProgress?.({ type: "phase", label: "Loading memory" });
       [memoryBlock, strategyContent] = await Promise.all([
         memory.buildMemoryBlock(),
@@ -3628,6 +3662,10 @@ export class sportsclawEngine {
       options?.platform,
       options?.chatId,
     );
+    if ((options?.delegationDepth ?? 0) > 0) {
+      delete tools.spawn_subagent;
+      delete tools.list_subagents;
+    }
     emitProgress?.({ type: "phase", label: "Routing to skills" });
     const routing = await this.resolveActiveToolsForPrompt(
       sanitizedPrompt,
@@ -3652,7 +3690,7 @@ export class sportsclawEngine {
       }
     }
 
-    const activeTools = finalizeActiveTools({
+    let activeTools = finalizeActiveTools({
       routedActiveTools: routing.activeTools,
       isFollowUp,
       lowConfidence: Boolean(
@@ -3670,8 +3708,33 @@ export class sportsclawEngine {
     // skill-overlap fallback which biases toward broad-skill generalists.
     const intentTags: string[] = [];
     if (isVisualIntent(sanitizedPrompt)) intentTags.push("visual");
-    const agentRoutes = routeToAgents(this.agents, selectedSkills, sanitizedPrompt, intentTags);
+    const agentRoutes = explicitAgents
+      ? explicitAgents.map((agent) => ({
+          agent,
+          score: 1,
+          reason: "Explicit native agent selection.",
+        }))
+      : routeToAgents(
+          this.agents.filter((agent) => agent.active),
+          selectedSkills,
+          sanitizedPrompt,
+          intentTags,
+        );
     const activeAgents = agentRoutes.map((r) => r.agent);
+
+    if (explicitAgents) {
+      const constrained = this.filterToolsForAgent(explicitAgents[0], Object.keys(tools));
+      if (constrained !== undefined) {
+        activeTools = finalizeActiveTools({
+          routedActiveTools: constrained,
+          isFollowUp,
+          lowConfidence: false,
+          historyToolNames: Array.from(historyToolNames),
+          totalToolCount: Object.keys(tools).length,
+          ceiling: providerToolCeiling(this.config.provider),
+        });
+      }
+    }
 
     if (this.config.verbose && routing.decision) {
       const d = routing.decision;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { execFile, execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 import { Transform, type TransformCallback } from "node:stream";
@@ -93,7 +94,11 @@ import {
 import {
   bootstrapDefaultAgents,
   needsAgentBootstrap,
-  loadAgents,
+  loadAgent,
+  listAgents,
+  createAgent,
+  updateAgent,
+  inactivateAgent,
   getAgentsDir,
 } from "./agents.js";
 import {
@@ -181,11 +186,15 @@ export type { PythonVersionResult, PrerequisiteStatus, EnsureVenvResult } from "
 export {
   loadAgents,
   loadAgent,
+  listAgents,
   listAgentIds,
+  createAgent,
+  updateAgent,
+  inactivateAgent,
   bootstrapDefaultAgents,
   getAgentsDir,
 } from "./agents.js";
-export type { AgentDef } from "./agents.js";
+export type { AgentDef, CreateAgentInput, UpdateAgentInput } from "./agents.js";
 export {
   loadConfig,
   saveConfig,
@@ -2175,6 +2184,7 @@ async function cmdQuery(args: string[]): Promise<void> {
   }
   const forceJson = args.includes("--json");
   const yoloMode = args.includes("--yolo");
+  const delegated = args.includes("--delegated");
   const explicitFormat = args.find((a) => a.startsWith("--format="))?.split("=")[1];
   const formatArg = explicitFormat ?? (forcePipe || forceJson ? "markdown" : "cli");
 
@@ -2194,9 +2204,19 @@ async function cmdQuery(args: string[]): Promise<void> {
     args.splice(systemPromptIdx, 2);
   }
 
+  const agentIds: string[] = [];
+  while (args.includes("--agent")) {
+    const agentIdx = args.indexOf("--agent");
+    if (agentIdx + 1 >= args.length || args[agentIdx + 1].startsWith("--")) {
+      throw new Error("--agent requires an agent id");
+    }
+    agentIds.push(args[agentIdx + 1]);
+    args.splice(agentIdx, 2);
+  }
+
   const filteredArgs = args.filter((a) =>
     a !== "--verbose" && a !== "-v" && a !== "--pipe" &&
-    a !== "--json" && a !== "--yolo" && !a.startsWith("--format=")
+    a !== "--json" && a !== "--yolo" && a !== "--delegated" && !a.startsWith("--format=")
   );
   const prompt = filteredArgs.join(" ");
 
@@ -2256,6 +2276,8 @@ async function cmdQuery(args: string[]): Promise<void> {
       }
       const result = await engine.run(prompt, {
         userId,
+        ...(agentIds.length > 0 ? { agentIds } : {}),
+        ...(delegated ? { delegationDepth: 1 as const } : {}),
         systemPrompt,
         ...(inboundImages && { images: inboundImages }),
         onProgress: (event) => emitNdjson({ ...event, category: "progress" }),
@@ -2287,7 +2309,11 @@ async function cmdQuery(args: string[]): Promise<void> {
   } else if (verbose) {
     // Verbose mode: no spinner, raw console.error logs
     try {
-      const result = await engine.run(prompt, { systemPrompt });
+      const result = await engine.run(prompt, {
+        systemPrompt,
+        ...(agentIds.length > 0 ? { agentIds } : {}),
+        ...(delegated ? { delegationDepth: 1 as const } : {}),
+      });
       console.log(renderMarkdown(result));
       await saveGeneratedImages(engine);
       await saveGeneratedVideos(engine);
@@ -2313,6 +2339,8 @@ async function cmdQuery(args: string[]): Promise<void> {
     try {
       const result = await engine.run(prompt, {
         systemPrompt,
+        ...(agentIds.length > 0 ? { agentIds } : {}),
+        ...(delegated ? { delegationDepth: 1 as const } : {}),
         onProgress: tracker.handler,
         abortSignal: cancel.abortSignal,
       });
@@ -2820,6 +2848,7 @@ function printHelp(): void {
   console.log("  --yolo           Bypass all Y/n approval prompts (autonomous execution)");
   console.log("  --json           Force headless NDJSON output (no spinners/clack)");
   console.log("  --pipe           Alias for --json (legacy)");
+  console.log("  --agent <id>     Select exactly one active native agent");
   console.log("  --help, -h       Show this help message");
   console.log("");
   console.log("Configuration:");
@@ -2868,11 +2897,51 @@ async function cmdChannels(_opts?: { fromChat?: boolean }): Promise<void> {
 // CLI: `sportsclaw agents` — list installed agents
 // ---------------------------------------------------------------------------
 
-function cmdAgents(_opts?: { fromChat?: boolean }): void {
+function readAgentInput(): Record<string, unknown> {
+  const raw = readFileSync(0, "utf-8");
+  if (!raw.trim()) throw new Error("Agent JSON input is required on stdin");
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Agent JSON input must be an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function cmdAgents(args: string[] = []): void {
   if (needsAgentBootstrap()) {
     bootstrapDefaultAgents();
   }
-  const agents = loadAgents();
+  const json = args.includes("--json");
+  const command = args.find((arg) => !arg.startsWith("--"));
+  const commandIndex = command ? args.indexOf(command) : -1;
+  const id = commandIndex >= 0 ? args.slice(commandIndex + 1).find((arg) => !arg.startsWith("--")) : undefined;
+
+  let result: unknown;
+  if (command === "get") {
+    if (!id) throw new Error("agents get requires an agent id");
+    const agent = loadAgent(id);
+    if (!agent) throw new Error(`Agent "${id}" not found`);
+    result = agent;
+  } else if (command === "create") {
+    result = createAgent(readAgentInput() as unknown as Parameters<typeof createAgent>[0]);
+  } else if (command === "update") {
+    if (!id) throw new Error("agents update requires an agent id");
+    result = updateAgent(id, readAgentInput() as Parameters<typeof updateAgent>[1]);
+  } else if (command === "inactivate") {
+    if (!id) throw new Error("agents inactivate requires an agent id");
+    result = inactivateAgent(id);
+  } else if (command && command !== "list") {
+    throw new Error(`Unknown agents command: ${command}`);
+  } else {
+    result = listAgents({ includeInactive: args.includes("--all") });
+  }
+
+  if (json) {
+    console.log(JSON.stringify({ status: true, data: result }));
+    return;
+  }
+
+  const agents = Array.isArray(result) ? result : [result];
   if (agents.length === 0) {
     console.log("No agents installed.");
     console.log(`Create agent files in: ${getAgentsDir()}/`);
@@ -3033,7 +3102,7 @@ async function main(): Promise<void> {
     case "openshell":
       return cmdOpenshell(subArgs);
     case "agents":
-      return cmdAgents();
+      return cmdAgents(subArgs);
     case "analytics":
       return cmdAnalytics(subArgs);
     
@@ -3070,5 +3139,8 @@ try {
 }
 
 if (isMain) {
-  main();
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -20,6 +20,7 @@
 import { mkdir, readFile, writeFile, appendFile, readdir, rename } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 import type { McpManager } from "./mcp.js";
 
 // ---------------------------------------------------------------------------
@@ -77,11 +78,11 @@ export interface ThreadMessage {
 // ---------------------------------------------------------------------------
 
 export interface MemoryStorage {
-  read(userId: string, file: string): Promise<string>;
-  write(userId: string, file: string, content: string): Promise<void>;
-  append(userId: string, file: string, content: string): Promise<void>;
-  list(userId: string, pattern: string): Promise<string[]>;
-  remove(userId: string, file: string): Promise<void>;
+  read(userId: string, file: string, agentId?: string): Promise<string>;
+  write(userId: string, file: string, content: string, agentId?: string): Promise<void>;
+  append(userId: string, file: string, content: string, agentId?: string): Promise<void>;
+  list(userId: string, pattern: string, agentId?: string): Promise<string[]>;
+  remove(userId: string, file: string, agentId?: string): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -128,12 +129,13 @@ export class FileMemoryStorage implements MemoryStorage {
     this.base = base;
   }
 
-  private userDir(userId: string): string {
-    return join(this.base, sanitizeId(userId));
+  private userDir(userId: string, agentId?: string): string {
+    const userDir = join(this.base, sanitizeId(userId));
+    return agentId ? join(userDir, "agents", sanitizeId(agentId)) : userDir;
   }
 
-  private async ensureDir(userId: string): Promise<string> {
-    const dir = this.userDir(userId);
+  private async ensureDir(userId: string, agentId?: string): Promise<string> {
+    const dir = this.userDir(userId, agentId);
     if (!this.dirCache.has(dir)) {
       await mkdir(dir, { recursive: true });
       this.dirCache.add(dir);
@@ -141,13 +143,13 @@ export class FileMemoryStorage implements MemoryStorage {
     return dir;
   }
 
-  async read(userId: string, file: string): Promise<string> {
-    const dir = await this.ensureDir(userId);
+  async read(userId: string, file: string, agentId?: string): Promise<string> {
+    const dir = await this.ensureDir(userId, agentId);
     return safeRead(join(dir, file));
   }
 
-  async write(userId: string, file: string, content: string): Promise<void> {
-    const dir = await this.ensureDir(userId);
+  async write(userId: string, file: string, content: string, agentId?: string): Promise<void> {
+    const dir = await this.ensureDir(userId, agentId);
     const path = join(dir, file);
     // Atomic write: temp + rename so a crash mid-write never tears the file.
     const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
@@ -155,13 +157,13 @@ export class FileMemoryStorage implements MemoryStorage {
     await rename(tmp, path);
   }
 
-  async append(userId: string, file: string, content: string): Promise<void> {
-    const dir = await this.ensureDir(userId);
+  async append(userId: string, file: string, content: string, agentId?: string): Promise<void> {
+    const dir = await this.ensureDir(userId, agentId);
     await appendFile(join(dir, file), content, "utf-8");
   }
 
-  async list(userId: string, _pattern: string): Promise<string[]> {
-    const dir = await this.ensureDir(userId);
+  async list(userId: string, _pattern: string, agentId?: string): Promise<string[]> {
+    const dir = await this.ensureDir(userId, agentId);
     try {
       const files = await readdir(dir);
       return files
@@ -172,8 +174,8 @@ export class FileMemoryStorage implements MemoryStorage {
     }
   }
 
-  async remove(userId: string, file: string): Promise<void> {
-    const dir = this.userDir(userId);
+  async remove(userId: string, file: string, agentId?: string): Promise<void> {
+    const dir = this.userDir(userId, agentId);
     const { unlink } = await import("node:fs/promises");
     try {
       await unlink(join(dir, file));
@@ -183,8 +185,8 @@ export class FileMemoryStorage implements MemoryStorage {
   }
 
   /** Absolute path to a user's memory directory */
-  getUserDir(userId: string): string {
-    return this.userDir(userId);
+  getUserDir(userId: string, agentId?: string): string {
+    return this.userDir(userId, agentId);
   }
 }
 
@@ -244,15 +246,26 @@ export class PodMemoryStorage implements MemoryStorage {
    * Includes auto-migration from old multi-doc layout on first access.
    * Concurrent calls share one in-flight promise to prevent duplicate-doc creation.
    */
-  private loadCached(userId: string): Promise<MemoryEntry> {
-    const cached = this.cache.get(userId);
+  private namespaceKey(userId: string, agentId?: string): string {
+    return agentId ? `${userId}::agent::${agentId}` : userId;
+  }
+
+  private documentName(userId: string, agentId?: string): string {
+    if (!agentId) return `memory-${userId}`;
+    const userHash = createHash("sha256").update(userId).digest("hex").slice(0, 32);
+    return `memory-agent-${userHash}-${sanitizeId(agentId)}`;
+  }
+
+  private loadCached(userId: string, agentId?: string): Promise<MemoryEntry> {
+    const key = this.namespaceKey(userId, agentId);
+    const cached = this.cache.get(key);
     if (cached) return cached;
-    const promise = this.loadFromPod(userId);
-    this.cache.set(userId, promise);
+    const promise = this.loadFromPod(userId, agentId);
+    this.cache.set(key, promise);
     return promise;
   }
 
-  private async loadFromPod(userId: string): Promise<MemoryEntry> {
+  private async loadFromPod(userId: string, agentId?: string): Promise<MemoryEntry> {
     // Search for the most-recently-updated consolidated doc with a non-empty
     // value. This handles two failure modes from earlier engine versions:
     //   (1) zombie empty docs from prior race-condition migrations, and
@@ -261,7 +274,7 @@ export class PodMemoryStorage implements MemoryStorage {
     // hit is empty, we fall back to the freshest empty hit (still better than
     // re-creating).
     const result = await this.callPod("search_documents", {
-      filters: { name: `memory-${userId}` },
+      filters: { name: this.documentName(userId, agentId) },
       fields: ["_id", "value", "content", "updated"],
       sorters: [["updated", -1]],
       page_size: 10,
@@ -283,7 +296,9 @@ export class PodMemoryStorage implements MemoryStorage {
     }
 
     // No consolidated doc anywhere — attempt migration from old multi-doc layout
-    const migrated = await this.migrateOldDocs(userId);
+    const migrated = agentId
+      ? { doc: {}, docId: null }
+      : await this.migrateOldDocs(userId);
     return { doc: migrated.doc, docId: migrated.docId, dirty: false };
   }
 
@@ -375,9 +390,9 @@ export class PodMemoryStorage implements MemoryStorage {
     return { doc, docId };
   }
 
-  async read(userId: string, file: string): Promise<string> {
+  async read(userId: string, file: string, agentId?: string): Promise<string> {
     try {
-      const { doc } = await this.loadCached(userId);
+      const { doc } = await this.loadCached(userId, agentId);
       const { field, date } = fileToField(file);
 
       if (field === "today" && date) {
@@ -392,9 +407,9 @@ export class PodMemoryStorage implements MemoryStorage {
     }
   }
 
-  async write(userId: string, file: string, content: string): Promise<void> {
+  async write(userId: string, file: string, content: string, agentId?: string): Promise<void> {
     try {
-      const entry = await this.loadCached(userId);
+      const entry = await this.loadCached(userId, agentId);
       const { field, date } = fileToField(file);
 
       if (field === "today" && date) {
@@ -412,38 +427,39 @@ export class PodMemoryStorage implements MemoryStorage {
       }
 
       entry.dirty = true;
-      await this.flush(userId);
+      await this.flush(userId, agentId);
     } catch {
       // Non-fatal
     }
   }
 
-  async append(userId: string, file: string, content: string): Promise<void> {
+  async append(userId: string, file: string, content: string, agentId?: string): Promise<void> {
     // Serialize concurrent appends per userId. read+write share a cached doc
     // that mutates synchronously, but the read→mutate→flush sequence isn't
     // atomic, so two concurrent appends would both read pre-mutation state
     // and the second write would overwrite the first. Queue them instead.
-    const previous = this.appendChain.get(userId) ?? Promise.resolve();
+    const key = this.namespaceKey(userId, agentId);
+    const previous = this.appendChain.get(key) ?? Promise.resolve();
     const next = previous
       .catch(() => {}) // existing append swallowed errors; preserve that
       .then(async () => {
-        const existing = await this.read(userId, file);
-        await this.write(userId, file, existing ? `${existing}\n${content}` : content);
+        const existing = await this.read(userId, file, agentId);
+        await this.write(userId, file, existing ? `${existing}\n${content}` : content, agentId);
       });
-    this.appendChain.set(userId, next);
+    this.appendChain.set(key, next);
     try {
       await next;
     } finally {
       // Drop the entry once we're the tail of the chain so the map doesn't grow.
-      if (this.appendChain.get(userId) === next) {
-        this.appendChain.delete(userId);
+      if (this.appendChain.get(key) === next) {
+        this.appendChain.delete(key);
       }
     }
   }
 
-  async list(userId: string, _pattern: string): Promise<string[]> {
+  async list(userId: string, _pattern: string, agentId?: string): Promise<string[]> {
     try {
-      const { doc } = await this.loadCached(userId);
+      const { doc } = await this.loadCached(userId, agentId);
       if (doc.today && doc.today_date) {
         return [`${doc.today_date}.md`];
       }
@@ -453,9 +469,9 @@ export class PodMemoryStorage implements MemoryStorage {
     }
   }
 
-  async remove(userId: string, file: string): Promise<void> {
+  async remove(userId: string, file: string, agentId?: string): Promise<void> {
     try {
-      const entry = await this.loadCached(userId);
+      const entry = await this.loadCached(userId, agentId);
       const { field } = fileToField(file);
 
       if (field === "today") {
@@ -466,15 +482,15 @@ export class PodMemoryStorage implements MemoryStorage {
       }
 
       entry.dirty = true;
-      await this.flush(userId);
+      await this.flush(userId, agentId);
     } catch {
       // Non-fatal
     }
   }
 
   /** Write cached doc back to pod if dirty. */
-  async flush(userId: string): Promise<void> {
-    const cachedPromise = this.cache.get(userId);
+  async flush(userId: string, agentId?: string): Promise<void> {
+    const cachedPromise = this.cache.get(this.namespaceKey(userId, agentId));
     if (!cachedPromise) return;
     const entry = await cachedPromise;
     if (!entry?.dirty) return;
@@ -487,9 +503,13 @@ export class PodMemoryStorage implements MemoryStorage {
         });
       } else {
         const result = await this.callPod("create_document", {
-          name: `memory-${userId}`,
+          name: this.documentName(userId, agentId),
           content: { value: entry.doc },
-          metadata: { type: "user-memory", user_id: userId },
+          metadata: {
+            type: "user-memory",
+            user_id: userId,
+            ...(agentId ? { agent_id: agentId } : {}),
+          },
         });
         entry.docId = result?.data?.data?._id ?? null;
       }
@@ -538,18 +558,21 @@ function timestamp(): string {
 export class MemoryManager {
   private storage: MemoryStorage;
   private userId: string;
+  private agentId?: string;
 
-  constructor(userId: string, storage?: MemoryStorage) {
+  constructor(userId: string, storage?: MemoryStorage, agentId?: string) {
     this.userId = userId;
     this.storage = storage ?? new FileMemoryStorage(MEMORY_BASE);
+    this.agentId = agentId;
   }
 
   /** Absolute path to the user's memory directory (only meaningful for file storage) */
   get memoryDir(): string {
     if (this.storage instanceof FileMemoryStorage) {
-      return this.storage.getUserDir(this.userId);
+      return this.storage.getUserDir(this.userId, this.agentId);
     }
-    return join(MEMORY_BASE, sanitizeId(this.userId));
+    const userDir = join(MEMORY_BASE, sanitizeId(this.userId));
+    return this.agentId ? join(userDir, "agents", sanitizeId(this.agentId)) : userDir;
   }
 
   // -------------------------------------------------------------------------
@@ -557,11 +580,11 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readContext(): Promise<string> {
-    return this.storage.read(this.userId, CONTEXT_FILE);
+    return this.storage.read(this.userId, CONTEXT_FILE, this.agentId);
   }
 
   async writeContext(content: string): Promise<void> {
-    await this.storage.write(this.userId, CONTEXT_FILE, content);
+    await this.storage.write(this.userId, CONTEXT_FILE, content, this.agentId);
   }
 
   // -------------------------------------------------------------------------
@@ -569,7 +592,7 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readTodayLog(): Promise<string> {
-    return this.storage.read(this.userId, `${todayStamp()}.md`);
+    return this.storage.read(this.userId, `${todayStamp()}.md`, this.agentId);
   }
 
   async appendExchange(userPrompt: string, assistantReply: string): Promise<void> {
@@ -585,13 +608,13 @@ export class MemoryManager {
       "",
     ].join("\n");
 
-    await this.storage.append(this.userId, `${todayStamp()}.md`, entry);
+    await this.storage.append(this.userId, `${todayStamp()}.md`, entry, this.agentId);
   }
 
   async appendNote(label: string, content: string): Promise<void> {
     const ts = timestamp();
     const entry = [`> **${label}** (${ts}): ${content}`, ""].join("\n");
-    await this.storage.append(this.userId, `${todayStamp()}.md`, entry);
+    await this.storage.append(this.userId, `${todayStamp()}.md`, entry, this.agentId);
   }
 
   // -------------------------------------------------------------------------
@@ -599,11 +622,11 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readSoul(): Promise<string> {
-    return this.storage.read(this.userId, SOUL_FILE);
+    return this.storage.read(this.userId, SOUL_FILE, this.agentId);
   }
 
   async writeSoul(content: string): Promise<void> {
-    await this.storage.write(this.userId, SOUL_FILE, content);
+    await this.storage.write(this.userId, SOUL_FILE, content, this.agentId);
   }
 
   parseSoulHeader(raw: string): SoulData {
@@ -637,7 +660,7 @@ export class MemoryManager {
 
     const header = `# Soul\nBorn: ${data.born}\nExchanges: ${data.exchanges}\n`;
     const content = data.rest ? `${header}\n${data.rest}\n` : header;
-    await this.storage.write(this.userId, SOUL_FILE, content);
+    await this.storage.write(this.userId, SOUL_FILE, content, this.agentId);
   }
 
   // -------------------------------------------------------------------------
@@ -645,11 +668,11 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readFanProfile(): Promise<string> {
-    return this.storage.read(this.userId, FAN_PROFILE_FILE);
+    return this.storage.read(this.userId, FAN_PROFILE_FILE, this.agentId);
   }
 
   async writeFanProfile(content: string): Promise<void> {
-    await this.storage.write(this.userId, FAN_PROFILE_FILE, content);
+    await this.storage.write(this.userId, FAN_PROFILE_FILE, content, this.agentId);
   }
 
   // -------------------------------------------------------------------------
@@ -657,11 +680,11 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readReflections(): Promise<string> {
-    return this.storage.read(this.userId, REFLECTIONS_FILE);
+    return this.storage.read(this.userId, REFLECTIONS_FILE, this.agentId);
   }
 
   async appendReflection(entry: string): Promise<void> {
-    await this.storage.append(this.userId, REFLECTIONS_FILE, entry + "\n");
+    await this.storage.append(this.userId, REFLECTIONS_FILE, entry + "\n", this.agentId);
   }
 
   // -------------------------------------------------------------------------
@@ -669,11 +692,11 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readStrategy(): Promise<string> {
-    return this.storage.read(this.userId, STRATEGY_FILE);
+    return this.storage.read(this.userId, STRATEGY_FILE, this.agentId);
   }
 
   async writeStrategy(content: string): Promise<void> {
-    await this.storage.write(this.userId, STRATEGY_FILE, content);
+    await this.storage.write(this.userId, STRATEGY_FILE, content, this.agentId);
   }
 
   // -------------------------------------------------------------------------
@@ -681,7 +704,7 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readThread(): Promise<ThreadMessage[]> {
-    const raw = await this.storage.read(this.userId, THREAD_FILE);
+    const raw = await this.storage.read(this.userId, THREAD_FILE, this.agentId);
     if (!raw) return [];
     try {
       return JSON.parse(raw);
@@ -692,7 +715,7 @@ export class MemoryManager {
 
   async writeThread(messages: ThreadMessage[]): Promise<void> {
     const capped = messages.slice(-MAX_THREAD_MESSAGES);
-    await this.storage.write(this.userId, THREAD_FILE, JSON.stringify(capped));
+    await this.storage.write(this.userId, THREAD_FILE, JSON.stringify(capped), this.agentId);
   }
 
   async appendToThread(userPrompt: string, assistantReply: string): Promise<void> {
@@ -710,15 +733,15 @@ export class MemoryManager {
   // -------------------------------------------------------------------------
 
   async readConsolidated(): Promise<string> {
-    return this.storage.read(this.userId, CONSOLIDATED_FILE);
+    return this.storage.read(this.userId, CONSOLIDATED_FILE, this.agentId);
   }
 
   async writeConsolidated(content: string): Promise<void> {
-    await this.storage.write(this.userId, CONSOLIDATED_FILE, content);
+    await this.storage.write(this.userId, CONSOLIDATED_FILE, content, this.agentId);
   }
 
   async listDailyLogs(): Promise<string[]> {
-    return this.storage.list(this.userId, "daily-log");
+    return this.storage.list(this.userId, "daily-log", this.agentId);
   }
 
   async getConsolidationCandidates(
@@ -738,7 +761,7 @@ export class MemoryManager {
       const dateStr = file.replace(".md", "");
       if (dateStr >= cutoffStamp || dateStr === today) continue;
 
-      const content = await this.storage.read(this.userId, file);
+      const content = await this.storage.read(this.userId, file, this.agentId);
       if (!content.trim()) continue;
 
       if (totalChars + content.length > MAX_CONSOLIDATION_INPUT_CHARS) break;
@@ -769,7 +792,7 @@ export class MemoryManager {
     await this.writeConsolidated(summary);
 
     for (const file of candidates.files) {
-      await this.storage.remove(this.userId, file);
+      await this.storage.remove(this.userId, file, this.agentId);
     }
 
     return candidates.files.length;

--- a/src/types.ts
+++ b/src/types.ts
@@ -511,6 +511,10 @@ export type ToolProgressEvent =
 export interface RunOptions {
   /** User or thread ID for memory isolation. If omitted, memory is disabled. */
   userId?: string;
+  /** Exactly one native agent ID to select explicitly for this run. */
+  agentIds?: string[];
+  /** Internal one-hop delegation marker. Delegated runs cannot spawn subagents. */
+  delegationDepth?: 0 | 1;
   /**
    * Session ID for multi-turn conversation continuity.
    * When provided, the engine loads prior message history from the global

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -152,6 +152,7 @@ describe("resolveConfig", () => {
 
       const resolved = runResolveConfigWithHome(home, {
         AZURE_FOUNDRY_BASE_URL: "https://example.openai.azure.com/openai/v1",
+        AZURE_FOUNDRY_API_KEY: "",
       });
 
       assert.strictEqual(resolved.provider, "azure-foundry");

--- a/test/native-agent-memory.test.mjs
+++ b/test/native-agent-memory.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+import { FileMemoryStorage, MemoryManager, PodMemoryStorage } from "../dist/memory.js";
+
+let dir;
+
+describe("native agent memory namespace", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sc-agent-memory-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("isolates soul and thread under userId/agents/agentId", async () => {
+    const storage = new FileMemoryStorage(dir);
+    const analyst = new MemoryManager("user-1", storage, "analyst");
+    const newsdesk = new MemoryManager("user-1", storage, "newsdesk");
+
+    await analyst.writeSoul("analyst soul");
+    await analyst.appendToThread("question", "analyst answer");
+
+    assert.equal(await analyst.readSoul(), "analyst soul");
+    assert.equal(await newsdesk.readSoul(), "");
+    assert.deepEqual(await newsdesk.readThread(), []);
+    assert.equal(existsSync(join(dir, "user-1", "agents", "analyst", "SOUL.md")), true);
+    assert.equal(existsSync(join(dir, "user-1", "agents", "analyst", "thread.json")), true);
+    assert.equal(existsSync(join(dir, "user-1", "SOUL.md")), false);
+  });
+
+  it("uses separate pod documents for each native agent", async () => {
+    const documents = new Map();
+    let nextId = 0;
+    const mcp = {
+      callToolDirect: async (_server, toolName, args) => {
+        if (toolName === "search_documents") {
+          const doc = documents.get(args.filters.name);
+          const data = doc ? [{ _id: doc.id, value: doc.value }] : [];
+          return { isError: false, content: JSON.stringify({ data: { data } }) };
+        }
+        if (toolName === "create_document") {
+          const id = `doc-${++nextId}`;
+          documents.set(args.name, { id, value: args.content.value });
+          return { isError: false, content: JSON.stringify({ data: { data: { _id: id } } }) };
+        }
+        if (toolName === "update_document") {
+          for (const [name, doc] of documents) {
+            if (doc.id === args.item_id) documents.set(name, { ...doc, value: args.content.value });
+          }
+          return { isError: false, content: "{}" };
+        }
+        return { isError: false, content: JSON.stringify({ data: { data: [] } }) };
+      },
+    };
+    const storage = new PodMemoryStorage(mcp, "pod");
+
+    await storage.write("user-1", "SOUL.md", "analyst", "analyst");
+    await storage.write("user-1", "SOUL.md", "newsdesk", "newsdesk");
+
+    const userHash = createHash("sha256").update("user-1").digest("hex").slice(0, 32);
+    assert.equal(documents.get(`memory-agent-${userHash}-analyst`).value.soul, "analyst");
+    assert.equal(documents.get(`memory-agent-${userHash}-newsdesk`).value.soul, "newsdesk");
+    assert.equal(documents.has("memory-user-1"), false);
+  });
+});

--- a/test/native-agent-selection.test.mjs
+++ b/test/native-agent-selection.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  filterToolNamesForAgent,
+  selectExplicitAgents,
+} from "../dist/agents.js";
+import { conversationNamespace, scopeSessionId } from "../dist/engine.js";
+
+const agents = [
+  {
+    id: "nba-reader",
+    name: "NBA Reader",
+    skills: ["nba"],
+    tags: [],
+    body: "NBA only",
+    active: true,
+    builtin: false,
+  },
+  {
+    id: "retired",
+    name: "Retired",
+    skills: ["nfl"],
+    tags: [],
+    body: "Inactive",
+    active: false,
+    builtin: false,
+  },
+];
+
+describe("explicit native agent selection", () => {
+  it("selects exactly the requested active agent", () => {
+    assert.deepEqual(selectExplicitAgents(agents, ["nba-reader"]), [agents[0]]);
+    assert.throws(() => selectExplicitAgents(agents, []), /exactly one/i);
+    assert.throws(() => selectExplicitAgents(agents, ["nba-reader", "retired"]), /exactly one/i);
+    assert.throws(() => selectExplicitAgents(agents, ["missing"]), /not found/i);
+  });
+
+  it("denies inactive agents", () => {
+    assert.throws(() => selectExplicitAgents(agents, ["retired"]), /inactive/i);
+  });
+
+  it("constrains tools to the selected agent skills", () => {
+    const owners = new Map([
+      ["nba_scores", "nba"],
+      ["nfl_scores", "nfl"],
+    ]);
+    assert.deepEqual(
+      filterToolNamesForAgent(
+        agents[0],
+        ["nba_scores", "nfl_scores", "run_selftest", "mcp__demo__health"],
+        (name) => owners.get(name),
+      ),
+      ["nba_scores", "run_selftest", "mcp__demo__health"],
+    );
+  });
+
+  it("isolates persisted sessions by native agent", () => {
+    assert.equal(scopeSessionId("discord-42", "nba-reader"), "discord-42::agent::nba-reader");
+    assert.notEqual(
+      scopeSessionId("discord-42", "nba-reader"),
+      scopeSessionId("discord-42", "retired"),
+    );
+    assert.notEqual(
+      conversationNamespace("user-1", "nba-reader", "session-a"),
+      conversationNamespace("user-1", "nba-reader", "session-b"),
+    );
+  });
+});

--- a/test/native-agents.test.mjs
+++ b/test/native-agents.test.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  bootstrapDefaultAgents,
+  createAgent,
+  inactivateAgent,
+  listAgents,
+  loadAgent,
+  loadAgents,
+  updateAgent,
+} from "../dist/agents.js";
+
+let dir;
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("native agent CRUD", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sc-agents-"));
+    process.env.SPORTSCLAW_AGENTS_DIR = dir;
+  });
+
+  afterEach(() => {
+    delete process.env.SPORTSCLAW_AGENTS_DIR;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates, updates, lists, and inactivates without destructive deletion", () => {
+    const created = createAgent({
+      id: "match-reader",
+      name: "Match Reader",
+      title: "Football Briefing Specialist",
+      skills: ["football", "news"],
+      tags: ["briefing"],
+      body: "## Directives\n\nRead the match.",
+    });
+    assert.equal(created.active, true);
+    assert.equal(created.builtin, false);
+    assert.equal(created.title, "Football Briefing Specialist");
+    assert.match(readFileSync(join(dir, "match-reader.md"), "utf8"), /^title: Football Briefing Specialist$/m);
+    assert.deepEqual(loadAgents().map((agent) => agent.id), ["match-reader"]);
+
+    const updated = updateAgent("match-reader", {
+      name: "Match Reader Pro",
+      title: "Senior Match Analyst",
+      skills: ["football"],
+      body: "## Directives\n\nRead the match carefully.",
+    });
+    assert.equal(updated.name, "Match Reader Pro");
+    assert.equal(updated.title, "Senior Match Analyst");
+    assert.deepEqual(updated.skills, ["football"]);
+
+    const inactive = inactivateAgent("match-reader");
+    assert.equal(inactive.active, false);
+    assert.deepEqual(loadAgents(), []);
+    assert.equal(loadAgent("match-reader")?.active, false);
+    assert.equal(listAgents({ includeInactive: true })[0].id, "match-reader");
+    assert.deepEqual(readdirSync(dir), ["match-reader.md"]);
+  });
+
+  it("uses atomic writes and leaves no temporary files", () => {
+    createAgent({ id: "atomic-agent", name: "Atomic Agent", body: "Initial body" });
+    updateAgent("atomic-agent", { body: "Updated body" });
+    assert.deepEqual(readdirSync(dir), ["atomic-agent.md"]);
+  });
+
+  it("defaults legacy agent titles to an empty string", () => {
+    writeFileSync(join(dir, "legacy-agent.md"), [
+      "---",
+      "name: Legacy Agent",
+      "skills: []",
+      "---",
+      "Legacy directives",
+      "",
+    ].join("\n"));
+
+    assert.equal(loadAgent("legacy-agent")?.title, "");
+  });
+
+  it("rejects traversal and malformed fields", () => {
+    const valid = { name: "Safe Agent", body: "Safe body" };
+    for (const id of ["../escape", "a/b", "a\\b", ".", "UPPER", "two words", ""] ) {
+      assert.throws(() => createAgent({ id, ...valid }), /agent id/i, id);
+      assert.throws(() => loadAgent(id), /agent id/i, id);
+    }
+    assert.throws(
+      () => createAgent({ id: "bad-name", name: " Bad ", body: "body" }),
+      /name/i,
+    );
+    for (const title of [`${"a".repeat(121)}`, " Bad title ", "bad\u007ftitle", "bad\ntitle"]) {
+      assert.throws(
+        () => createAgent({ id: `bad-title-${title.length}`, name: "Bad Title", title, body: "body" }),
+        /title/i,
+      );
+    }
+    assert.throws(
+      () => createAgent({ id: "bad-skills", name: "Bad Skills", body: "body", skills: ["NBA"] }),
+      /skills/i,
+    );
+    assert.throws(
+      () => createAgent({ id: "bad-tags", name: "Bad Tags", body: "body", tags: ["a", "a"] }),
+      /tags/i,
+    );
+    assert.throws(
+      () => createAgent({ id: "bad-body", name: "Bad Body", body: "" }),
+      /body/i,
+    );
+  });
+
+  it("rejects symlink-backed agent files", () => {
+    const outside = join(dir, "..", `outside-${process.pid}.md`);
+    writeFileSync(outside, "outside", "utf8");
+    symlinkSync(outside, join(dir, "linked-agent.md"));
+    try {
+      assert.throws(() => loadAgent("linked-agent"), /regular file/i);
+      assert.throws(() => updateAgent("linked-agent", { body: "changed" }), /regular file/i);
+      assert.equal(readFileSync(outside, "utf8"), "outside");
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  it("preserves built-in agents", () => {
+    assert.equal(bootstrapDefaultAgents(), 3);
+    const builtins = listAgents({ includeInactive: true });
+    assert.deepEqual(builtins.map((agent) => agent.id), ["analyst", "newsdesk", "scoreboard"]);
+    assert.ok(builtins.every((agent) => agent.builtin && agent.active));
+    assert.throws(() => createAgent({ id: "analyst", name: "Other", body: "body" }), /built-in|exists/i);
+    assert.throws(() => updateAgent("analyst", { body: "replacement" }), /built-in/i);
+    assert.throws(() => inactivateAgent("analyst"), /built-in/i);
+  });
+
+  it("exposes the same lifecycle through the JSON CLI", () => {
+    const run = (args, input) => {
+      const result = spawnSync(
+        process.execPath,
+        [join(repoRoot, "dist", "index.js"), "agents", ...args, "--json"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          input: input ? JSON.stringify(input) : undefined,
+          env: { ...process.env, SPORTSCLAW_AGENTS_DIR: dir },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      return JSON.parse(result.stdout).data;
+    };
+
+    const created = run(["create"], {
+      id: "relay-agent",
+      name: "Relay Agent",
+      title: "NBA Relay Specialist",
+      body: "Relay directives",
+      skills: ["nba"],
+    });
+    assert.equal(created.id, "relay-agent");
+    assert.equal(created.title, "NBA Relay Specialist");
+    assert.equal(run(["get", "relay-agent"]).name, "Relay Agent");
+    const updated = run(["update", "relay-agent"], {
+      title: "",
+      tags: ["briefing"],
+    });
+    assert.equal(updated.title, "");
+    assert.equal(updated.tags[0], "briefing");
+    assert.equal(run(["inactivate", "relay-agent"]).active, false);
+    assert.ok(run(["list", "--all"]).some((agent) => agent.id === "relay-agent"));
+  });
+});

--- a/test/relay-highlights-api.test.mjs
+++ b/test/relay-highlights-api.test.mjs
@@ -153,6 +153,9 @@ class _Router:
     def add_post(self, path, handler):
         self.routes.append(("POST", path, handler))
 
+    def add_patch(self, path, handler):
+        self.routes.append(("PATCH", path, handler))
+
 
 class _Application(dict):
     def __init__(self):

--- a/test/relay-native-agents-api.test.mjs
+++ b/test/relay-native-agents-api.test.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const relayDir = join(repoRoot, "docker", "relay");
+const python = process.env.PYTHON_PATH || "python3";
+
+const driver = String.raw`
+import json, os, sys, tempfile, types
+
+root = tempfile.mkdtemp(prefix="sc-relay-agents-")
+os.environ["HIGHLIGHTS_JOBS_ROOT"] = os.path.join(root, "jobs")
+os.environ["HIGHLIGHTS_MEDIA_ROOT"] = os.path.join(root, "media")
+os.environ["AGENTS_API_TOKEN"] = "agent-secret"
+
+class Response:
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+class Router:
+    def __init__(self): self.routes = []
+    def add_get(self, path, handler): self.routes.append(("GET", path))
+    def add_post(self, path, handler): self.routes.append(("POST", path))
+    def add_patch(self, path, handler): self.routes.append(("PATCH", path))
+
+class Application(dict):
+    def __init__(self):
+        super().__init__()
+        self.router = Router()
+
+web = types.SimpleNamespace(
+    Request=object, Response=Response, StreamResponse=object,
+    Application=Application,
+    json_response=lambda data, status=200: Response(data, status),
+    run_app=None,
+)
+aiohttp = types.ModuleType("aiohttp")
+aiohttp.web = web
+sys.modules["aiohttp"] = aiohttp
+sys.path.insert(0, sys.argv[1])
+import relay_server
+
+scenario = sys.argv[2]
+if scenario == "routes":
+    print(json.dumps(relay_server.create_app().router.routes))
+elif scenario == "command":
+    print(json.dumps(relay_server._build_cmd({"prompt": "hello", "user_id": "u1", "agent_id": "analyst"})))
+elif scenario == "delegated_command":
+    print(json.dumps(relay_server._build_cmd({"prompt": "hello", "agent_id": "analyst", "_delegated": True})))
+elif scenario == "invalid":
+    try:
+        relay_server._build_cmd({"prompt": "hello", "agent_id": "../escape"})
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+    else:
+        print(json.dumps({"error": None}))
+elif scenario == "delegate":
+    print(json.dumps(relay_server._build_delegated_body({
+        "prompt": "research this", "user_id": "u1",
+        "source_agent_id": "analyst", "agent_id": "newsdesk"
+    })))
+elif scenario == "self":
+    try:
+        relay_server._build_delegated_body({
+            "prompt": "research this", "user_id": "u1",
+            "source_agent_id": "analyst", "agent_id": "analyst"
+        })
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+    else:
+        print(json.dumps({"error": None}))
+elif scenario == "recursive":
+    try:
+        relay_server._build_delegated_body({
+            "prompt": "research this", "user_id": "u1",
+            "source_agent_id": "analyst", "agent_id": "newsdesk",
+            "delegation_depth": 1
+        })
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+    else:
+        print(json.dumps({"error": None}))
+elif scenario == "inactive":
+    class Request:
+        headers = {"X-Auth-Token": "agent-secret"}
+        async def json(self):
+            return {
+                "prompt": "research", "user_id": "u1",
+                "source_agent_id": "analyst", "agent_id": "retired"
+            }
+    async def fake_cli(args, payload=None):
+        agent_id = args[1]
+        return {"id": agent_id, "active": agent_id != "retired"}
+    relay_server._run_agent_cli = fake_cli
+    result = __import__("asyncio").run(relay_server.agents_delegate(Request()))
+    print(json.dumps({"status": result.status, "data": result.data}))
+elif scenario == "auth":
+    class Request:
+        headers = {}
+    result = __import__("asyncio").run(relay_server.agents_list(Request()))
+    print(json.dumps({"status": result.status, "data": result.data}))
+elif scenario == "query_auth":
+    class Request:
+        headers = {}
+    result = relay_server._query_agent_auth_error(Request(), {"agent_id": "analyst"})
+    print(json.dumps({"status": result.status, "data": result.data}))
+elif scenario == "query_compat":
+    del os.environ["AGENTS_API_TOKEN"]
+    class Request:
+        headers = {}
+    result = relay_server._query_agent_auth_error(Request(), {"prompt": "hello"})
+    print(json.dumps({"allowed": result is None}))
+elif scenario == "active_type":
+    try:
+        relay_server._validate_agent_payload({"active": 0}, create=False)
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+    else:
+        print(json.dumps({"error": None}))
+elif scenario == "title_validation":
+    errors = []
+    for title in ("x" * 121, " padded ", "bad\x7ftitle", "bad\ntitle"):
+        try:
+            relay_server._validate_agent_payload({"title": title}, create=False)
+        except Exception as exc:
+            errors.append(str(exc))
+    empty = relay_server._validate_agent_payload({"title": ""}, create=False)
+    print(json.dumps({"errors": errors, "empty": empty}))
+elif scenario == "mutation_responses":
+    calls = []
+    async def fake_cli(args, payload=None):
+        calls.append({"args": args, "payload": payload})
+        return {
+            "id": payload.get("id", "match-reader"),
+            "name": payload.get("name", "Match Reader"),
+            "title": payload.get("title", ""),
+            "body": payload.get("body", "Directives"),
+            "skills": payload.get("skills", []),
+            "tags": payload.get("tags", []),
+            "active": True,
+            "builtin": False,
+        }
+    relay_server._run_agent_cli = fake_cli
+    class Request:
+        headers = {"X-Auth-Token": "agent-secret"}
+        match_info = {"agent_id": "match-reader"}
+        def __init__(self, payload): self.payload = payload
+        async def json(self): return self.payload
+    async def mutate():
+        created = await relay_server.agents_create(Request({
+            "id": "match-reader", "name": "Match Reader",
+            "title": "Football Briefing Specialist", "body": "Directives"
+        }))
+        updated = await relay_server.agents_patch(Request({"title": "Senior Match Analyst"}))
+        return {
+            "created_status": created.status,
+            "created": created.data,
+            "updated_status": updated.status,
+            "updated": updated.data,
+            "calls": calls,
+        }
+    print(json.dumps(__import__("asyncio").run(mutate())))
+`;
+
+function run(scenario) {
+  const result = spawnSync(python, ["-c", driver, relayDir, scenario], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout.trim());
+}
+
+describe("relay native agents API", () => {
+  it("registers CRUD and one-hop delegation routes", () => {
+    const routes = run("routes").map(([method, path]) => `${method} ${path}`);
+    assert.ok(routes.includes("GET /api/agents"));
+    assert.ok(routes.includes("POST /api/agents"));
+    assert.ok(routes.includes("GET /api/agents/{agent_id}"));
+    assert.ok(routes.includes("PATCH /api/agents/{agent_id}"));
+    assert.ok(routes.includes("POST /api/agents/delegate"));
+  });
+
+  it("validates and forwards query agent_id as --agent", () => {
+    const command = run("command");
+    assert.deepEqual(command.slice(-4), ["--user", "u1", "--agent", "analyst"]);
+    assert.match(run("invalid").error, /agent_id/i);
+  });
+
+  it("builds a one-hop target query without arbitrary system prompts", () => {
+    const delegated = run("delegate");
+    assert.equal(delegated.agent_id, "newsdesk");
+    assert.equal(delegated.user_id, "u1");
+    assert.equal(delegated.prompt, "research this");
+    assert.equal("system_prompt" in delegated, false);
+    assert.match(run("self").error, /self/i);
+    assert.match(run("recursive").error, /recursive|one-hop/i);
+    assert.ok(run("delegated_command").includes("--delegated"));
+  });
+
+  it("denies delegation to an inactive target", () => {
+    const response = run("inactive");
+    assert.equal(response.status, 403);
+    assert.match(response.data.error, /inactive/i);
+  });
+
+  it("fails closed without agent API auth and rejects non-boolean inactivation", () => {
+    assert.equal(run("auth").status, 401);
+    assert.equal(run("query_auth").status, 401);
+    assert.equal(run("query_compat").allowed, true);
+    assert.match(run("active_type").error, /active/i);
+  });
+
+  it("validates optional titles and returns them from create and update", () => {
+    const validation = run("title_validation");
+    assert.equal(validation.errors.length, 4);
+    assert.ok(validation.errors.every((error) => /title/i.test(error)));
+    assert.equal(validation.empty.title, "");
+
+    const mutations = run("mutation_responses");
+    assert.equal(mutations.created_status, 201);
+    assert.equal(mutations.created.agent.title, "Football Briefing Specialist");
+    assert.equal(mutations.updated_status, 200);
+    assert.equal(mutations.updated.agent.title, "Senior Match Analyst");
+    assert.equal(mutations.calls[0].payload.title, "Football Briefing Specialist");
+    assert.equal(mutations.calls[1].payload.title, "Senior Match Analyst");
+  });
+});


### PR DESCRIPTION
## Summary
- add file-backed native agent CRUD, selection, isolated memory, and one-hop relay delegation
- add optional agent titles across YAML, TypeScript inputs, CLI JSON, and relay create/update APIs
- harden validation, atomic persistence, authentication, and backward compatibility for existing agent files

## Verification
- `npm run build`
- `node --test test/*.test.mjs` (1244 passed)
- `git diff --check`
- `gitleaks stdin` on staged diff

No image was published and no deployment was performed.