### PR TITLE
perf(operator): stream partials at 200ms (was 600ms) for a visible typewriter

### DIFF
--- a/src/operator-daemon.ts
+++ b/src/operator-daemon.ts
@@ -652,7 +652,7 @@ export function createOperatorDaemon(
         const emitPartial = (final = false) => {
           if (!cfg.onPartialOutput) return;
           const now = Date.now();
-          if (!final && now - lastEmit < 600) return;
+          if (!final && now - lastEmit < 200) return;
           const m = argsBuf.match(/"(?:answer|narrative)"\s*:\s*"((?:[^"\\]|\\.)*)/);
           if (!m) return;
           lastEmit = now;


### PR DESCRIPTION
One-line change that was written on `feat/momentum-explainer-phase3` and never made it into `main` — the rest of that branch landed via #135, #136 and #138, leaving this commit stranded. `main` still has `600`.

```diff
-          if (!final && now - lastEmit < 600) return;
+          if (!final && now - lastEmit < 200) return;
```

`src/operator-daemon.ts` — the partial-output throttle in `emitPartial`. At 600ms the operator's streamed answer arrives in visible chunks; at 200ms it reads as a typewriter.

Only throttles emission of already-buffered text — no extra model calls, no change to what is emitted, and `final` emissions were never throttled.

## Verification

- Cherry-picked clean onto current `main`
- `tsc` strict clean
- `test/operator-daemon.test.mjs` 56/56

🤖 Generated with [Claude Code](https://claude.com/claude-code)