### PR TITLE
fix(relay): route an api_key override to the provider's own env var

### DIFF
--- a/docker/relay/relay_server.py
+++ b/docker/relay/relay_server.py
@@ -779,12 +779,24 @@ def _build_env(body: dict | None = None) -> dict[str, str]:
         if body.get("api_key"):
             # Determine the right env var based on provider
             provider = body.get("provider", env.get("SPORTSCLAW_PROVIDER", "anthropic"))
+            # Mirrors PROVIDER_API_KEY_ENV in src/config.ts. A provider missing
+            # here silently lands the caller's key in ANTHROPIC_API_KEY, so the
+            # run authenticates with the wrong credential instead of failing.
             key_map = {
                 "anthropic": "ANTHROPIC_API_KEY",
                 "openai": "OPENAI_API_KEY",
                 "google": "GOOGLE_GENERATIVE_AI_API_KEY",
+                "azure-foundry": "AZURE_FOUNDRY_API_KEY",
             }
-            env_var = key_map.get(provider, "ANTHROPIC_API_KEY")
+            env_var = key_map.get(provider)
+            if env_var is None:
+                raise web.HTTPBadRequest(
+                    text=json.dumps({
+                        "status": False,
+                        "error": f"unsupported provider for api_key override: {provider}",
+                    }),
+                    content_type="application/json",
+                )
             env[env_var] = body["api_key"]
         if body.get("images"):
             env["SPORTSCLAW_INBOUND_IMAGES"] = json.dumps(body["images"])

--- a/test/relay-provider-key-map.test.mjs
+++ b/test/relay-provider-key-map.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Relay provider → API-key env mapping contract
+ *
+ * `_build_env` in the relay server translates a per-request `api_key` into the
+ * environment variable the engine reads for the active provider. That mapping
+ * duplicates `PROVIDER_ENV` in src/config.ts, and the two had already drifted:
+ * the relay knew anthropic, openai and google, but not azure-foundry, so an
+ * azure-foundry request carrying `api_key` wrote the caller's key to
+ * ANTHROPIC_API_KEY. The run then authenticated with the wrong credential —
+ * or silently reused an unrelated one — instead of failing.
+ *
+ * The expectation is derived from the engine source rather than restated here,
+ * so adding a provider to src/config.ts without teaching the relay about it
+ * fails this test instead of shipping a misrouted credential.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const relayServerPath = join(repoRoot, "docker/relay/relay_server.py");
+const configPath = join(repoRoot, "src/config.ts");
+
+let relayServer;
+let engineProviders;
+
+before(() => {
+  relayServer = readFileSync(relayServerPath, "utf8");
+
+  // PROVIDER_ENV in src/config.ts is the single source of truth.
+  const block = readFileSync(configPath, "utf8").match(
+    /export const PROVIDER_ENV: Record<LLMProvider, string> = \{([\s\S]*?)\};/
+  );
+  assert.ok(block, "PROVIDER_ENV not found in src/config.ts");
+
+  engineProviders = new Map(
+    [...block[1].matchAll(/"?([a-z-]+)"?\s*:\s*"([A-Z0-9_]+)"/g)].map((m) => [m[1], m[2]])
+  );
+  assert.ok(engineProviders.size >= 4, "expected at least four providers in PROVIDER_ENV");
+});
+
+describe("relay provider key map", () => {
+  it("covers every provider the engine knows, with the same env var", () => {
+    const keyMap = relayServer.match(/key_map = \{([\s\S]*?)\}/);
+    assert.ok(keyMap, "key_map not found in _build_env");
+
+    const relayProviders = new Map(
+      [...keyMap[1].matchAll(/"([a-z-]+)"\s*:\s*"([A-Z0-9_]+)"/g)].map((m) => [m[1], m[2]])
+    );
+
+    for (const [provider, envVar] of engineProviders) {
+      assert.equal(
+        relayProviders.get(provider),
+        envVar,
+        `relay key_map must map ${provider} to ${envVar} (see PROVIDER_ENV in src/config.ts)`
+      );
+    }
+  });
+
+  it("rejects an unknown provider instead of defaulting to a real credential", () => {
+    // The previous `key_map.get(provider, "ANTHROPIC_API_KEY")` turned any
+    // unrecognised provider into an Anthropic credential write.
+    assert.doesNotMatch(
+      relayServer,
+      /key_map\.get\(provider,\s*"ANTHROPIC_API_KEY"\)/,
+      "unknown providers must not fall back to ANTHROPIC_API_KEY"
+    );
+    assert.match(
+      relayServer,
+      /unsupported provider for api_key override/,
+      "an unknown provider should surface an explicit error"
+    );
+  });
+});


### PR DESCRIPTION
## The bug

`_build_env` in `docker/relay/relay_server.py` translates a per-request `api_key` into the env var the engine reads. It mapped three providers and defaulted everything else to Anthropic:

```python
key_map = {"anthropic": ..., "openai": ..., "google": ...}
env_var = key_map.get(provider, "ANTHROPIC_API_KEY")
env[env_var] = body["api_key"]
```

`azure-foundry` is a supported provider (`LLMProvider` in `src/types.ts`, and `PROVIDER_ENV` in `src/config.ts:112-117` maps it to `AZURE_FOUNDRY_API_KEY`). So a request with `provider: "azure-foundry"` and an `api_key` wrote that key to `ANTHROPIC_API_KEY`. The run then authenticated with the wrong credential — or silently reused an unrelated Anthropic key already in the environment — rather than failing.

Scope: only the per-request `api_key` override path. Tenants whose key comes from the deployment env are unaffected. Noting it anyway because `tenant-machina-drops-corinthians-intelligence` runs `SPORTSCLAW_PROVIDER=azure-foundry` with an `AZURE_FOUNDRY_API_KEY` secret, so it is a live configuration.

## The change

- Add `azure-foundry` to the map.
- Replace the silent default with an explicit `400`. An unrecognised provider is a caller error, not a reason to write a secret into whatever variable happens to be first in the list.

## Test

`test/relay-provider-key-map.test.mjs` follows the `relay-container-contract` idiom: it asserts the relay source as text and **derives** the expectation from `PROVIDER_ENV`, so adding a provider to the engine without teaching the relay about it fails here instead of shipping a misrouted credential.

Verified it catches the bug — reverting the fix turns both cases red:

```
--- with the bug present ---     --- with the fix ---
# pass 0  # fail 2               # pass 2  # fail 0
```

Other relay suites on this branch: `relay-container-contract` 13/13, `relay-native-agents-api` 6/6, `relay-highlights-api` 31/31. `relay-skills-catalog` has 2 failures (`sportsclaw_SCHEMA_DIR` spelling) that reproduce on clean `origin/main` and are unrelated to this change.

## How I found it

Auditing the relay while wiring the Broadcast AI tenant's MCP integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)