### PR TITLE
fix(intelligence): replace non-existent gemini-3.5-pro with gemini-3.7-flash

### DIFF
--- a/src/intelligence/momentum-evaluator.ts
+++ b/src/intelligence/momentum-evaluator.ts
@@ -59,7 +59,7 @@ import {
 export const DEFAULT_EVALUATOR_MODELS: Record<LLMProvider, string> = {
   anthropic: "claude-sonnet-4-5-20250929",
   openai: "gpt-5.4",
-  google: "gemini-3.5-pro",
+  google: "gemini-3.7-flash",
   "azure-foundry": "gpt-5.4-mini",
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,9 +180,9 @@ export const PROVIDER_MODEL_PROFILES: Record<LLMProvider, ProviderModelProfile> 
         hint: "recommended",
       },
       {
-        value: "gemini-3.5-pro",
-        label: "Gemini 3.5 Pro",
-        hint: "advanced reasoning",
+        value: "gemini-3.7-flash",
+        label: "Gemini 3.7 Flash",
+        hint: "latest",
       },
       {
         value: "gemini-3-flash-preview",


### PR DESCRIPTION
`gemini-3.5-pro` is not a real model. Both occurrences replaced with `gemini-3.7-flash`.

## Where it came from

It entered `main` in **`64fc9880`** — "fix(intelligence): harden momentum evaluator gates", the last commit on #135 before merge. That commit also dropped the `DEFAULT_MODELS` indirection:

```diff
-import { DEFAULT_MODELS } from "../types.js";
-  openai: DEFAULT_MODELS.openai,
-  google: "gemini-3.5-flash",
-  "azure-foundry": DEFAULT_MODELS["azure-foundry"],
+  openai: "gpt-5.4",
+  google: "gemini-3.5-pro",
+  "azure-foundry": "gpt-5.4-mini",
```

The commit message is a single line about gates and says nothing about models, so the swap has no decision record anywhere.

## What this changes

| file | was | now |
|---|---|---|
| `src/intelligence/momentum-evaluator.ts` | `gemini-3.5-pro` | `gemini-3.7-flash` |
| `src/types.ts` (google picker) | `gemini-3.5-pro` / "Gemini 3.5 Pro" / "advanced reasoning" | `gemini-3.7-flash` / "Gemini 3.7 Flash" / "latest" |

The `types.ts` one matters as much as the evaluator default — a non-existent id was being offered in the user-facing model picker, so anyone selecting "Gemini 3.5 Pro" got a broken provider call.

## Invariants checked at runtime

```
evaluator google default    : gemini-3.7-flash
generator google default    : gemini-3.5-flash
maker/checker still distinct: true
evaluator default is selectable: true
```

The maker/checker separation the evaluator's own doc comment calls for is preserved — the checker is still a different model than the generator.

## Verification

`tsc` strict clean; full suite **1291/1291**.

## Not addressed here

The same commit pinned `openai: "gpt-5.4"` (profile default is `gpt-5.4-mini`) and `azure-foundry: "gpt-5.4-mini"`, hardcoded rather than tracking `PROVIDER_MODEL_PROFILES`. Those ids are real, so they're left alone — but the evaluator defaults no longer follow the profiles, which is worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)