### PR TITLE
docs(mcp): document the per-server tool allowlist and what it protects

### DIFF
--- a/docker/relay/k8s/overlays/example/config.env
+++ b/docker/relay/k8s/overlays/example/config.env
@@ -31,6 +31,11 @@ PYTHON_PATH=/opt/venv/bin/python3
 # value has "url" and optional "headers". Tokens can also be set
 # via SPORTSCLAW_MCP_TOKEN_<SERVER_NAME_UPPER> in secrets.env.
 # SPORTSCLAW_MCP_SERVERS={"adidas-tracker":{"url":"https://machina-podcasts-adidas-tracker.org.machina.gg/mcp/sse"}}
+#
+# Every tool the server advertises is registered unless you restrict it. Add "tools"
+# to register only the ones you name — without it a pod exposing delete_document or
+# execute_workflow hands those to the model, and no approval gate covers MCP calls.
+# SPORTSCLAW_MCP_SERVERS={"adidas-tracker":{"url":"https://…/mcp/sse","tools":["search_documents","get_document","health_check"]}}
 
 # --- Skill Guides (optional) ---
 # Path to skill guide directories inside the container.

--- a/docs/advanced/mcp.md
+++ b/docs/advanced/mcp.md
@@ -26,19 +26,20 @@ offers `delete_document` or `execute_workflow`, the agent can call them.
 Set `tools` on the server entry to register only the ones you name. Anything the server
 advertises that is not on the list is never given to the model:
 
+`~/.sportsclaw/mcp.json` — the server name is the top-level key:
+
 ```json
 {
-  "mcpServers": {
-    "my-pod": {
-      "url": "https://my-pod.org.machina.gg/mcp/sse",
-      "tools": ["search_documents", "get_document", "health_check"]
-    }
+  "my-pod": {
+    "url": "https://my-pod.org.machina.gg/mcp/sse",
+    "tools": ["search_documents", "get_document", "health_check"]
   }
 }
 ```
 
-The same key works in the relay's `SPORTSCLAW_MCP_SERVERS` env var. Run with `--verbose` to
-confirm what registered — the log reads `mcp: "my-pod" has 3 tool(s) (filtered from 41)`.
+`SPORTSCLAW_MCP_SERVERS` takes the same object as a JSON string, so the relay is configured
+the same way. Run with `--verbose` to confirm what registered — the log reads
+`mcp: "my-pod" has 3 tool(s) (filtered from 41)`.
 
 ::: warning Prompt rules are not enforcement
 Telling the agent in its instructions not to call a write tool is not a control: the tool is

--- a/docs/advanced/mcp.md
+++ b/docs/advanced/mcp.md
@@ -17,8 +17,48 @@ sportsclaw mcp remove <name>                             # disconnect one
 - `--token <token>` — a bearer token, if the server needs auth.
 - `--description <text>` and `--timeout <ms>` — optional metadata and per-call timeout.
 
-Once connected, the tools that server exposes become available to the agent automatically,
-alongside the built-in sports tools.
+Once connected, **every** tool that server exposes becomes available to the agent,
+alongside the built-in sports tools. There is no read/write classification: if the server
+offers `delete_document` or `execute_workflow`, the agent can call them.
+
+### Restricting a server to specific tools
+
+Set `tools` on the server entry to register only the ones you name. Anything the server
+advertises that is not on the list is never given to the model:
+
+```json
+{
+  "mcpServers": {
+    "my-pod": {
+      "url": "https://my-pod.org.machina.gg/mcp/sse",
+      "tools": ["search_documents", "get_document", "health_check"]
+    }
+  }
+}
+```
+
+The same key works in the relay's `SPORTSCLAW_MCP_SERVERS` env var. Run with `--verbose` to
+confirm what registered — the log reads `mcp: "my-pod" has 3 tool(s) (filtered from 41)`.
+
+::: warning Prompt rules are not enforcement
+Telling the agent in its instructions not to call a write tool is not a control: the tool is
+still registered and the model can still call it. `tools` is the enforcement point.
+
+The approval gate does not help here either. It is declarative — it fires when a tool spec
+defines `needsApproval` — and MCP tool specs are built from the server's advertised schema
+with no such field, so an MCP write runs without a confirmation prompt. The gate is also
+interactive-only: outside a TTY it fails closed, which is not what you want for a relay.
+
+If a server exposes writes you do want, one workable shape is to allowlist only its read tools
+and have your own application perform the writes after a user confirms them — the agent
+proposes, your app executes.
+:::
+
+::: tip Pod memory needs write tools
+`SPORTSCLAW_MEMORY_PROVIDER=pod` stores memory through the pod's own `create_document` and
+`update_document`. A read-only allowlist denies those: leave the provider at `auto` (it falls
+back to file memory) rather than `pod`, or the run throws.
+:::
 
 ### Where tokens live
 


### PR DESCRIPTION
## Why

`docs/advanced/mcp.md` said:

> Once connected, the tools that server exposes become available to the agent automatically, alongside the built-in sports tools.

True, and for a write-capable server that sentence reads as a convenience rather than the security decision it actually is. A Machina pod advertises document CRUD and workflow execution, so connecting one gives the model `delete_document`, `bulk_delete_documents`, `create_secrets` and `execute_workflow` with nothing but prompt text in between.

`tools` already implements the fix — `src/mcp.ts:598-604` filters the discovered list — but it appears in **neither** the guide nor `docker/relay/k8s/overlays/example/config.env`, so the safe configuration is undiscoverable exactly when someone is connecting a pod.

We hit this on the Broadcast AI tenant: the relay had no allowlist and the assistant could have called `delete_document` on the production pod. After adding `tools`, the agent now answers that the write tools are *not registered* and lists the thirteen reads it has — enforcement instead of refusal.

## What changed

- **`docs/advanced/mcp.md`** — new "Restricting a server to specific tools" section: the `tools` key with a JSON example, the note that it works in the relay's `SPORTSCLAW_MCP_SERVERS`, and the `--verbose` line that confirms the result (`mcp: "my-pod" has 3 tool(s) (filtered from 41)`). Plus two admonitions.
- **`docker/relay/k8s/overlays/example/config.env`** — the commented `SPORTSCLAW_MCP_SERVERS` example now shows a `tools` variant.

## Claims, each checked against source

| Claim | Evidence |
|---|---|
| Every advertised tool registers unless `tools` is set | `src/mcp.ts:598-604` |
| No read/write classification anywhere | `src/agents.ts:567` always allows `mcp__*`; specs carry no capability flag |
| Approval gate is declarative via `needsApproval` | `src/engine.ts:1198` |
| MCP specs never set it | `src/mcp.ts:613-623` builds specs with `name`/`description`/`input_schema` only |
| Gate is interactive-only, relay is piped | `src/engine.ts:1171` (`isTTY`); `relay_server.py:738` (`--pipe`) |
| Pod memory needs the denied writes | `src/mcp.ts:896-900` requires `create_document` + `update_document` |

Docs and a comment only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)