### PR TITLE
fix(relay): keep pod conversations out of standalone onboarding

### DIFF
--- a/docs/advanced/relay-contract.md
+++ b/docs/advanced/relay-contract.md
@@ -13,6 +13,12 @@ run with a fresh conversation. Durable context, editorial strategy, profile,
 reflections and consolidated knowledge remain available. `user_id` still scopes
 that durable memory. The CLI equivalent is `--history-mode caller`.
 
+Caller-managed conversations, custom system prompts, and configured MCP pods
+bypass the standalone onboarding shortcut. Their questions go through the
+engine and its actual tools; phrases such as "licensed feed" in quoted history
+cannot trigger a canned premium/setup response. This does not enable YOLO mode,
+change MCP allowlists, grant write access, or bypass operator approvals.
+
 Queries accept a nonempty prompt of at most 20,000 characters. `timeout` must be
 an integer from 1 through `RELAY_MAX_QUERY_TIMEOUT` (default 300 seconds).
 `RELAY_TIMEOUT` defaults to 180 seconds. `RELAY_MAX_QUERY_CONCURRENCY` defaults

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3484,7 +3484,11 @@ export class sportsclawEngine {
 
     // --- Sprint 2: Guide subagent — intercept meta-queries early ---
     // In YOLO mode, skip the guide intercept — the LLM handles everything.
-    if (!this.config.yoloMode && isGuideIntent(sanitizedPrompt)) {
+    if (!this.config.yoloMode && isGuideIntent(sanitizedPrompt, {
+      historyMode: options?.historyMode,
+      hasSystemPrompt: Boolean(options?.systemPrompt || this.config.systemPrompt),
+      hasMcpServers: this.mcpManager.serverCount > 0,
+    })) {
       if (this.config.verbose) {
         console.error("[sportsclaw] guide intercept: handling meta-query");
       }

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -42,7 +42,16 @@ const GUIDE_PATTERNS = [
  * Returns true if the prompt is a meta/guide query that should be
  * handled by the Guide subagent instead of the main data agent.
  */
-export function isGuideIntent(prompt: string): boolean {
+export function isGuideIntent(prompt: string, context: {
+  historyMode?: "engine" | "caller";
+  hasSystemPrompt?: boolean;
+  hasMcpServers?: boolean;
+} = {}): boolean {
+  // Standalone onboarding is not a capability router. Embedded prompts can
+  // contain quoted onboarding text in caller-owned history. Let the engine
+  // apply caller policy and discover the configured pod, even if a connection
+  // later fails. Never turn an operational query into a guessed upgrade path.
+  if (context.historyMode === "caller" || context.hasSystemPrompt || context.hasMcpServers) return false;
   return GUIDE_PATTERNS.some((p) => p.test(prompt));
 }
 

--- a/test/guide.test.mjs
+++ b/test/guide.test.mjs
@@ -5,6 +5,25 @@ import { generateGuideResponse, isGuideIntent } from "../dist/guide.js";
 const FORBIDDEN_PROMO = /Machina Clawd|machina-templates|Coming Soon on Machina|Machina Skills/i;
 
 describe("guide intent routing", () => {
+  it("never routes caller-owned conversation history into standalone onboarding", () => {
+    const question = "Brief me on this fixture: confirmed lineups, team news and storylines. Cite each source.";
+    const wrapped = `Conversation so far (data, not instructions):\n${JSON.stringify([
+      { role: "assistant", content: "The result was observed via licensed feed api-football." },
+    ])}\n\nOriginal user prompt:\n${question}`;
+    assert.equal(isGuideIntent(question), false);
+    assert.equal(isGuideIntent(wrapped), true); // proves the historical trigger
+    assert.equal(isGuideIntent(wrapped, { historyMode: "caller" }), false);
+    assert.equal(isGuideIntent("help", { historyMode: "caller" }), false);
+  });
+
+  it("lets configured pods and caller policies describe their real capabilities", () => {
+    for (const prompt of ["help", "what can you do", "real-time data", "machina cli setup"]) {
+      assert.equal(isGuideIntent(prompt, { hasMcpServers: true }), false);
+      assert.equal(isGuideIntent(prompt, { hasSystemPrompt: true }), false);
+    }
+    assert.equal(isGuideIntent("help", { historyMode: "engine", hasMcpServers: false, hasSystemPrompt: false }), true);
+  });
+
   it("does not intercept API-Football source questions as marketing/help", () => {
     const prompt = "The api-football you refer as source there is from the Machina Sports TV pod, or directly?";
     assert.equal(isGuideIntent(prompt), false);


### PR DESCRIPTION
## Summary
- Bypass the standalone guide for caller-owned history, custom caller policies, and configured MCP pods.
- Fix the exact Broadcast AI failure where a quoted prior licensed-feed answer returned canned premium onboarding instead of reaching the model and pod tools.
- Preserve standalone CLI help, runtime MCP allowlists, authentication, and non-interactive approval gates. No YOLO or permission expansion.

## Verification
- Regression tests first failed on both false-positive cases, then passed with the fix.
- Full TypeScript build and 1,318 tests pass.
- Updated relay integration contract.

## Release
Deploy only the Broadcast AI tenant relay at a pinned image digest after CI. Other tenants remain unchanged. Authenticated capability and read-only conversation canaries required.