### PR TITLE
fix(relay): authenticate and bound queries with explicit history ownership

### DIFF
--- a/.github/workflows/build-relay.yml
+++ b/.github/workflows/build-relay.yml
@@ -34,6 +34,8 @@ jobs:
           context: .
           file: ./docker/relay/Dockerfile
           push: true
+          build-args: |
+            SPORTSCLAW_BUILD_REVISION=${{ github.sha }}
           tags: |
             ${{ secrets.REGISTRY_URL }}/${{ env.APP_NAME }}:${{ env.RELEASE_NAME }}
             ${{ secrets.REGISTRY_URL }}/${{ env.APP_NAME }}:latest

--- a/docker/relay/Dockerfile
+++ b/docker/relay/Dockerfile
@@ -83,6 +83,7 @@ RUN node dist/index.js init --all --verbose
 
 # --- Relay server & entrypoint ------------------------------------------------
 COPY docker/relay/relay_server.py /opt/sportsclaw/relay_server.py
+COPY docker/relay/query_runtime.py /opt/sportsclaw/query_runtime.py
 COPY docker/relay/skills_catalog.py /opt/sportsclaw/skills_catalog.py
 COPY docker/relay/highlights_jobs.py /opt/sportsclaw/highlights_jobs.py
 COPY docker/relay/entrypoint.sh /opt/sportsclaw/entrypoint.sh
@@ -103,6 +104,8 @@ RUN mkdir -p /data/highlights-jobs /data/media
 
 # --- Runtime defaults (overridable) -------------------------------------------
 ENV RELAY_PORT=8080
+ARG SPORTSCLAW_BUILD_REVISION=unknown
+ENV SPORTSCLAW_BUILD_REVISION=${SPORTSCLAW_BUILD_REVISION}
 ENV SPORTSCLAW_PROVIDER=anthropic
 ENV PYTHON_PATH=/opt/venv/bin/python3
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/relay/query_runtime.py
+++ b/docker/relay/query_runtime.py
@@ -1,0 +1,73 @@
+"""Bounded subprocess lifecycle shared by query and discovery endpoints."""
+import asyncio
+import os
+import signal
+from contextlib import asynccontextmanager
+
+MAX_OUTPUT_BYTES = 32 * 1024 * 1024
+MAX_STDERR_BYTES = 64 * 1024
+
+
+async def drain(reader, limit, *, truncate=False):
+    chunks, size = [], 0
+    while True:
+        chunk = await reader.read(65536)
+        if not chunk:
+            return b"".join(chunks)
+        if size + len(chunk) > limit and not truncate:
+            raise ValueError("query output exceeds configured limit")
+        if size < limit:
+            chunks.append(chunk[:limit - size])
+        size += len(chunk)
+
+
+async def stop(proc):
+    # Each child owns a new session, so this never signals the relay's group.
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    await proc.wait()
+
+
+@asynccontextmanager
+async def process(cmd, env, *, with_stdin=False):
+    spawn = asyncio.create_task(asyncio.create_subprocess_exec(
+        *cmd, env=env, stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE, start_new_session=True,
+        stdin=asyncio.subprocess.PIPE if with_stdin else None,
+        limit=MAX_OUTPUT_BYTES,
+    ))
+    try:
+        proc = await asyncio.shield(spawn)
+    except asyncio.CancelledError:
+        proc = await spawn
+        await stop(proc)
+        raise
+    stderr = asyncio.create_task(drain(proc.stderr, MAX_STDERR_BYTES, truncate=True))
+    try:
+        yield proc, stderr
+    finally:
+        # Shield cleanup from the HTTP handler's cancellation. Always reap.
+        cleanup = asyncio.create_task(stop(proc))
+        try:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            await cleanup
+            raise
+        finally:
+            stderr.cancel()
+            await asyncio.gather(stderr, return_exceptions=True)
+
+
+async def buffered(cmd, env, timeout, stdin=None):
+    async with process(cmd, env, with_stdin=stdin is not None) as (proc, stderr):
+        async def collect():
+            if stdin is not None:
+                proc.stdin.write(stdin)
+                await proc.stdin.drain()
+                proc.stdin.close()
+            stdout = await drain(proc.stdout, MAX_OUTPUT_BYTES)
+            await proc.wait()
+            return stdout, await stderr, proc.returncode
+        return await asyncio.wait_for(collect(), timeout)

--- a/docker/relay/relay_server.py
+++ b/docker/relay/relay_server.py
@@ -47,10 +47,13 @@ import os
 import re
 import secrets
 import time
+from functools import wraps
+from pathlib import Path
 
 from aiohttp import web
 
 from skills_catalog import parse_catalog
+from query_runtime import buffered, process, MAX_OUTPUT_BYTES
 from highlights_jobs import (
     DEFAULT_JOB_TTL_SEC,
     DEFAULT_MAX_JOB_OUTPUT_BYTES,
@@ -64,6 +67,11 @@ PORT = int(os.environ.get("RELAY_PORT", 8080))
 SPORTSCLAW_BIN = os.environ.get("SPORTSCLAW_BIN", "node")
 SPORTSCLAW_ENTRY = os.environ.get("SPORTSCLAW_ENTRY", "/app/dist/index.js")
 DEFAULT_TIMEOUT = int(os.environ.get("RELAY_TIMEOUT", 180))
+MAX_QUERY_TIMEOUT = int(os.environ.get("RELAY_MAX_QUERY_TIMEOUT", 300))
+MAX_QUERY_CONCURRENCY = int(os.environ.get("RELAY_MAX_QUERY_CONCURRENCY", 4))
+MAX_PROMPT_CHARS = 20000
+if not 1 <= DEFAULT_TIMEOUT <= MAX_QUERY_TIMEOUT or MAX_QUERY_CONCURRENCY < 1:
+    raise ValueError("invalid relay query limits")
 AGENT_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 AGENTS_AUTH_HEADER = "X-Auth-Token"
 
@@ -97,14 +105,9 @@ async def list_skills(request: web.Request) -> web.Response:
     catalog; a nonzero exit or an unparseable payload is now an error instead.
     """
     try:
-        proc = await asyncio.create_subprocess_exec(
-            SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "list", "--json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=_build_env(),
-        )
-        stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
-        skills = parse_catalog(stdout.decode(), proc.returncode)
+        stdout, _stderr, returncode = await buffered(
+            [SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "list", "--json"], _build_env(), 10)
+        skills = parse_catalog(stdout.decode(), returncode)
         return web.json_response({"status": True, "skills": skills})
     except Exception as e:
         # Only the parser's own message is surfaced — child stderr is never
@@ -129,7 +132,7 @@ def _agents_auth_error(request: web.Request) -> web.Response | None:
     expected = os.environ.get("AGENTS_API_TOKEN", "")
     if not expected:
         return web.json_response(
-            {"status": False, "error": "agents API is unavailable — no API token is configured"},
+            {"status": False, "error": "relay API is unavailable — no API token is configured"},
             status=503,
         )
     supplied = request.headers.get(AGENTS_AUTH_HEADER, "")
@@ -146,10 +149,71 @@ def _agents_auth_error(request: web.Request) -> web.Response | None:
 def _query_agent_auth_error(
     request: web.Request, body: dict
 ) -> web.Response | None:
-    """Keep legacy queries public, but authenticate explicit agent selection."""
-    if body.get("agent_id") is None:
-        return None
+    """Every query uses the same trusted caller boundary, including auto-routing."""
     return _agents_auth_error(request)
+
+
+def query_guard(handler):
+    @wraps(handler)
+    async def guarded(request):
+        denied = _agents_auth_error(request)
+        if denied is not None:
+            return denied
+        try:
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ValueError("request body must be an object")
+            prompt = body.get("prompt")
+            if not isinstance(prompt, str) or not prompt.strip() or len(prompt) > MAX_PROMPT_CHARS:
+                raise ValueError(f"prompt must contain 1-{MAX_PROMPT_CHARS} characters")
+            timeout = body.get("timeout", DEFAULT_TIMEOUT)
+            if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= MAX_QUERY_TIMEOUT:
+                raise ValueError(f"timeout must be an integer between 1 and {MAX_QUERY_TIMEOUT}")
+            if body.get("history_mode", "engine") not in ("caller", "engine"):
+                raise ValueError("history_mode must be caller or engine")
+            for key in ("user_id", "provider", "model", "system_prompt", "format", "api_key"):
+                if key in body and (not isinstance(body[key], str) or len(body[key]) > MAX_PROMPT_CHARS):
+                    raise ValueError(f"invalid {key}")
+        except (ValueError, TypeError) as error:
+            return web.json_response({"status": False, "error": str(error)}, status=400)
+        app = request.app
+        # No await between inspection and increment: admission is atomic on the event loop.
+        if app.get("active_queries", 0) >= MAX_QUERY_CONCURRENCY:
+            return web.json_response({"status": False, "error": "query capacity exhausted"}, status=429)
+        app["active_queries"] = app.get("active_queries", 0) + 1
+        try:
+            return await handler(request)
+        finally:
+            app["active_queries"] -= 1
+    return guarded
+
+
+async def capabilities(request):
+    denied = _agents_auth_error(request)
+    if denied is not None:
+        return denied
+    try:
+        stdout, _, code = await buffered(
+            [SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "list", "--json"], _build_env(), 10)
+        skills = parse_catalog(stdout.decode(), code)
+        package = json.loads((Path(SPORTSCLAW_ENTRY).resolve().parent.parent / "package.json").read_text())
+        configs = json.loads(os.environ.get("SPORTSCLAW_MCP_SERVERS", "{}"))
+        mcp = [{"server": name, "allowed_tools": config.get("tools") or None,
+                "policy": "allowlist" if config.get("tools") else "all_discovered"}
+               for name, config in configs.items()]
+        return web.json_response({
+            "protocol_version": "1.0", "engine_version": package["version"],
+            "build_revision": os.environ.get("SPORTSCLAW_BUILD_REVISION"),
+            "skills": skills, "mcp_servers": mcp,
+            "history_modes": ["engine", "caller"],
+            "query": {"default_timeout_seconds": DEFAULT_TIMEOUT,
+                      "max_timeout_seconds": MAX_QUERY_TIMEOUT,
+                      "max_concurrency": MAX_QUERY_CONCURRENCY,
+                      "max_prompt_characters": MAX_PROMPT_CHARS,
+                      "max_output_bytes": MAX_OUTPUT_BYTES},
+        })
+    except Exception:
+        return web.json_response({"status": False, "error": "capability discovery unavailable"}, status=503)
 
 
 def _validate_agent_id(agent_id: object) -> str:
@@ -221,21 +285,12 @@ async def _read_json_object(request: web.Request) -> dict:
 
 async def _run_agent_cli(args: list[str], payload: dict | None = None):
     cmd = [SPORTSCLAW_BIN, SPORTSCLAW_ENTRY, "agents", *args, "--json"]
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdin=asyncio.subprocess.PIPE if payload is not None else None,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=_build_env(),
-    )
     stdin = json.dumps(payload).encode() if payload is not None else None
     try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(stdin), timeout=10)
+        stdout, stderr, returncode = await buffered(cmd, _build_env(), 10, stdin)
     except asyncio.TimeoutError as exc:
-        proc.kill()
-        await proc.communicate()
         raise AgentApiError("agent operation timed out", 504) from exc
-    if proc.returncode != 0:
+    if returncode != 0:
         detail = stderr.decode().strip().splitlines()
         message = detail[-1] if detail else "agent operation failed"
         status = 404 if "not found" in message.lower() else 409 if "exists" in message.lower() else 400
@@ -322,16 +377,17 @@ def _build_delegated_body(body: object) -> dict:
     if source_id == target_id:
         raise AgentApiError("self-delegation is not allowed")
     delegated = {"prompt": prompt, "agent_id": target_id, "_delegated": True}
-    for key in ("user_id", "provider", "model", "verbose", "format", "timeout", "api_key"):
+    for key in ("user_id", "provider", "model", "verbose", "format", "timeout", "api_key", "history_mode"):
         if key in body:
             delegated[key] = body[key]
     return delegated
 
 
 class _DelegatedRequest:
-    def __init__(self, body: dict, headers):
+    def __init__(self, body: dict, headers, app=None):
         self._body = body
         self.headers = headers
+        self.app = app if app is not None else {}
 
     async def json(self) -> dict:
         return self._body
@@ -350,7 +406,7 @@ async def agents_delegate(request: web.Request) -> web.Response:
             raise AgentApiError(f'Agent "{source["id"]}" is inactive', 403)
         if not target.get("active"):
             raise AgentApiError(f'Agent "{target["id"]}" is inactive', 403)
-        return await query_sync(_DelegatedRequest(delegated, request.headers))
+        return await query_sync(_DelegatedRequest(delegated, request.headers, request.app))
     except Exception as error:
         return _agent_error_response(error)
 
@@ -368,6 +424,7 @@ async def _require_active_query_agent(body: dict) -> None:
 # Query — streaming NDJSON (forwards engine events in real-time)
 # ---------------------------------------------------------------------------
 
+@query_guard
 async def query_stream(request: web.Request) -> web.StreamResponse:
     """
     Execute a SportsClaw query and stream NDJSON events in real-time.
@@ -411,51 +468,43 @@ async def query_stream(request: web.Request) -> web.StreamResponse:
     await response.prepare(request)
 
     try:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-            limit=16 * 1024 * 1024,  # 16MB line buffer (base64 images ~88KB, videos can be several MB)
-        )
-
-        async def stream_stdout():
-            async for line in proc.stdout:
-                decoded = line.decode().rstrip("\n")
-                if not decoded:
-                    continue
-                # Try to parse as JSON and inject user_id
-                try:
-                    event = json.loads(decoded)
-                    event["user_id"] = user_id
-                    await response.write(json.dumps(event).encode() + b"\n")
-                except json.JSONDecodeError:
-                    # Non-JSON line (e.g. pip output) — wrap as debug
-                    await response.write(json.dumps({
-                        "type": "debug", "text": decoded,
-                    }).encode() + b"\n")
-
-        await asyncio.wait_for(stream_stdout(), timeout=timeout)
-        await proc.wait()
-
-        # If engine exited with error and no error event was emitted
-        if proc.returncode != 0:
-            stderr_bytes = await proc.stderr.read()
-            stderr_text = stderr_bytes.decode().strip() if stderr_bytes else ""
-            await response.write(json.dumps({
-                "type": "error",
-                "error": stderr_text or f"Exit code {proc.returncode}",
-                "returncode": proc.returncode,
-            }).encode() + b"\n")
+        async with process(cmd, env) as (proc, stderr):
+            async def stream_stdout():
+                size = 0
+                async for line in proc.stdout:
+                    size += len(line)
+                    if size > MAX_OUTPUT_BYTES:
+                        raise ValueError("query output exceeds configured limit")
+                    decoded = line.decode(errors="replace").rstrip("\n")
+                    if not decoded:
+                        continue
+                    try:
+                        event = json.loads(decoded)
+                        if not isinstance(event, dict):
+                            continue
+                        event["user_id"] = user_id
+                        await response.write(json.dumps(event).encode() + b"\n")
+                    except json.JSONDecodeError:
+                        # Child diagnostics are not a public protocol or credential-safe output.
+                        continue
+                await proc.wait()
+                await stderr
+            await asyncio.wait_for(stream_stdout(), timeout=timeout)
+            if proc.returncode != 0:
+                await response.write(json.dumps({
+                    "type": "error", "error": "Query engine failed",
+                    "returncode": proc.returncode,
+                }).encode() + b"\n")
 
     except asyncio.TimeoutError:
-        proc.kill()
         await response.write(json.dumps({
             "type": "error",
             "error": f"Query timed out after {timeout}s",
         }).encode() + b"\n")
     except (ConnectionResetError, asyncio.CancelledError):
-        proc.kill()
+        raise
+    except (ValueError, OSError):
+        await response.write(json.dumps({"type": "error", "error": "Query engine failed"}).encode() + b"\n")
 
     await response.write_eof()
     return response
@@ -465,6 +514,7 @@ async def query_stream(request: web.Request) -> web.StreamResponse:
 # Query — synchronous (buffered) response
 # ---------------------------------------------------------------------------
 
+@query_guard
 async def query_sync(request: web.Request) -> web.Response:
     """
     Execute a SportsClaw query and return a single JSON response.
@@ -497,20 +547,7 @@ async def query_sync(request: web.Request) -> web.Response:
     log(f"sync: user={user_id} prompt={prompt[:80]}")
 
     try:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
-
-        # Use communicate() to read ALL stdout bytes at once (no line-length
-        # limit), then split by \n ourselves.  readline() enforces a 64KB
-        # default StreamReader limit that truncates large base64 lines;
-        # communicate() uses read() which has no such limit.
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout
-        )
+        stdout_bytes, stderr_bytes, returncode = await buffered(cmd, env, timeout)
         elapsed_ms = int((time.monotonic() - started_at) * 1000)
 
         stdout_text = stdout_bytes.decode() if stdout_bytes else ""
@@ -518,7 +555,7 @@ async def query_sync(request: web.Request) -> web.Response:
 
         log(f"sync: stdout={len(stdout_bytes)} bytes, "
             f"stderr={len(stderr_bytes)} bytes, "
-            f"exit={proc.returncode}")
+            f"exit={returncode}")
 
         # Parse NDJSON lines from engine output
         result_text = None
@@ -535,6 +572,9 @@ async def query_sync(request: web.Request) -> web.Response:
             line_num += 1
             try:
                 event = json.loads(decoded)
+                if not isinstance(event, dict):
+                    parse_failures += 1
+                    continue
                 etype = event.get("type")
                 if etype == "result":
                     result_text = event.get("text", "")
@@ -565,10 +605,10 @@ async def query_sync(request: web.Request) -> web.Response:
         if parse_failures:
             log(f"sync: {parse_failures} NDJSON line(s) failed to parse")
 
-        if error_text:
+        if error_text or returncode != 0:
             return web.json_response({
                 "status": False,
-                "error": error_text,
+                "error": error_text or "Query engine failed",
                 "user_id": user_id,
                 "elapsed_ms": elapsed_ms,
             }, status=500)
@@ -590,27 +630,28 @@ async def query_sync(request: web.Request) -> web.Response:
 
         # Fallback: no result event parsed
         log(f"sync: no result event found in {line_num} lines")
-        if proc.returncode == 0:
+        if returncode == 0:
             return web.json_response({
-                "status": True,
-                "text": "(no result event emitted by engine)",
+                "status": False,
+                "error": "Query completed without a result event",
                 "user_id": user_id,
                 "elapsed_ms": elapsed_ms,
-            })
+            }, status=502)
         else:
             return web.json_response({
                 "status": False,
-                "error": stderr_text or f"Exit code {proc.returncode}",
-                "returncode": proc.returncode,
+                "error": "Query engine failed",
+                "returncode": returncode,
                 "elapsed_ms": elapsed_ms,
             }, status=500)
 
     except asyncio.TimeoutError:
-        proc.kill()
         return web.json_response({
             "status": False,
             "error": f"Query timed out after {timeout}s",
         }, status=504)
+    except (ValueError, OSError):
+        return web.json_response({"status": False, "error": "Query engine failed"}, status=502)
 
 
 # ---------------------------------------------------------------------------
@@ -740,6 +781,8 @@ def _build_cmd(body: dict) -> list[str]:
     user_id = body.get("user_id")
     if user_id:
         cmd.extend(["--user", user_id])
+    if body.get("history_mode") is not None:
+        cmd.extend(["--history-mode", body["history_mode"]])
 
     agent_id = body.get("agent_id")
     if agent_id is not None:
@@ -812,6 +855,7 @@ def create_app() -> web.Application:
     app = web.Application()
     app.router.add_get("/health", health)
     app.router.add_get("/api/skills", list_skills)
+    app.router.add_get("/api/capabilities", capabilities)
     app.router.add_post("/api/query", query_stream)
     app.router.add_post("/api/query/sync", query_sync)
     app.router.add_get("/api/agents", agents_list)
@@ -842,4 +886,4 @@ def create_app() -> web.Application:
 
 if __name__ == "__main__":
     log(f"Starting on port {PORT}")
-    web.run_app(create_app(), host="0.0.0.0", port=PORT)
+    web.run_app(create_app(), host="0.0.0.0", port=PORT, handler_cancellation=True)

--- a/docs/advanced/relay-contract.md
+++ b/docs/advanced/relay-contract.md
@@ -1,0 +1,32 @@
+# Relay integration contract
+
+Queries (`POST /api/query`, `POST /api/query/sync`) and `GET /api/capabilities`
+require `X-Auth-Token` matching `AGENTS_API_TOKEN`, including automatic agent
+selection. Missing server configuration returns 503; missing/invalid caller
+credentials return 401. Health remains public. Configure caller credentials
+before upgrading an older deployment that accepted anonymous queries.
+
+`history_mode` accepts `engine` (default) or `caller`. Caller mode means the
+caller supplies the transcript with its prompt. The engine does not restore or
+append its thread/session transcript or daily conversation log, and starts each
+run with a fresh conversation. Durable context, editorial strategy, profile,
+reflections and consolidated knowledge remain available. `user_id` still scopes
+that durable memory. The CLI equivalent is `--history-mode caller`.
+
+Queries accept a nonempty prompt of at most 20,000 characters. `timeout` must be
+an integer from 1 through `RELAY_MAX_QUERY_TIMEOUT` (default 300 seconds).
+`RELAY_TIMEOUT` defaults to 180 seconds. `RELAY_MAX_QUERY_CONCURRENCY` defaults
+to 4; excess requests return 429 immediately without launching a child. Limits
+are per relay instance, not distributed quotas. Responses are bounded to 32 MiB;
+stderr is concurrently drained with only 64 KiB retained internally. Cancellation
+or timeout kills the isolated subprocess group and reaps its leader. Remote work
+already accepted by another service is not undone by local process termination.
+
+`GET /api/capabilities` reports protocol version `1.0`, package engine version,
+build revision, installed skill names, configured per-server MCP allowlists,
+supported history modes, and query limits. A null `allowed_tools` with policy
+`all_discovered` denotes unrestricted discovery, not an empty tool list. This is
+configured policy, not a claim that every downstream server is healthy. Discovery
+failure returns 503. Tokens, headers, URLs and other credentials are excluded.
+Container builds should set `SPORTSCLAW_BUILD_REVISION`; release CI supplies its
+commit automatically.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3443,8 +3443,9 @@ export class sportsclawEngine {
       options?.sessionId,
     );
     if (
-      this._conversationNamespace &&
-      this._conversationNamespace !== activeConversationNamespace
+      options?.historyMode === "caller" ||
+      (this._conversationNamespace &&
+      this._conversationNamespace !== activeConversationNamespace)
     ) {
       this.messages = [];
       this._threadLoaded = false;
@@ -3502,7 +3503,7 @@ export class sportsclawEngine {
     }
 
     // --- Session: restore prior conversation history ---
-    const sessionId = options?.sessionId
+    const sessionId = options?.historyMode !== "caller" && options?.sessionId
       ? scopeSessionId(options.sessionId, nativeAgentId)
       : undefined;
     if (sessionId) {
@@ -3547,7 +3548,7 @@ export class sportsclawEngine {
       options?.onProgress?.({ type: "phase", label: "Loading memory" });
       try {
         [memoryBlock, strategyContent] = await Promise.all([
-          memory.buildMemoryBlock(),
+          memory.buildMemoryBlock({ includeConversationLog: options?.historyMode !== "caller" }),
           memory.readStrategy(),
         ]);
       } catch (err) {
@@ -3610,7 +3611,7 @@ export class sportsclawEngine {
     // accumulates naturally via subsequent run() calls, so skip to avoid
     // duplicating history. The _threadLoaded flag distinguishes "first run
     // with memory/system messages" from "second run with real history".
-    if (memory && !this._threadLoaded) {
+    if (memory && options?.historyMode !== "caller" && !this._threadLoaded) {
       this._threadLoaded = true;
       try {
         const threadHistory = await memory.readThread();
@@ -3802,8 +3803,8 @@ export class sportsclawEngine {
       this.messages.push({ role: "assistant", content: [{ type: "text", text: clarification }] });
       if (memory) {
         try {
-          await memory.appendToThread(sanitizedPrompt, clarification);
-          await memory.appendExchange(sanitizedPrompt, clarification);
+          if (options?.historyMode !== "caller") await memory.appendToThread(sanitizedPrompt, clarification);
+          if (options?.historyMode !== "caller") await memory.appendExchange(sanitizedPrompt, clarification);
         } catch (err) {
           if (!hindsightMemory) throw err;
           console.error(
@@ -3836,8 +3837,8 @@ export class sportsclawEngine {
       this.messages.push({ role: "assistant", content: [{ type: "text", text: intentQ }] });
       if (memory) {
         try {
-          await memory.appendToThread(sanitizedPrompt, intentQ);
-          await memory.appendExchange(sanitizedPrompt, intentQ);
+          if (options?.historyMode !== "caller") await memory.appendToThread(sanitizedPrompt, intentQ);
+          if (options?.historyMode !== "caller") await memory.appendExchange(sanitizedPrompt, intentQ);
         } catch (err) {
           if (!hindsightMemory) throw err;
           console.error(
@@ -3995,8 +3996,8 @@ export class sportsclawEngine {
       // Memory persistence
       if (memory) {
         try {
-          await memory.appendToThread(sanitizedPrompt, responseText);
-          await memory.appendExchange(sanitizedPrompt, responseText);
+          if (options?.historyMode !== "caller") await memory.appendToThread(sanitizedPrompt, responseText);
+          if (options?.historyMode !== "caller") await memory.appendExchange(sanitizedPrompt, responseText);
         } catch (err) {
           console.error(
             `[sportsclaw] memory write error: ${err instanceof Error ? err.message : err}`
@@ -4337,8 +4338,8 @@ export class sportsclawEngine {
     // --- Memory: write after LLM reply (async, non-blocking) ---
     if (memory) {
       try {
-        await memory.appendToThread(sanitizedPrompt, responseText);
-        await memory.appendExchange(sanitizedPrompt, responseText);
+        if (options?.historyMode !== "caller") await memory.appendToThread(sanitizedPrompt, responseText);
+        if (options?.historyMode !== "caller") await memory.appendExchange(sanitizedPrompt, responseText);
       } catch (err) {
         console.error(
           `[sportsclaw] memory write error: ${err instanceof Error ? err.message : err}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -2205,6 +2205,7 @@ function emitNdjson(event: Record<string, unknown>): void {
 }
 
 export function buildOneShotRunOptions(params: {
+  historyMode?: RunOptions["historyMode"];
   userId?: string;
   systemPrompt?: string;
   agentIds: string[];
@@ -2214,6 +2215,7 @@ export function buildOneShotRunOptions(params: {
   abortSignal?: AbortSignal;
 }): RunOptions {
   return {
+    ...(params.historyMode ? { historyMode: params.historyMode } : {}),
     userId: params.userId,
     systemPrompt: params.systemPrompt,
     ...(params.agentIds.length > 0 ? { agentIds: params.agentIds } : {}),
@@ -2257,6 +2259,12 @@ async function cmdQuery(args: string[]): Promise<void> {
 
   // Parse --user <id> flag (used by relay/pipe to enable memory & thread persistence)
   const userId = takeOneShotUserId(args);
+  const historyIdx = args.indexOf("--history-mode");
+  const historyMode = historyIdx >= 0 ? args[historyIdx + 1] : "engine";
+  if (historyMode !== "caller" && historyMode !== "engine") {
+    throw new Error("--history-mode must be caller or engine");
+  }
+  if (historyIdx >= 0) args.splice(historyIdx, 2);
 
   // Parse --system-prompt <text> flag (used by relay to inject caller context)
   let systemPrompt: string | undefined;
@@ -2337,6 +2345,7 @@ async function cmdQuery(args: string[]): Promise<void> {
         }
       }
       const result = await runOneShotEngine(engine, prompt, {
+        historyMode,
         userId,
         systemPrompt,
         agentIds,
@@ -2372,6 +2381,7 @@ async function cmdQuery(args: string[]): Promise<void> {
     // Verbose mode: no spinner, raw console.error logs
     try {
       const result = await runOneShotEngine(engine, prompt, {
+        historyMode,
         userId,
         systemPrompt,
         agentIds,
@@ -2402,6 +2412,7 @@ async function cmdQuery(args: string[]): Promise<void> {
     try {
       const result = await runOneShotEngine(engine, prompt, {
         userId,
+        historyMode,
         systemPrompt,
         agentIds,
         delegated,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -670,8 +670,9 @@ export class McpManager {
     // Only attempt if the server has the standard discovery tools
     const hasSearch = (toolName: string) =>
       this.routeMap.has(`mcp__${serverName}__${toolName}`);
+    const workflowSearch = hasSearch("search_workflow") ? "search_workflow" : "search_workflows";
 
-    if (!hasSearch("search_workflows") && !hasSearch("search_agents") && !hasSearch("connector_search")) {
+    if (!hasSearch(workflowSearch) && !hasSearch("search_agents") && !hasSearch("connector_search")) {
       return; // Not a Machina pod — skip discovery
     }
 
@@ -680,8 +681,8 @@ export class McpManager {
       // miss entries beyond the API's small default page size.
       const args = { page_size: 100 };
       const [wfResult, agResult, cnResult] = await Promise.allSettled([
-        hasSearch("search_workflows")
-          ? this.callTool(`mcp__${serverName}__search_workflows`, args)
+        hasSearch(workflowSearch)
+          ? this.callTool(`mcp__${serverName}__${workflowSearch}`, args)
           : Promise.resolve(null),
         hasSearch("search_agents")
           ? this.callTool(`mcp__${serverName}__search_agents`, args)

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1430,10 +1430,10 @@ export class MemoryManager {
   // Combined read for prompt injection-safe context assembly
   // -------------------------------------------------------------------------
 
-  async buildMemoryBlock(): Promise<string> {
+  async buildMemoryBlock(options?: { includeConversationLog?: boolean }): Promise<string> {
     const [context, todayLog, fanProfile, soul, reflections, consolidated] = await Promise.all([
       this.readContext(),
-      this.readTodayLog(),
+      options?.includeConversationLog === false ? Promise.resolve("") : this.readTodayLog(),
       this.readFanProfile(),
       this.readSoul(),
       this.readReflections(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -509,6 +509,8 @@ export type ToolProgressEvent =
   | { type: "synthesizing" };
 
 export interface RunOptions {
+  /** Caller mode leaves transcript ownership to the API caller; durable memory remains enabled. */
+  historyMode?: "caller" | "engine";
   /** User or thread ID for memory isolation. If omitted, memory is disabled. */
   userId?: string;
   /** Exactly one native agent ID to select explicitly for this run. */

--- a/test/broadcast-runtime-contract.test.mjs
+++ b/test/broadcast-runtime-contract.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { McpManager } from "../dist/mcp.js";
+import { MemoryManager } from "../dist/memory.js";
+import { buildOneShotRunOptions } from "../dist/index.js";
+import { sportsclawEngine } from "../dist/engine.js";
+import { MockLanguageModelV3 } from "ai/test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+test("capability discovery accepts actual singular workflow name and legacy plural", async () => {
+  for (const name of ["search_workflow", "search_workflows"]) {
+    const manager = new McpManager();
+    manager.routeMap.set(`mcp__pod__${name}`, {});
+    const calls = [];
+    manager.callTool = async (tool) => {
+      calls.push(tool);
+      return { content: JSON.stringify([{ name: "generate-poll-bank" }]), isError: false };
+    };
+    await manager.discoverCapabilities("pod");
+    assert.deepEqual(calls, [`mcp__pod__${name}`]);
+    assert.equal(manager.podCaps.get("pod").workflows[0].name, "generate-poll-bank");
+  }
+});
+
+test("caller transcript mode preserves durable context without loading daily conversation log", async () => {
+  const reads = [];
+  const storage = { async read(user, file) {
+    reads.push(file);
+    return file === "CONTEXT.md" ? "Editorial style: precise" : "";
+  } };
+  const memory = new MemoryManager("thread", storage);
+  const block = await memory.buildMemoryBlock({ includeConversationLog: false });
+  assert.match(block, /Editorial style: precise/);
+  assert.ok(reads.every(file => !/^\d{4}-/.test(file)));
+  const options = buildOneShotRunOptions({ userId: "thread", agentIds: [], delegated: false, historyMode: "caller" });
+  assert.equal(options.historyMode, "caller");
+  assert.equal(options.userId, "thread");
+});
+
+test("reused engine in caller mode neither replays nor saves conversation turns", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "sc-caller-history-"));
+  const agents = join(root, "agents");
+  const schemas = join(root, "schemas");
+  mkdirSync(agents); mkdirSync(schemas);
+  writeFileSync(join(agents, "desk.md"), "---\nname: Desk\nskills: []\nactive: true\n---\nAnswer directly.\n");
+  const overrides = { SPORTSCLAW_AGENTS_DIR: agents, sportsclaw_SCHEMA_DIR: schemas, SPORTSCLAW_MEMORY_PROVIDER: "file" };
+  const old = Object.fromEntries(Object.keys(overrides).map(key => [key, process.env[key]]));
+  Object.assign(process.env, overrides);
+  const read = t.mock.method(MemoryManager.prototype, "readThread", async () => [{ role: "user", content: "private old turn" }]);
+  const append = t.mock.method(MemoryManager.prototype, "appendToThread", async () => {});
+  const log = t.mock.method(MemoryManager.prototype, "appendExchange", async () => {});
+  t.mock.method(MemoryManager.prototype, "buildMemoryBlock", async () => "Editorial context");
+  t.mock.method(MemoryManager.prototype, "readStrategy", async () => "");
+  t.mock.method(MemoryManager.prototype, "recallContext", async () => "");
+  try {
+    const engine = new sportsclawEngine({ clarifyOnLowConfidence: false, thinkingBudget: 0 });
+    engine.initAsync = async () => {};
+    const model = new MockLanguageModelV3({ doGenerate: async () => ({
+      content: [{ type: "text", text: "answer" }], finishReason: { unified: "stop" },
+      usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } }, warnings: [],
+    }) });
+    engine.mainModel = model;
+    const options = { userId: "caller-test", agentIds: ["desk"], historyMode: "caller" };
+    assert.equal(await engine.run("Discuss the first storyline", options), "answer");
+    assert.equal(await engine.run("Discuss the second storyline", options), "answer");
+    assert.equal(read.mock.callCount(), 0);
+    assert.equal(append.mock.callCount(), 0);
+    assert.equal(log.mock.callCount(), 0);
+    const prompt = JSON.stringify(model.doGenerateCalls.at(-1).prompt);
+    assert.ok(!prompt.includes("first storyline"));
+    assert.ok(!prompt.includes("private old turn"));
+    assert.ok(prompt.includes("Editorial context"));
+  } finally {
+    for (const [key, value] of Object.entries(old)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/relay-highlights-api.test.mjs
+++ b/test/relay-highlights-api.test.mjs
@@ -1410,9 +1410,9 @@ describe("relay highlights authentication", () => {
       assert.ok(!r.body.includes(token), `secret-unset ${route} must never echo a token`);
     }
 
-    // The existing query endpoints stay token-free (prompt validation, not auth).
-    assert.equal(results["query-no-token"].status, 400);
-    assert.equal(results["query-sync-no-token"].status, 400);
+    // Queries also fail closed before prompt validation when no secret is set.
+    assert.equal(results["query-no-token"].status, 503);
+    assert.equal(results["query-sync-no-token"].status, 503);
   });
 });
 

--- a/test/relay-native-agents-api.test.mjs
+++ b/test/relay-native-agents-api.test.mjs
@@ -210,7 +210,7 @@ describe("relay native agents API", () => {
   it("fails closed without agent API auth and rejects non-boolean inactivation", () => {
     assert.equal(run("auth").status, 401);
     assert.equal(run("query_auth").status, 401);
-    assert.equal(run("query_compat").allowed, true);
+    assert.equal(run("query_compat").allowed, false);
     assert.match(run("active_type").error, /active/i);
   });
 

--- a/test/relay-query-runtime.py
+++ b/test/relay-query-runtime.py
@@ -1,0 +1,167 @@
+"""Offline behavioral checks: real child processes, stubbed HTTP response layer."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "docker/relay"))
+class Response:
+    def __init__(self, data, status=200):
+        self.data, self.status = data, status
+class StreamResponse:
+    def __init__(self, **kwargs): self.lines = []
+    async def prepare(self, request): self.request = request
+    async def write(self, data):
+        self.lines.append(data)
+        if hasattr(self.request, "received"): self.request.received.set()
+    async def write_eof(self): pass
+web = types.SimpleNamespace(Request=object, Response=Response, StreamResponse=StreamResponse,
+    json_response=lambda data, status=200: Response(data, status))
+sys.modules["aiohttp"] = types.SimpleNamespace(web=web)
+import relay_server as relay
+import query_runtime as runtime
+
+class Request:
+    def __init__(self, body=None, headers=None, app=None):
+        self.body = body or {"prompt": "hello"}
+        self.headers = headers or {}
+        self.app = app if app is not None else {}
+    async def json(self):
+        return self.body
+
+class Contracts(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.old = dict(os.environ)
+        os.environ["AGENTS_API_TOKEN"] = "test-only-token"
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.old)
+    def request(self, body=None, app=None):
+        return Request(body, {"X-Auth-Token": "test-only-token"}, app)
+
+    async def test_auth_all_queries(self):
+        for handler in (relay.query_stream, relay.query_sync, relay.capabilities):
+            self.assertEqual((await handler(Request())).status, 401)
+        del os.environ["AGENTS_API_TOKEN"]
+        self.assertEqual((await relay.query_sync(Request())).status, 503)
+
+    async def test_validation_precedes_process(self):
+        for extra in ({"timeout": 0}, {"timeout": True}, {"timeout": 301},
+                      {"timeout": "20"}, {"history_mode": "merge"}, {"prompt": ["hello"]}):
+            self.assertEqual((await relay.query_sync(self.request({"prompt": "hello", **extra}))).status, 400)
+        self.assertIn("--history-mode", relay._build_cmd({"prompt": "hello", "history_mode": "caller"}))
+
+    async def test_admission_and_release_on_cancel(self):
+        app = {"active_queries": relay.MAX_QUERY_CONCURRENCY}
+        self.assertEqual((await relay.query_sync(self.request(app=app))).status, 429)
+        app["active_queries"] = 0
+        started = asyncio.Event()
+        @relay.query_guard
+        async def hanging(request):
+            started.set()
+            await asyncio.Event().wait()
+        task = asyncio.create_task(hanging(self.request(app=app)))
+        await started.wait()
+        self.assertEqual(app["active_queries"], 1)
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        self.assertEqual(app["active_queries"], 0)
+
+    async def test_capabilities_disclose_policy_not_credentials(self):
+        previous, entry = relay.buffered, relay.SPORTSCLAW_ENTRY
+        async def fake(*args):
+            return b'{"defaultSports": ["football"], "optionalSports": [], "defaultSupport": [], "optionalSupport": [], "unknown": []}', b'', 0
+        relay.buffered = fake
+        relay.SPORTSCLAW_ENTRY = str(Path(__file__).resolve().parents[1] / "dist/index.js")
+        os.environ["SPORTSCLAW_MCP_SERVERS"] = json.dumps({"pod": {
+            "tools": ["search_workflow"], "headers": {"X-Api-Token": "do-not-disclose"}}})
+        try:
+            result = await relay.capabilities(self.request())
+            self.assertEqual(result.status, 200)
+            self.assertEqual(result.data["history_modes"], ["engine", "caller"])
+            self.assertNotIn("do-not-disclose", json.dumps(result.data))
+            self.assertEqual(result.data["mcp_servers"][0]["allowed_tools"], ["search_workflow"])
+        finally:
+            relay.buffered, relay.SPORTSCLAW_ENTRY = previous, entry
+
+    async def test_stderr_larger_than_pipe_is_drained_and_bounded(self):
+        out, err, code = await runtime.buffered([sys.executable, "-c",
+            'import sys; sys.stderr.write("x" * 2000000); print("ok")'], dict(os.environ), 5)
+        self.assertEqual((out, code), (b"ok\n", 0))
+        self.assertEqual(len(err), runtime.MAX_STDERR_BYTES)
+
+    async def test_timeout_and_cancel_terminate_descendants(self):
+        for cancel in (False, True):
+            with tempfile.TemporaryDirectory() as directory:
+                marker = str(Path(directory) / "orphan-ran")
+                child = f'import time; time.sleep(0.5); open({marker!r}, "w").write("bad")'
+                script = f'import subprocess,sys,time; subprocess.Popen([sys.executable,"-c",{child!r}]); print("ready",flush=True); time.sleep(30)'
+                async with runtime.process([sys.executable, "-c", script], dict(os.environ)) as (proc, _):
+                    await proc.stdout.readline()
+                    if cancel:
+                        task = asyncio.create_task(proc.wait())
+                        task.cancel()
+                        with self.assertRaises(asyncio.CancelledError): await task
+                    else:
+                        with self.assertRaises(asyncio.TimeoutError):
+                            await asyncio.wait_for(proc.wait(), .03)
+                self.assertIsNotNone(proc.returncode)
+                await asyncio.sleep(.65)
+                self.assertFalse(Path(marker).exists())
+
+    async def test_stdout_limit(self):
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"0123456789")
+        reader.feed_eof()
+        with self.assertRaises(ValueError): await runtime.drain(reader, 5)
+
+    async def test_buffered_stdin_and_missing_result(self):
+        out, _, code = await runtime.buffered([sys.executable, "-c",
+            'import sys; print(sys.stdin.read())'], dict(os.environ), 3, b"agent body")
+        self.assertEqual((out, code), (b"agent body\n", 0))
+        previous = relay._build_cmd
+        relay._build_cmd = lambda body: [sys.executable, "-c", 'print("[]")']
+        try:
+            result = await relay.query_sync(self.request())
+            self.assertEqual(result.status, 502)
+            self.assertFalse(result.data["status"])
+        finally:
+            relay._build_cmd = previous
+
+    async def test_streaming_drains_stderr_and_handles_non_object_json(self):
+        previous = relay._build_cmd
+        relay._build_cmd = lambda body: [sys.executable, "-c",
+            'import sys; sys.stderr.write("x"*2000000); print("[]"); print(\'{"type":"result","text":"ok"}\')']
+        try:
+            result = await relay.query_stream(self.request())
+            self.assertEqual(len(result.lines), 1)
+            self.assertEqual(json.loads(result.lines[0])["text"], "ok")
+        finally:
+            relay._build_cmd = previous
+
+    async def test_disconnected_stream_cleans_process_group_and_admission(self):
+        previous = relay._build_cmd
+        with tempfile.TemporaryDirectory() as directory:
+            marker = str(Path(directory) / "orphan-ran")
+            child = f'import time; time.sleep(.5); open({marker!r}, "w").write("bad")'
+            script = f'import subprocess,sys,time; subprocess.Popen([sys.executable,"-c",{child!r}]); print(\'{{"type":"start"}}\',flush=True); time.sleep(30)'
+            relay._build_cmd = lambda body: [sys.executable, "-c", script]
+            request = self.request()
+            request.received = asyncio.Event()
+            try:
+                task = asyncio.create_task(relay.query_stream(request))
+                await asyncio.wait_for(request.received.wait(), 3)
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError): await task
+                self.assertEqual(request.app["active_queries"], 0)
+                await asyncio.sleep(.65)
+                self.assertFalse(Path(marker).exists())
+            finally:
+                relay._build_cmd = previous
+
+unittest.main()

--- a/test/relay-query-runtime.test.mjs
+++ b/test/relay-query-runtime.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+test("relay query admission, auth, capability and subprocess lifecycle contracts", () => {
+  const result = spawnSync(process.env.PYTHON_PATH || "python3", [
+    fileURLToPath(new URL("./relay-query-runtime.py", import.meta.url)),
+  ], { encoding: "utf8", timeout: 20000 });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});


### PR DESCRIPTION
## Summary
- Require query authentication even without agent_id, including synchronous queries.
- Bound subprocess concurrency, prompt/output size, deadlines, and cancellation cleanup.
- Add caller-owned history mode while preserving scoped durable editorial context.
- Expose authenticated versioned capabilities and exact MCP allowlist metadata.
- Include build revision in relay images and fix singular search_workflow alias.

## Validation
- 1,315 tests passed, including relay lifecycle, auth, history, and MCP policy checks.
- TypeScript production build passed.
- GPT-6 Astra review completed.

## Rollout
This is the first dependency for the Broadcast AI production desk. Deploy only the dedicated Broadcast AI relay in tenant-machina-drops; preserve its memory PVC, tokens, and 13 read-only MCP tools. Verify authenticated capabilities and unauthenticated rejection before rolling out templates/app. Engine callers default to existing history behavior; Broadcast AI opts into caller history.

The current image lives in ACR; the generic Docker Hub tag workflow is not a verified ACR deployment path. No runtime changes are made by this PR itself.